### PR TITLE
Rmc 176 uac qid pairs for unaddressed

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/config/QueueSetterUpper.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/config/QueueSetterUpper.java
@@ -24,9 +24,17 @@ public class QueueSetterUpper {
   @Value("${queueconfig.emit-case-event-action-queue}")
   private String emitCaseEventActionQueue;
 
+  @Value("${queueconfig.unaddressed-inbound-queue}")
+  private String unaddressedQueue;
+
   @Bean
   public Queue inboundQueue() {
     return new Queue(inboundQueue, true);
+  }
+
+  @Bean
+  public Queue unaddressedQueue() {
+    return new Queue(unaddressedQueue, true);
   }
 
   @Bean

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiver.java
@@ -1,0 +1,26 @@
+package uk.gov.ons.census.casesvc.messaging;
+
+import org.springframework.integration.annotation.MessageEndpoint;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.ons.census.casesvc.model.dto.CreateUacQid;
+import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
+import uk.gov.ons.census.casesvc.service.UacProcessor;
+
+@MessageEndpoint
+public class UnaddressedReceiver {
+  private final UacProcessor uacProcessor;
+
+  public UnaddressedReceiver(UacProcessor uacProcessor) {
+    this.uacProcessor = uacProcessor;
+  }
+
+  @Transactional
+  @ServiceActivator(inputChannel = "unaddressedInputChannel")
+  public void receiveMessage(CreateUacQid createUacQid) {
+    UacQidLink uacQidLink =
+        uacProcessor.saveUacQidLink(null, Integer.parseInt(createUacQid.getQuestionnaireType()));
+    uacProcessor.emitUacUpdatedEvent(uacQidLink, null);
+    uacProcessor.logEvent(uacQidLink, "Unaddressed UAC/QID pair created");
+  }
+}

--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/CreateUacQid.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/CreateUacQid.java
@@ -1,0 +1,8 @@
+package uk.gov.ons.census.casesvc.model.dto;
+
+import lombok.Data;
+
+@Data
+public class CreateUacQid {
+  private String questionnaireType;
+}

--- a/src/main/java/uk/gov/ons/census/casesvc/service/UacProcessor.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/UacProcessor.java
@@ -70,12 +70,15 @@ public class UacProcessor {
 
     Uac uac = new Uac();
     uac.setActive(true);
-    uac.setCaseId(caze.getCaseId().toString());
-    uac.setCaseType(caze.getAddressType());
-    uac.setCollectionExerciseId(caze.getCollectionExerciseId());
     uac.setQuestionnaireId(uacQidLink.getQid());
     uac.setUacHash(Sha256Helper.hash(uacQidLink.getUac()));
     uac.setUac(uacQidLink.getUac());
+
+    if (caze != null) {
+      uac.setCaseId(caze.getCaseId().toString());
+      uac.setCaseType(caze.getAddressType());
+      uac.setCollectionExerciseId(caze.getCollectionExerciseId());
+    }
 
     Payload payload = new Payload();
     payload.setUac(uac);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,7 @@ queueconfig:
   emit-case-event-exchange: myfanout.exchange
   emit-case-event-rh-queue: myfanout.rhqueue
   emit-case-event-action-queue: myfanout.actionqueue
+  unaddressed-inbound-queue: unaddressedRequestQueue
   consumers: 50
 
 healthcheck:

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
@@ -2,21 +2,19 @@ package uk.gov.ons.census.casesvc.messaging;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -33,6 +31,7 @@ import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class SampleReceiverIT {
   @Value("${queueconfig.inbound-queue}")
@@ -79,7 +78,8 @@ public class SampleReceiverIT {
     rabbitQueueHelper.checkExpectedMessageReceived(queue1);
 
     List<EventType> eventTypesSeen = new LinkedList<>();
-    ResponseManagementEvent responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(queue2);
+    ResponseManagementEvent responseManagementEvent =
+        rabbitQueueHelper.checkExpectedMessageReceived(queue2);
     eventTypesSeen.add(responseManagementEvent.getEvent().getType());
     responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(queue2);
     eventTypesSeen.add(responseManagementEvent.getEvent().getType());

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverTest.java
@@ -28,5 +28,4 @@ public class SampleReceiverTest {
     // Then
     verify(eventProcessor).processSampleReceivedMessage(createCaseSample);
   }
-
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiverTest.java
@@ -15,8 +15,7 @@ import uk.gov.ons.census.casesvc.service.UacProcessor;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UnaddressedReceiverTest {
-  @Mock
-  UacProcessor uacProcessor;
+  @Mock UacProcessor uacProcessor;
 
   @InjectMocks UnaddressedReceiver underTest;
 

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiverTest.java
@@ -1,0 +1,38 @@
+package uk.gov.ons.census.casesvc.messaging;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.ons.census.casesvc.model.dto.CreateUacQid;
+import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
+import uk.gov.ons.census.casesvc.service.UacProcessor;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UnaddressedReceiverTest {
+  @Mock
+  UacProcessor uacProcessor;
+
+  @InjectMocks UnaddressedReceiver underTest;
+
+  @Test
+  public void testReceiveCreateUacQid() {
+    // Given
+    CreateUacQid createUacQid = new CreateUacQid();
+    createUacQid.setQuestionnaireType("21");
+    UacQidLink uacQidLink = new UacQidLink();
+    when(uacProcessor.saveUacQidLink(null, 21)).thenReturn(uacQidLink);
+
+    // When
+    underTest.receiveMessage(createUacQid);
+
+    // Then
+    verify(uacProcessor).emitUacUpdatedEvent(eq(uacQidLink), eq(null));
+    verify(uacProcessor).logEvent(eq(uacQidLink), eq("Unaddressed UAC/QID pair created"));
+  }
+}

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiverTestIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiverTestIT.java
@@ -1,0 +1,69 @@
+package uk.gov.ons.census.casesvc.messaging;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.ons.census.casesvc.model.dto.CreateUacQid;
+import uk.gov.ons.census.casesvc.model.dto.EventType;
+import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
+import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
+import uk.gov.ons.census.casesvc.model.repository.EventRepository;
+import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
+import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
+
+@ContextConfiguration
+@ActiveProfiles("test")
+@SpringBootTest
+@RunWith(SpringJUnit4ClassRunner.class)
+public class UnaddressedReceiverTestIT {
+  @Value("${queueconfig.unaddressed-inbound-queue}")
+  private String unaddressedQueue;
+
+  @Value("${queueconfig.emit-case-event-rh-queue}")
+  private String emitCaseEventRhQueue;
+
+  @Autowired
+  private RabbitQueueHelper rabbitQueueHelper;
+  @Autowired private EventRepository eventRepository;
+  @Autowired private UacQidLinkRepository uacQidLinkRepository;
+
+  @Before
+  @Transactional
+  public void setUp() {
+    rabbitQueueHelper.purgeQueue(unaddressedQueue);
+    rabbitQueueHelper.purgeQueue(emitCaseEventRhQueue);
+    eventRepository.deleteAllInBatch();
+    uacQidLinkRepository.deleteAllInBatch();
+  }
+
+  @Test
+  public void testHappyPath() throws IOException, InterruptedException {
+    // GIVEN
+    BlockingQueue<String> queue = rabbitQueueHelper.listen(emitCaseEventRhQueue);
+    CreateUacQid createUacQid = new CreateUacQid();
+    createUacQid.setQuestionnaireType("21");
+
+    // WHEN
+    rabbitQueueHelper.sendMessage(unaddressedQueue, createUacQid);
+
+    // THEN
+    ResponseManagementEvent responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(queue);
+    assertEquals(EventType.UAC_UPDATED, responseManagementEvent.getEvent().getType());
+    assertThat(responseManagementEvent.getPayload().getUac().getQuestionnaireId()).startsWith("21");
+  }
+
+}

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiverTestIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiverTestIT.java
@@ -1,10 +1,8 @@
 package uk.gov.ons.census.casesvc.messaging;
 
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.concurrent.BlockingQueue;
 import org.junit.Before;
@@ -13,6 +11,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -20,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.census.casesvc.model.dto.CreateUacQid;
 import uk.gov.ons.census.casesvc.model.dto.EventType;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
-import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 import uk.gov.ons.census.casesvc.model.repository.EventRepository;
 import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
 import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
@@ -29,6 +27,7 @@ import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 @ActiveProfiles("test")
 @SpringBootTest
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class UnaddressedReceiverTestIT {
   @Value("${queueconfig.unaddressed-inbound-queue}")
   private String unaddressedQueue;
@@ -36,8 +35,7 @@ public class UnaddressedReceiverTestIT {
   @Value("${queueconfig.emit-case-event-rh-queue}")
   private String emitCaseEventRhQueue;
 
-  @Autowired
-  private RabbitQueueHelper rabbitQueueHelper;
+  @Autowired private RabbitQueueHelper rabbitQueueHelper;
   @Autowired private EventRepository eventRepository;
   @Autowired private UacQidLinkRepository uacQidLinkRepository;
 
@@ -61,9 +59,9 @@ public class UnaddressedReceiverTestIT {
     rabbitQueueHelper.sendMessage(unaddressedQueue, createUacQid);
 
     // THEN
-    ResponseManagementEvent responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(queue);
+    ResponseManagementEvent responseManagementEvent =
+        rabbitQueueHelper.checkExpectedMessageReceived(queue);
     assertEquals(EventType.UAC_UPDATED, responseManagementEvent.getEvent().getType());
     assertThat(responseManagementEvent.getPayload().getUac().getQuestionnaireId()).startsWith("21");
   }
-
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/testutil/RabbitQueueHelper.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/testutil/RabbitQueueHelper.java
@@ -75,5 +75,4 @@ public class RabbitQueueHelper {
     assertEquals("RM", responseManagementEvent.getEvent().getChannel());
     return responseManagementEvent;
   }
-
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/testutil/RabbitQueueHelper.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/testutil/RabbitQueueHelper.java
@@ -1,7 +1,13 @@
 package uk.gov.ons.census.casesvc.testutil;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
 import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -12,11 +18,13 @@ import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.test.context.ActiveProfiles;
+import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 
 @Component
 @ActiveProfiles("test")
 @EnableRetry
 public class RabbitQueueHelper {
+  private ObjectMapper objectMapper = new ObjectMapper();
 
   @Autowired private ConnectionFactory connectionFactory;
 
@@ -56,4 +64,16 @@ public class RabbitQueueHelper {
   public void purgeQueue(String queueName) {
     amqpAdmin.purgeQueue(queueName);
   }
+
+  public ResponseManagementEvent checkExpectedMessageReceived(BlockingQueue<String> queue)
+      throws IOException, InterruptedException {
+    String actualMessage = queue.poll(20, TimeUnit.SECONDS);
+    assertNotNull("Did not receive message before timeout", actualMessage);
+    ResponseManagementEvent responseManagementEvent =
+        objectMapper.readValue(actualMessage, ResponseManagementEvent.class);
+    assertNotNull(responseManagementEvent);
+    assertEquals("RM", responseManagementEvent.getEvent().getChannel());
+    return responseManagementEvent;
+  }
+
 }


### PR DESCRIPTION
# Motivation and Context
We need to print a certain amount of letters, questionnaires, continuation pages etc. without an address. These will have an associated UAC/QID but no case - the case association will happen later. This PR covers the part where we generate the UAC/QID pair and emit the event to RH and Action Scheduler.

# What has changed
Created a new inbound queue called `unaddressedRequestQueue`. Process new JSON messages that arrive on new queue, issuing a UAC/QID pair without an associated case.

# How to test?
Run the acceptance tests from the same branch name (`rmc-176-uac-qid-pairs-for-unaddressed`) or run the new unaddressed batch runner (when it's completed).

# Links
Trello: https://trello.com/c/Hv7z7OqL/684-rmc-176-create-uac-qid-pairs-for-unaddressed-ccs-questionnaires-8

# Screenshots (if appropriate):