### PR TITLE
receipt uses qid

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/repository/UacQidLinkRepository.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/repository/UacQidLinkRepository.java
@@ -1,7 +1,10 @@
 package uk.gov.ons.census.casesvc.model.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 
-public interface UacQidLinkRepository extends JpaRepository<UacQidLink, UUID> {}
+public interface UacQidLinkRepository extends JpaRepository<UacQidLink, UUID> {
+  Optional<UacQidLink> findByQid(String qid);
+}

--- a/src/main/java/uk/gov/ons/census/casesvc/service/ReceiptProcessor.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/ReceiptProcessor.java
@@ -4,7 +4,6 @@ import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.census.casesvc.model.dto.PayloadDTO;
 import uk.gov.ons.census.casesvc.model.dto.Receipt;
@@ -12,43 +11,45 @@ import uk.gov.ons.census.casesvc.model.entity.Case;
 import uk.gov.ons.census.casesvc.model.entity.EventType;
 import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
+import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
 
 @Service
 public class ReceiptProcessor {
   private static final Logger log = LoggerFactory.getLogger(ReceiptProcessor.class);
   public static final String QID_RECEIPTED = "QID Receipted";
-  private static final String CASE_NOT_FOUND_ERROR = "Failed to find case by receipt id";
-  private static final String CASE_CREATED_EVENT_DESCRIPTION = "Case updated";
+  private static final String QID_NOT_FOUND_ERROR = "Qid not found error";
   private final CaseProcessor caseProcessor;
+  private final UacQidLinkRepository uacQidLinkRepository;
   private final CaseRepository caseRepository;
   private final UacProcessor uacProcessor;
 
   public ReceiptProcessor(
-      CaseProcessor caseProcessor, CaseRepository caseRepository, UacProcessor uacProcessor) {
+      CaseProcessor caseProcessor,
+      UacQidLinkRepository uacQidLinkRepository,
+      CaseRepository caseRepository,
+      UacProcessor uacProcessor) {
     this.caseProcessor = caseProcessor;
+    this.uacQidLinkRepository = uacQidLinkRepository;
     this.caseRepository = caseRepository;
     this.uacProcessor = uacProcessor;
   }
 
   public void processReceipt(Receipt receipt, Map<String, String> headers) {
-    // HERE BE DRAGONS, THIS IS A HACK.  IN THE LONG RUN WE WILL RECEIVE JUST A QID
-    // HOWEVER THIS CODE IS WRITTEN IN A WAY TO MAKE THE PROMISED LAND OF RECEIVING A QID EASY
-    // JUST HAVE A QIDREPOSITORY RATHER THAN A CASE RESPOSITORY AND WORK OF THAT (AND THE QID)
+    Optional<UacQidLink> uacQidLinkOpt =
+        uacQidLinkRepository.findByQid(receipt.getQuestionnaire_Id());
 
-    Optional<Case> cazeOpt = caseRepository.findByCaseId(UUID.fromString(receipt.getCaseId()));
-
-    if (cazeOpt.isEmpty()) {
-      log.error(CASE_NOT_FOUND_ERROR);
+    if (uacQidLinkOpt.isEmpty()) {
+      log.error(QID_NOT_FOUND_ERROR);
       throw new RuntimeException();
     }
 
-    // This nice long path and the 'random' get(0) will dissapear when we get QID
-    UacQidLink uacQidLink = cazeOpt.get().getUacQidLinks().get(0);
-    PayloadDTO uacPayloadDTO = uacProcessor.emitUacUpdatedEvent(uacQidLink, cazeOpt.get(), false);
-    Case caze = cazeOpt.get();
+    UacQidLink uacQidLink = uacQidLinkOpt.get();
+    Case caze = uacQidLink.getCaze();
+
+    PayloadDTO uacPayloadDTO = uacProcessor.emitUacUpdatedEvent(uacQidLink, caze, false);
     caze.setReceiptReceived(true);
     caseRepository.saveAndFlush(caze);
-    caseProcessor.emitCaseUpdatedEvent(cazeOpt.get());
+    caseProcessor.emitCaseUpdatedEvent(caze);
     uacProcessor.logEvent(
         uacQidLink,
         QID_RECEIPTED,

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
@@ -95,7 +95,7 @@ public class ReceiptReceiverIT {
     uacQidLinkRepository.saveAndFlush(uacQidLink);
 
     Receipt receipt = new Receipt();
-    receipt.setCaseId(TEST_CASE_ID.toString());
+    receipt.setQuestionnaire_Id(TEST_QID);
 
     String json = convertObjectToJson(receipt);
     Message message =

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/TransactionsIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/TransactionsIT.java
@@ -69,7 +69,7 @@ public class TransactionsIT {
     BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(rhUacQueue);
 
     Receipt receipt = new Receipt();
-    receipt.setCaseId(TEST_CASE_ID.toString());
+    receipt.setQuestionnaire_Id(TEST_QID);
 
     // WHEN
     String json = convertObjectToJson(receipt);


### PR DESCRIPTION
# Motivation and Context
Now expect all receipts to contain a qid, use this rather than the case id that doesn't have specific qid

# What has changed
ReceiptProcessor now uses qid rather than case_id

# How to test?
mvn clean install and new ATs

https://github.com/ONSdigital/census-rm-acceptance-tests/compare/675-response-received-qid?expand=1
# Links
https://trello.com/c/McxFBZD0/675-rmc-152b-implement-response-received-event-8
# Screenshots (if appropriate):