### PR TITLE
Check for case ref collisons

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
@@ -1,6 +1,5 @@
 package uk.gov.ons.census.casesvc.messaging;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +17,7 @@ public class SampleReceiver {
 
   @Transactional
   @ServiceActivator(inputChannel = "caseSampleInputChannel")
-  public void receiveMessage(CreateCaseSample createCaseSample) throws JsonProcessingException {
+  public void receiveMessage(CreateCaseSample createCaseSample) {
     eventProcessor.processSampleReceivedMessage(createCaseSample);
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiver.java
@@ -1,6 +1,5 @@
 package uk.gov.ons.census.casesvc.messaging;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +19,7 @@ public class UnaddressedReceiver {
 
   @Transactional
   @ServiceActivator(inputChannel = "unaddressedInputChannel")
-  public void receiveMessage(CreateUacQid createUacQid) throws JsonProcessingException {
+  public void receiveMessage(CreateUacQid createUacQid) {
     UacQidLink uacQidLink =
         uacProcessor.saveUacQidLink(
             null, Integer.parseInt(createUacQid.getQuestionnaireType()), createUacQid.getBatchId());

--- a/src/main/java/uk/gov/ons/census/casesvc/service/CaseProcessor.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CaseProcessor.java
@@ -41,13 +41,20 @@ public class CaseProcessor {
   }
 
   public Case saveCase(CreateCaseSample createCaseSample) {
+    int caseRef = RandomCaseRefGenerator.getCaseRef();
+
+    // Check for collisions
+    if (caseRepository.existsById(caseRef)) {
+      throw new RuntimeException();
+    }
+
     Case caze = mapperFacade.map(createCaseSample, Case.class);
-    caze.setCaseRef(RandomCaseRefGenerator.getCaseRef());
+    caze.setCaseRef(caseRef);
     caze.setCaseId(UUID.randomUUID());
     caze.setState(CaseState.ACTIONABLE);
     caze.setCreatedDateTime(OffsetDateTime.now());
     caze.setReceiptReceived(false);
-    caze = caseRepository.save(caze);
+    caze = caseRepository.saveAndFlush(caze);
     return caze;
   }
 

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseProcessorTest.java
@@ -54,7 +54,7 @@ public class CaseProcessorTest {
     createCaseSample.setFieldOfficerId(FIELD_OFFICER_ID);
     createCaseSample.setCeExpectedCapacity(CE_CAPACITY);
     // Given
-    when(caseRepository.save(any(Case.class))).then(obj -> obj.getArgument(0));
+    when(caseRepository.saveAndFlush(any(Case.class))).then(obj -> obj.getArgument(0));
 
     // When
     underTest.saveCase(createCaseSample);
@@ -62,7 +62,7 @@ public class CaseProcessorTest {
     // Then
     verify(mapperFacade).map(createCaseSample, Case.class);
     ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
-    verify(caseRepository).save(caseArgumentCaptor.capture());
+    verify(caseRepository).saveAndFlush(caseArgumentCaptor.capture());
 
     Case savedCase = caseArgumentCaptor.getValue();
     assertThat(savedCase.getTreatmentCode()).isEqualTo(TEST_TREATMENT_CODE);


### PR DESCRIPTION
# Motivation and Context
In the event of a case ref collision Hibernate is not throwing an ID not unique exception, but instead updating an existing entity, causing us to overwrite case data. We need to check that our ID is unique before we proceed with it and we need to flush it to the DB so that we guarantee that new cases are non-colliding.

# What has changed
Check for uniqueness of caseref. Use 'saveAndFlush' instead of 'save'.

# How to test?
Fill up the `cases` table with all possible caserefs using the SQL `INSERT INTO casev2.cases (case_ref) SELECT * FROM generate_series(10000000, 99999999);` and then ensure that the cases are valid using the SQL `update casev2.cases set receipt_received='f';`. Then try loading a sample - the messages should never be consumed from the `case.sample.inbound` queue and no messages should be published.

# Links
Trello: https://trello.com/c/seupU0RG