### PR TITLE
Change the topic exchange name to "events"

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,7 +28,7 @@ spring:
 
 queueconfig:
   inbound-queue: case.sample.inbound
-  outbound-exchange: case.outbound.exchange
+  outbound-exchange: events
   rh-case-queue: case.rh.case
   rh-case-routing-key: event.case.*
   rh-uac-queue: case.rh.uac


### PR DESCRIPTION
# Motivation and Context
The agreed topic exchange name is "events" but its currently set to "case.outbound.exchange"

# What has changed
change outbound-exchange config item to "events"

# How to test?
run acceptance tests and everything should work as normal
