### PR TITLE
Fix location of java after openjdk moved in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ COPY target/$JAR_FILE /opt/census-rm-case-processor.jar
 COPY healthcheck.sh /opt/healthcheck.sh
 RUN chmod +x /opt/healthcheck.sh
 
-CMD exec /usr/bin/java $JAVA_OPTS -jar /opt/census-rm-case-processor.jar
+CMD exec /usr/local/openjdk-11/bin/java $JAVA_OPTS -jar /opt/census-rm-case-processor.jar


### PR DESCRIPTION
# Motivation and Context
The docker image `openjdk:11-slim` has changed the location of the `java` binary.

# What has changed
Changed the `java` path to the correct one.

# How to test?
Build the image. Container should start.

# Links
Trello: https://trello.com/c/7ivpCfY6
Reasons why stuff got broken: https://github.com/docker-library/openjdk/issues/320#issuecomment-494417274

# Screenshots (if appropriate):