### PR TITLE
persist deactivation of uac/qid to database

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/ReceiptProcessor.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/ReceiptProcessor.java
@@ -58,12 +58,16 @@ public class ReceiptProcessor {
     }
 
     UacQidLink uacQidLink = uacQidLinkOpt.get();
-    Case caze = uacQidLink.getCaze();
+    uacQidLink.setActive(false);
+    uacQidLinkRepository.saveAndFlush(uacQidLink);
 
-    uacProcessor.emitUacUpdatedEvent(uacQidLink, caze, false);
+    Case caze = uacQidLink.getCaze();
     caze.setReceiptReceived(true);
     caseRepository.saveAndFlush(caze);
+
+    uacProcessor.emitUacUpdatedEvent(uacQidLink, caze, uacQidLink.isActive());
     caseProcessor.emitCaseUpdatedEvent(caze);
+
     eventLogger.logReceiptEvent(
         uacQidLink, QID_RECEIPTED, EventType.UAC_UPDATED, receiptPayload, receiptEvent.getEvent());
   }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
@@ -120,9 +120,11 @@ public class ReceiptReceiverIT {
     assertThat(events.size()).isEqualTo(1);
     Event event = events.get(0);
     assertThat(event.getEventDescription()).isEqualTo(QID_RECEIPTED);
+
     UacQidLink actualUacQidLink = event.getUacQidLink();
     assertThat(actualUacQidLink.getQid()).isEqualTo(TEST_QID);
     assertThat(actualUacQidLink.getUac()).isEqualTo(TEST_UAC);
     assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
+    assertThat(actualUacQidLink.isActive()).isFalse();
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/service/ReceiptProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/ReceiptProcessorTest.java
@@ -59,7 +59,10 @@ public class ReceiptProcessorTest {
     underTest.processReceipt(managementEvent);
 
     // then
+    verify(uacQidLinkRepository, times(1)).saveAndFlush(expectedUacQidLink);
+    verify(caseRepository, times(1)).saveAndFlush(expectedCase);
     verify(uacProcessor, times(1)).emitUacUpdatedEvent(expectedUacQidLink, expectedCase, false);
+    verify(caseProcessor, times(1)).emitCaseUpdatedEvent(expectedCase);
     verify(eventLogger, times(1))
         .logReceiptEvent(
             expectedUacQidLink,


### PR DESCRIPTION
# Motivation and Context
When a case receipt notification is received, the uac/qid link active state property is not persisted.
<!--- Why is this change required? What problem does it solve? -->

# What has changed
uac/qid link active state persisted to database
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
build local docker image from branch
run with docker dev
run tests
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
[Trello](https://trello.com/c/PVJDUlm5/985-deactivate-uac-qid-on-receipt-of-responsereceived-event-3)
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):