### PR TITLE
Add EventType enum to Event

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiver.java
@@ -4,6 +4,7 @@ import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.census.casesvc.model.dto.CreateUacQid;
+import uk.gov.ons.census.casesvc.model.entity.EventType;
 import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 import uk.gov.ons.census.casesvc.service.UacProcessor;
 
@@ -21,6 +22,6 @@ public class UnaddressedReceiver {
     UacQidLink uacQidLink =
         uacProcessor.saveUacQidLink(null, Integer.parseInt(createUacQid.getQuestionnaireType()));
     uacProcessor.emitUacUpdatedEvent(uacQidLink, null);
-    uacProcessor.logEvent(uacQidLink, "Unaddressed UAC/QID pair created");
+    uacProcessor.logEvent(uacQidLink, "Unaddressed UAC/QID pair created", EventType.UAC_UPDATED);
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/Event.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/Event.java
@@ -4,6 +4,8 @@ import java.util.Date;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import lombok.Data;
@@ -18,4 +20,8 @@ public class Event {
   @Column private Date eventDate;
 
   @Column private String eventDescription;
+
+  @Column
+  @Enumerated(EnumType.STRING)
+  private EventType eventType;
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/EventType.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/EventType.java
@@ -1,0 +1,6 @@
+package uk.gov.ons.census.casesvc.model.entity;
+
+public enum EventType {
+  CASE_CREATED,
+  UAC_UPDATED
+}

--- a/src/main/java/uk/gov/ons/census/casesvc/service/EventProcessor.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/EventProcessor.java
@@ -5,6 +5,7 @@ import com.godaddy.logging.LoggerFactory;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.census.casesvc.model.dto.CreateCaseSample;
 import uk.gov.ons.census.casesvc.model.entity.Case;
+import uk.gov.ons.census.casesvc.model.entity.EventType;
 import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 import uk.gov.ons.census.casesvc.utility.QuestionnaireTypeHelper;
 
@@ -30,13 +31,13 @@ public class EventProcessor {
     UacQidLink uacQidLink = uacProcessor.saveUacQidLink(caze, questionnaireType);
     uacProcessor.emitUacUpdatedEvent(uacQidLink, caze);
     caseProcessor.emitCaseCreatedEvent(caze);
-    uacProcessor.logEvent(uacQidLink, CASE_CREATED_EVENT_DESCRIPTION);
-    uacProcessor.logEvent(uacQidLink, UAC_QID_LINKED_EVENT_DESCRIPTION);
+    uacProcessor.logEvent(uacQidLink, CASE_CREATED_EVENT_DESCRIPTION, EventType.CASE_CREATED);
+    uacProcessor.logEvent(uacQidLink, UAC_QID_LINKED_EVENT_DESCRIPTION, EventType.UAC_UPDATED);
 
     if (QuestionnaireTypeHelper.isQuestionnaireWelsh(caze.getTreatmentCode())) {
       uacQidLink = uacProcessor.saveUacQidLink(caze, 3);
       uacProcessor.emitUacUpdatedEvent(uacQidLink, caze);
-      uacProcessor.logEvent(uacQidLink, UAC_QID_LINKED_EVENT_DESCRIPTION);
+      uacProcessor.logEvent(uacQidLink, UAC_QID_LINKED_EVENT_DESCRIPTION, EventType.UAC_UPDATED);
     }
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/UacProcessor.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/UacProcessor.java
@@ -57,13 +57,17 @@ public class UacProcessor {
     return uacQidLink;
   }
 
-  public void logEvent(UacQidLink uacQidLink, String eventDescription) {
+  public void logEvent(
+      UacQidLink uacQidLink,
+      String eventDescription,
+      uk.gov.ons.census.casesvc.model.entity.EventType eventType) {
     uk.gov.ons.census.casesvc.model.entity.Event loggedEvent =
         new uk.gov.ons.census.casesvc.model.entity.Event();
     loggedEvent.setId(UUID.randomUUID());
     loggedEvent.setEventDate(new Date());
     loggedEvent.setEventDescription(eventDescription);
     loggedEvent.setUacQidLink(uacQidLink);
+    loggedEvent.setEventType(eventType);
     eventRepository.save(loggedEvent);
   }
 

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiverTest.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.casesvc.messaging;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -10,6 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ons.census.casesvc.model.dto.CreateUacQid;
+import uk.gov.ons.census.casesvc.model.entity.EventType;
 import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 import uk.gov.ons.census.casesvc.service.UacProcessor;
 
@@ -32,6 +34,7 @@ public class UnaddressedReceiverTest {
 
     // Then
     verify(uacProcessor).emitUacUpdatedEvent(eq(uacQidLink), eq(null));
-    verify(uacProcessor).logEvent(eq(uacQidLink), eq("Unaddressed UAC/QID pair created"));
+    verify(uacProcessor)
+        .logEvent(eq(uacQidLink), eq("Unaddressed UAC/QID pair created"), any(EventType.class));
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/service/EventProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/EventProcessorTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ons.census.casesvc.model.dto.CreateCaseSample;
 import uk.gov.ons.census.casesvc.model.entity.Case;
+import uk.gov.ons.census.casesvc.model.entity.EventType;
 import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -38,7 +39,8 @@ public class EventProcessorTest {
     verify(uacProcessor).saveUacQidLink(eq(caze), eq(1));
     verify(uacProcessor).emitUacUpdatedEvent(uacQidLink, caze);
     verify(caseProcessor).emitCaseCreatedEvent(caze);
-    verify(uacProcessor, times(2)).logEvent(eq(uacQidLink), any(String.class));
+    verify(uacProcessor, times(2))
+        .logEvent(eq(uacQidLink), any(String.class), any(EventType.class));
   }
 
   @Test
@@ -61,6 +63,7 @@ public class EventProcessorTest {
     verify(uacProcessor, times(1)).saveUacQidLink(eq(caze), eq(2));
     verify(uacProcessor, times(2)).emitUacUpdatedEvent(uacQidLink, caze);
     verify(caseProcessor).emitCaseCreatedEvent(caze);
-    verify(uacProcessor, times(3)).logEvent(eq(uacQidLink), any(String.class));
+    verify(uacProcessor, times(3))
+        .logEvent(eq(uacQidLink), any(String.class), any(EventType.class));
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/service/UacProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/UacProcessorTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.casesvc.model.entity.Case;
 import uk.gov.ons.census.casesvc.model.entity.Event;
+import uk.gov.ons.census.casesvc.model.entity.EventType;
 import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 import uk.gov.ons.census.casesvc.model.repository.EventRepository;
 import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
@@ -56,7 +57,6 @@ public class UacProcessorTest {
 
     // When
     UacQidLink result;
-    // ArgumentCaptor<UacQidLink> caseArgumentCaptor = ArgumentCaptor.forClass(UacQidLink.class);
     result = underTest.saveUacQidLink(caze, 1);
 
     // Then
@@ -71,12 +71,13 @@ public class UacProcessorTest {
     uacQuidLink.setUniqueNumber(12345L);
 
     // When
-    underTest.logEvent(uacQuidLink, "TEST_LOGGED_EVENT");
+    underTest.logEvent(uacQuidLink, "TEST_LOGGED_EVENT", EventType.UAC_UPDATED);
 
     // Then
     ArgumentCaptor<Event> eventArgumentCaptor = ArgumentCaptor.forClass(Event.class);
     verify(eventRepository).save(eventArgumentCaptor.capture());
     assertEquals("TEST_LOGGED_EVENT", eventArgumentCaptor.getValue().getEventDescription());
+    assertEquals(EventType.UAC_UPDATED, eventArgumentCaptor.getValue().getEventType());
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
We need an event type stored against the case events to make it easier to find specific ones. The event types should come from a discrete enumerated list.

# What has changed
Added `EventType` enum and added it as a column to the `Event` entity.

# How to test?
Run ATs and check `event_type` DB column is populated in the `event` table in the case DB.

# Links
Trello: https://trello.com/c/ECRAB4bx