### PR TITLE
Rename processors to service

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/ActionSchedulerEventReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/ActionSchedulerEventReceiver.java
@@ -5,22 +5,22 @@ import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
-import uk.gov.ons.census.casesvc.service.EventProcessor;
+import uk.gov.ons.census.casesvc.service.EventService;
 
 @MessageEndpoint
 public class ActionSchedulerEventReceiver {
 
-  private final EventProcessor eventProcessor;
+  private final EventService eventService;
 
-  public ActionSchedulerEventReceiver(EventProcessor eventProcessor) {
-    this.eventProcessor = eventProcessor;
+  public ActionSchedulerEventReceiver(EventService eventService) {
+    this.eventService = eventService;
   }
 
   @Transactional
   @ServiceActivator(inputChannel = "actionCaseInputChannel")
   public void receiveMessage(ResponseManagementEvent event) {
     if (event.getEvent().getType() == EventTypeDTO.PRINT_CASE_SELECTED) {
-      eventProcessor.processPrintCaseSelected(event);
+      eventService.processPrintCaseSelected(event);
     } else {
       throw new RuntimeException(); // Unexpected event type received
     }

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/FulfilmentRequestReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/FulfilmentRequestReceiver.java
@@ -4,19 +4,19 @@ import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
-import uk.gov.ons.census.casesvc.service.FulfilmentRequestProcessor;
+import uk.gov.ons.census.casesvc.service.FulfilmentRequestService;
 
 @MessageEndpoint
 public class FulfilmentRequestReceiver {
-  private final FulfilmentRequestProcessor fulfilmentRequestProcessor;
+  private final FulfilmentRequestService fulfilmentRequestService;
 
-  public FulfilmentRequestReceiver(FulfilmentRequestProcessor fulfilmentRequestProcessor) {
-    this.fulfilmentRequestProcessor = fulfilmentRequestProcessor;
+  public FulfilmentRequestReceiver(FulfilmentRequestService fulfilmentRequestService) {
+    this.fulfilmentRequestService = fulfilmentRequestService;
   }
 
   @Transactional
   @ServiceActivator(inputChannel = "fulfilmentInputChannel")
   public void receiveMessage(ResponseManagementEvent fulfilmentEvent) {
-    fulfilmentRequestProcessor.processFulfilmentRequest(fulfilmentEvent);
+    fulfilmentRequestService.processFulfilmentRequest(fulfilmentEvent);
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiver.java
@@ -4,19 +4,19 @@ import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
-import uk.gov.ons.census.casesvc.service.QuestionnaireLinkedProcessor;
+import uk.gov.ons.census.casesvc.service.QuestionnaireLinkedService;
 
 @MessageEndpoint
 public class QuestionnaireLinkedReceiver {
-  private final QuestionnaireLinkedProcessor questionnaireLinkedProcessor;
+  private final QuestionnaireLinkedService questionnaireLinkedService;
 
-  public QuestionnaireLinkedReceiver(QuestionnaireLinkedProcessor questionnaireLinkedProcessor) {
-    this.questionnaireLinkedProcessor = questionnaireLinkedProcessor;
+  public QuestionnaireLinkedReceiver(QuestionnaireLinkedService questionnaireLinkedService) {
+    this.questionnaireLinkedService = questionnaireLinkedService;
   }
 
   @Transactional
   @ServiceActivator(inputChannel = "questionnaireLinkedInputChannel")
   public void receiveMessage(ResponseManagementEvent questionnaireLinkedEvent) {
-    questionnaireLinkedProcessor.processQuestionnaireLinked(questionnaireLinkedEvent);
+    questionnaireLinkedService.processQuestionnaireLinked(questionnaireLinkedEvent);
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiver.java
@@ -4,19 +4,19 @@ import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
-import uk.gov.ons.census.casesvc.service.ReceiptProcessor;
+import uk.gov.ons.census.casesvc.service.ReceiptService;
 
 @MessageEndpoint
 public class ReceiptReceiver {
-  private final ReceiptProcessor receiptProcessor;
+  private final ReceiptService receiptService;
 
-  public ReceiptReceiver(ReceiptProcessor receiptProcessor) {
-    this.receiptProcessor = receiptProcessor;
+  public ReceiptReceiver(ReceiptService receiptService) {
+    this.receiptService = receiptService;
   }
 
   @Transactional
   @ServiceActivator(inputChannel = "receiptInputChannel")
   public void receiveMessage(ResponseManagementEvent receiptEvent) {
-    receiptProcessor.processReceipt(receiptEvent);
+    receiptService.processReceipt(receiptEvent);
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiver.java
@@ -4,19 +4,19 @@ import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
-import uk.gov.ons.census.casesvc.service.RefusalProcessor;
+import uk.gov.ons.census.casesvc.service.RefusalService;
 
 @MessageEndpoint
 public class RefusalReceiver {
-  private final RefusalProcessor refusalProcessor;
+  private final RefusalService refusalService;
 
-  public RefusalReceiver(RefusalProcessor refusalProcessor) {
-    this.refusalProcessor = refusalProcessor;
+  public RefusalReceiver(RefusalService refusalService) {
+    this.refusalService = refusalService;
   }
 
   @Transactional
   @ServiceActivator(inputChannel = "refusalInputChannel")
   public void receiveMessage(ResponseManagementEvent refusalEvent) {
-    refusalProcessor.processRefusal(refusalEvent);
+    refusalService.processRefusal(refusalEvent);
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
@@ -4,20 +4,20 @@ import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.census.casesvc.model.dto.CreateCaseSample;
-import uk.gov.ons.census.casesvc.service.EventProcessor;
+import uk.gov.ons.census.casesvc.service.EventService;
 
 @MessageEndpoint
 public class SampleReceiver {
 
-  private final EventProcessor eventProcessor;
+  private final EventService eventService;
 
-  public SampleReceiver(EventProcessor eventProcessor) {
-    this.eventProcessor = eventProcessor;
+  public SampleReceiver(EventService eventService) {
+    this.eventService = eventService;
   }
 
   @Transactional
   @ServiceActivator(inputChannel = "caseSampleInputChannel")
   public void receiveMessage(CreateCaseSample createCaseSample) {
-    eventProcessor.processSampleReceivedMessage(createCaseSample);
+    eventService.processSampleReceivedMessage(createCaseSample);
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/UacCreatedEventReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/UacCreatedEventReceiver.java
@@ -4,19 +4,19 @@ import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
-import uk.gov.ons.census.casesvc.service.UacProcessor;
+import uk.gov.ons.census.casesvc.service.UacService;
 
 @MessageEndpoint
 public class UacCreatedEventReceiver {
-  private final UacProcessor uacProcessor;
+  private final UacService uacService;
 
-  public UacCreatedEventReceiver(UacProcessor uacProcessor) {
-    this.uacProcessor = uacProcessor;
+  public UacCreatedEventReceiver(UacService uacService) {
+    this.uacService = uacService;
   }
 
   @Transactional
   @ServiceActivator(inputChannel = "uacCreatedInputChannel")
   public void receiveMessage(ResponseManagementEvent uacCreatedEvent) {
-    uacProcessor.ingestUacCreatedEvent(uacCreatedEvent);
+    uacService.ingestUacCreatedEvent(uacCreatedEvent);
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiver.java
@@ -13,16 +13,16 @@ import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
 import uk.gov.ons.census.casesvc.model.dto.PayloadDTO;
 import uk.gov.ons.census.casesvc.model.entity.EventType;
 import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
-import uk.gov.ons.census.casesvc.service.UacProcessor;
+import uk.gov.ons.census.casesvc.service.UacService;
 
 @MessageEndpoint
 public class UnaddressedReceiver {
 
-  private final UacProcessor uacProcessor;
+  private final UacService uacService;
   private final EventLogger eventLogger;
 
-  public UnaddressedReceiver(UacProcessor uacProcessor, EventLogger eventLogger) {
-    this.uacProcessor = uacProcessor;
+  public UnaddressedReceiver(UacService uacService, EventLogger eventLogger) {
+    this.uacService = uacService;
     this.eventLogger = eventLogger;
   }
 
@@ -30,9 +30,9 @@ public class UnaddressedReceiver {
   @ServiceActivator(inputChannel = "unaddressedInputChannel")
   public void receiveMessage(CreateUacQid createUacQid) {
     UacQidLink uacQidLink =
-        uacProcessor.generateAndSaveUacQidLink(
+        uacService.generateAndSaveUacQidLink(
             null, Integer.parseInt(createUacQid.getQuestionnaireType()), createUacQid.getBatchId());
-    PayloadDTO uacPayloadDTO = uacProcessor.emitUacUpdatedEvent(uacQidLink, null);
+    PayloadDTO uacPayloadDTO = uacService.emitUacUpdatedEvent(uacQidLink, null);
     eventLogger.logUacQidEvent(
         uacQidLink,
         OffsetDateTime.now(),

--- a/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 import ma.glasnost.orika.MapperFacade;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import uk.gov.ons.census.casesvc.model.dto.Address;
 import uk.gov.ons.census.casesvc.model.dto.CollectionCase;
 import uk.gov.ons.census.casesvc.model.dto.CreateCaseSample;
@@ -22,9 +22,9 @@ import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 import uk.gov.ons.census.casesvc.utility.EventHelper;
 import uk.gov.ons.census.casesvc.utility.RandomCaseRefGenerator;
 
-@Component
-public class CaseProcessor {
-  private static final Logger log = LoggerFactory.getLogger(CaseProcessor.class);
+@Service
+public class CaseService {
+  private static final Logger log = LoggerFactory.getLogger(CaseService.class);
   private static final String CASE_NOT_FOUND_ERROR = "Case not found error";
   private static final String SURVEY = "CENSUS";
   static final String CASE_UPDATE_ROUTING_KEY = "event.case.update";
@@ -36,7 +36,7 @@ public class CaseProcessor {
   @Value("${queueconfig.case-event-exchange}")
   private String outboundExchange;
 
-  public CaseProcessor(
+  public CaseService(
       CaseRepository caseRepository, RabbitTemplate rabbitTemplate, MapperFacade mapperFacade) {
     this.caseRepository = caseRepository;
     this.rabbitTemplate = rabbitTemplate;

--- a/src/main/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestService.java
@@ -18,7 +18,7 @@ import uk.gov.ons.census.casesvc.model.entity.CaseState;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 
 @Service
-public class FulfilmentRequestProcessor {
+public class FulfilmentRequestService {
   private static final String FULFILMENT_REQUEST_RECEIVED = "Fulfilment Request Received";
   private static final String HOUSEHOLD_INDIVIDUAL_RESPONSE_ADDRESS_TYPE = "HI";
   private static final String HOUSEHOLD_INDIVIDUAL_RESPONSE_REQUEST_ENGLAND = "UACIT1";
@@ -35,13 +35,13 @@ public class FulfilmentRequestProcessor {
 
   private final CaseRepository caseRepository;
   private final EventLogger eventLogger;
-  private final CaseProcessor caseProcessor;
+  private final CaseService caseService;
 
-  public FulfilmentRequestProcessor(
-      CaseRepository caseRepository, EventLogger eventLogger, CaseProcessor caseProcessor) {
+  public FulfilmentRequestService(
+      CaseRepository caseRepository, EventLogger eventLogger, CaseService caseService) {
     this.caseRepository = caseRepository;
     this.eventLogger = eventLogger;
-    this.caseProcessor = caseProcessor;
+    this.caseService = caseService;
   }
 
   public void processFulfilmentRequest(ResponseManagementEvent fulfilmentRequest) {
@@ -49,8 +49,7 @@ public class FulfilmentRequestProcessor {
     FulfilmentRequestDTO fulfilmentRequestPayload =
         fulfilmentRequest.getPayload().getFulfilmentRequest();
 
-    Case caze =
-        caseProcessor.getCaseByCaseId(UUID.fromString(fulfilmentRequestPayload.getCaseId()));
+    Case caze = caseService.getCaseByCaseId(UUID.fromString(fulfilmentRequestPayload.getCaseId()));
 
     eventLogger.logCaseEvent(
         caze,
@@ -63,7 +62,7 @@ public class FulfilmentRequestProcessor {
 
     if (individualResponseRequestCodes.contains(fulfilmentRequestPayload.getFulfilmentCode())) {
       Case individualResponseCase = saveIndividualResponseCaseFromParentCase(caze);
-      caseProcessor.emitCaseCreatedEvent(individualResponseCase);
+      caseService.emitCaseCreatedEvent(individualResponseCase);
     }
   }
 
@@ -71,7 +70,7 @@ public class FulfilmentRequestProcessor {
     Case individualResponseCase = new Case();
 
     individualResponseCase.setCaseId(UUID.randomUUID());
-    individualResponseCase.setCaseRef(caseProcessor.getUniqueCaseRef());
+    individualResponseCase.setCaseRef(caseService.getUniqueCaseRef());
     individualResponseCase.setState(CaseState.ACTIONABLE);
     individualResponseCase.setCreatedDateTime(OffsetDateTime.now());
     individualResponseCase.setAddressType(HOUSEHOLD_INDIVIDUAL_RESPONSE_ADDRESS_TYPE);

--- a/src/main/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedService.java
@@ -7,7 +7,7 @@ import com.godaddy.logging.LoggerFactory;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import uk.gov.ons.census.casesvc.logging.EventLogger;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.casesvc.model.dto.UacDTO;
@@ -17,28 +17,28 @@ import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
 
-@Component
-public class QuestionnaireLinkedProcessor {
-  private static final Logger log = LoggerFactory.getLogger(QuestionnaireLinkedProcessor.class);
+@Service
+public class QuestionnaireLinkedService {
+  private static final Logger log = LoggerFactory.getLogger(QuestionnaireLinkedService.class);
   private static final String QID_NOT_FOUND_ERROR = "Qid not found error";
   private static final String QUESTIONNAIRE_LINKED = "Questionnaire Linked";
 
   private final UacQidLinkRepository uacQidLinkRepository;
   private final CaseRepository caseRepository;
-  private final UacProcessor uacProcessor;
-  private final CaseProcessor caseProcessor;
+  private final UacService uacService;
+  private final CaseService caseService;
   private final EventLogger eventLogger;
 
-  public QuestionnaireLinkedProcessor(
+  public QuestionnaireLinkedService(
       UacQidLinkRepository uacQidLinkRepository,
       CaseRepository caseRepository,
-      UacProcessor uacProcessor,
-      CaseProcessor caseProcessor,
+      UacService uacService,
+      CaseService caseService,
       EventLogger eventLogger) {
     this.uacQidLinkRepository = uacQidLinkRepository;
     this.caseRepository = caseRepository;
-    this.uacProcessor = uacProcessor;
-    this.caseProcessor = caseProcessor;
+    this.uacService = uacService;
+    this.caseService = caseService;
     this.eventLogger = eventLogger;
   }
 
@@ -54,19 +54,19 @@ public class QuestionnaireLinkedProcessor {
 
     UacQidLink uacQidLink = uacQidLinkOpt.get();
 
-    Case caze = caseProcessor.getCaseByCaseId(UUID.fromString(uac.getCaseId()));
+    Case caze = caseService.getCaseByCaseId(UUID.fromString(uac.getCaseId()));
 
     // If UAC/QID has been receipted before case, update case
     if (!uacQidLink.isActive() && !caze.isReceiptReceived()) {
       caze.setReceiptReceived(true);
       caseRepository.saveAndFlush(caze);
-      caseProcessor.emitCaseUpdatedEvent(caze);
+      caseService.emitCaseUpdatedEvent(caze);
     }
 
     uacQidLink.setCaze(caze);
     uacQidLinkRepository.saveAndFlush(uacQidLink);
 
-    uacProcessor.emitUacUpdatedEvent(uacQidLink, caze);
+    uacService.emitUacUpdatedEvent(uacQidLink, caze);
 
     eventLogger.logUacQidEvent(
         uacQidLink,

--- a/src/main/java/uk/gov/ons/census/casesvc/service/ReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/ReceiptService.java
@@ -17,26 +17,26 @@ import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
 
 @Service
-public class ReceiptProcessor {
-  private static final Logger log = LoggerFactory.getLogger(ReceiptProcessor.class);
+public class ReceiptService {
+  private static final Logger log = LoggerFactory.getLogger(ReceiptService.class);
   public static final String QID_RECEIPTED = "QID Receipted";
   private static final String QID_NOT_FOUND_ERROR = "Qid not found error";
-  private final CaseProcessor caseProcessor;
+  private final CaseService caseService;
   private final UacQidLinkRepository uacQidLinkRepository;
   private final CaseRepository caseRepository;
-  private final UacProcessor uacProcessor;
+  private final UacService uacService;
   private final EventLogger eventLogger;
 
-  public ReceiptProcessor(
-      CaseProcessor caseProcessor,
+  public ReceiptService(
+      CaseService caseService,
       UacQidLinkRepository uacQidLinkRepository,
       CaseRepository caseRepository,
-      UacProcessor uacProcessor,
+      UacService uacService,
       EventLogger eventLogger) {
-    this.caseProcessor = caseProcessor;
+    this.caseService = caseService;
     this.uacQidLinkRepository = uacQidLinkRepository;
     this.caseRepository = caseRepository;
-    this.uacProcessor = uacProcessor;
+    this.uacService = uacService;
     this.eventLogger = eventLogger;
   }
 
@@ -59,8 +59,8 @@ public class ReceiptProcessor {
     caze.setReceiptReceived(true);
     caseRepository.saveAndFlush(caze);
 
-    uacProcessor.emitUacUpdatedEvent(uacQidLink, caze, uacQidLink.isActive());
-    caseProcessor.emitCaseUpdatedEvent(caze);
+    uacService.emitUacUpdatedEvent(uacQidLink, caze, uacQidLink.isActive());
+    caseService.emitCaseUpdatedEvent(caze);
 
     eventLogger.logUacQidEvent(
         uacQidLink,

--- a/src/main/java/uk/gov/ons/census/casesvc/service/RefusalService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/RefusalService.java
@@ -13,25 +13,25 @@ import uk.gov.ons.census.casesvc.model.entity.EventType;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 
 @Service
-public class RefusalProcessor {
+public class RefusalService {
   private static final String REFUSAL_RECEIVED = "Refusal Received";
-  private final CaseProcessor caseProcessor;
+  private final CaseService caseService;
   private final CaseRepository caseRepository;
   private final EventLogger eventLogger;
 
-  public RefusalProcessor(
-      CaseProcessor caseProcessor, CaseRepository caseRepository, EventLogger eventLogger) {
-    this.caseProcessor = caseProcessor;
+  public RefusalService(
+      CaseService caseService, CaseRepository caseRepository, EventLogger eventLogger) {
+    this.caseService = caseService;
     this.caseRepository = caseRepository;
     this.eventLogger = eventLogger;
   }
 
   public void processRefusal(ResponseManagementEvent refusalEvent) {
     RefusalDTO refusal = refusalEvent.getPayload().getRefusal();
-    Case caze = caseProcessor.getCaseByCaseId(UUID.fromString(refusal.getCollectionCase().getId()));
+    Case caze = caseService.getCaseByCaseId(UUID.fromString(refusal.getCollectionCase().getId()));
     caze.setRefusalReceived(true);
     caseRepository.saveAndFlush(caze);
-    caseProcessor.emitCaseUpdatedEvent(caze);
+    caseService.emitCaseUpdatedEvent(caze);
 
     eventLogger.logCaseEvent(
         caze,

--- a/src/main/java/uk/gov/ons/census/casesvc/service/UacService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/UacService.java
@@ -6,7 +6,7 @@ import java.time.OffsetDateTime;
 import java.util.UUID;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import uk.gov.ons.census.casesvc.client.UacQidServiceClient;
 import uk.gov.ons.census.casesvc.logging.EventLogger;
 import uk.gov.ons.census.casesvc.model.dto.EventDTO;
@@ -22,30 +22,30 @@ import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
 import uk.gov.ons.census.casesvc.utility.EventHelper;
 import uk.gov.ons.census.casesvc.utility.Sha256Helper;
 
-@Component
-public class UacProcessor {
+@Service
+public class UacService {
   private static final String UAC_UPDATE_ROUTING_KEY = "event.uac.update";
 
   private final UacQidLinkRepository uacQidLinkRepository;
   private final RabbitTemplate rabbitTemplate;
   private final UacQidServiceClient uacQidServiceClient;
   private final EventLogger eventLogger;
-  private final CaseProcessor caseProcessor;
+  private final CaseService caseService;
 
   @Value("${queueconfig.case-event-exchange}")
   private String outboundExchange;
 
-  public UacProcessor(
+  public UacService(
       UacQidLinkRepository uacQidLinkRepository,
       RabbitTemplate rabbitTemplate,
       UacQidServiceClient uacQidServiceClient,
       EventLogger eventLogger,
-      CaseProcessor caseProcessor) {
+      CaseService caseService) {
     this.rabbitTemplate = rabbitTemplate;
     this.uacQidServiceClient = uacQidServiceClient;
     this.uacQidLinkRepository = uacQidLinkRepository;
     this.eventLogger = eventLogger;
-    this.caseProcessor = caseProcessor;
+    this.caseService = caseService;
   }
 
   public UacQidLink generateAndSaveUacQidLink(Case caze, int questionnaireType) {
@@ -105,7 +105,7 @@ public class UacProcessor {
 
   public void ingestUacCreatedEvent(ResponseManagementEvent uacCreatedEvent) {
     Case linkedCase =
-        caseProcessor.getCaseByCaseId(uacCreatedEvent.getPayload().getUacQidCreated().getCaseId());
+        caseService.getCaseByCaseId(uacCreatedEvent.getPayload().getUacQidCreated().getCaseId());
 
     UacQidLink uacQidLink =
         createAndSaveUacQidLink(

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/ActionSchedulerEventReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/ActionSchedulerEventReceiverTest.java
@@ -8,15 +8,15 @@ import org.junit.Test;
 import uk.gov.ons.census.casesvc.model.dto.EventDTO;
 import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
-import uk.gov.ons.census.casesvc.service.EventProcessor;
+import uk.gov.ons.census.casesvc.service.EventService;
 
 public class ActionSchedulerEventReceiverTest {
 
   @Test
   public void testReceiveMessage() {
     // Given
-    EventProcessor eventProcessor = mock(EventProcessor.class);
-    ActionSchedulerEventReceiver underTest = new ActionSchedulerEventReceiver(eventProcessor);
+    EventService eventService = mock(EventService.class);
+    ActionSchedulerEventReceiver underTest = new ActionSchedulerEventReceiver(eventService);
 
     ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
     EventDTO event = new EventDTO();
@@ -27,14 +27,14 @@ public class ActionSchedulerEventReceiverTest {
     underTest.receiveMessage(responseManagementEvent);
 
     // Then
-    verify(eventProcessor).processPrintCaseSelected(eq(responseManagementEvent));
+    verify(eventService).processPrintCaseSelected(eq(responseManagementEvent));
   }
 
   @Test(expected = RuntimeException.class)
   public void testReceiveUnexpectedMessage() {
     // Given
-    EventProcessor eventProcessor = mock(EventProcessor.class);
-    ActionSchedulerEventReceiver underTest = new ActionSchedulerEventReceiver(eventProcessor);
+    EventService eventService = mock(EventService.class);
+    ActionSchedulerEventReceiver underTest = new ActionSchedulerEventReceiver(eventService);
 
     ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
     EventDTO event = new EventDTO();

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/FulfilmentRequestReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/FulfilmentRequestReceiverTest.java
@@ -5,19 +5,19 @@ import static uk.gov.ons.census.casesvc.testutil.DataUtils.getTestResponseManage
 
 import org.junit.Test;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
-import uk.gov.ons.census.casesvc.service.FulfilmentRequestProcessor;
+import uk.gov.ons.census.casesvc.service.FulfilmentRequestService;
 
 public class FulfilmentRequestReceiverTest {
 
   @Test
   public void testFulfilmentRequestReceiver() {
     ResponseManagementEvent managementEvent = getTestResponseManagementEvent();
-    FulfilmentRequestProcessor fulfilmentRequestProcessor = mock(FulfilmentRequestProcessor.class);
+    FulfilmentRequestService fulfilmentRequestService = mock(FulfilmentRequestService.class);
 
     FulfilmentRequestReceiver fulfilmentRequestReceiver =
-        new FulfilmentRequestReceiver(fulfilmentRequestProcessor);
+        new FulfilmentRequestReceiver(fulfilmentRequestService);
     fulfilmentRequestReceiver.receiveMessage(managementEvent);
 
-    verify(fulfilmentRequestProcessor, times(1)).processFulfilmentRequest(managementEvent);
+    verify(fulfilmentRequestService, times(1)).processFulfilmentRequest(managementEvent);
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverTest.java
@@ -9,24 +9,23 @@ import java.time.OffsetDateTime;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
-import uk.gov.ons.census.casesvc.service.QuestionnaireLinkedProcessor;
+import uk.gov.ons.census.casesvc.service.QuestionnaireLinkedService;
 
 public class QuestionnaireLinkedReceiverTest {
 
   @Test
   public void testQuestionnaireLinking() {
     ResponseManagementEvent managementEvent = getTestResponseManagementEvent();
-    QuestionnaireLinkedProcessor questionnaireLinkedProcessor =
-        mock(QuestionnaireLinkedProcessor.class);
+    QuestionnaireLinkedService questionnaireLinkedService = mock(QuestionnaireLinkedService.class);
     OffsetDateTime expectedEventDateTime = managementEvent.getEvent().getDateTime();
 
     QuestionnaireLinkedReceiver questionnaireLinkedReceiver =
-        new QuestionnaireLinkedReceiver(questionnaireLinkedProcessor);
+        new QuestionnaireLinkedReceiver(questionnaireLinkedService);
     questionnaireLinkedReceiver.receiveMessage(managementEvent);
 
     ArgumentCaptor<ResponseManagementEvent> eventArgumentCaptor =
         ArgumentCaptor.forClass(ResponseManagementEvent.class);
-    verify(questionnaireLinkedProcessor).processQuestionnaireLinked(eventArgumentCaptor.capture());
+    verify(questionnaireLinkedService).processQuestionnaireLinked(eventArgumentCaptor.capture());
 
     OffsetDateTime actualEventDateTime = eventArgumentCaptor.getValue().getEvent().getDateTime();
     assertThat(actualEventDateTime).isEqualTo(expectedEventDateTime);

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.census.casesvc.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.ons.census.casesvc.service.ReceiptProcessor.QID_RECEIPTED;
+import static uk.gov.ons.census.casesvc.service.ReceiptService.QID_RECEIPTED;
 import static uk.gov.ons.census.casesvc.testutil.DataUtils.getTestResponseManagementReceiptEvent;
 import static uk.gov.ons.census.casesvc.utility.JsonHelper.convertObjectToJson;
 

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverTest.java
@@ -5,18 +5,18 @@ import static uk.gov.ons.census.casesvc.testutil.DataUtils.getTestResponseManage
 
 import org.junit.Test;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
-import uk.gov.ons.census.casesvc.service.ReceiptProcessor;
+import uk.gov.ons.census.casesvc.service.ReceiptService;
 
 public class ReceiptReceiverTest {
 
   @Test
   public void testReceipting() {
     ResponseManagementEvent managementEvent = getTestResponseManagementEvent();
-    ReceiptProcessor receiptProcessor = mock(ReceiptProcessor.class);
+    ReceiptService receiptService = mock(ReceiptService.class);
 
-    ReceiptReceiver receiptReceiver = new ReceiptReceiver(receiptProcessor);
+    ReceiptReceiver receiptReceiver = new ReceiptReceiver(receiptService);
     receiptReceiver.receiveMessage(managementEvent);
 
-    verify(receiptProcessor, times(1)).processReceipt(managementEvent);
+    verify(receiptService, times(1)).processReceipt(managementEvent);
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverTest.java
@@ -11,12 +11,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
-import uk.gov.ons.census.casesvc.service.RefusalProcessor;
+import uk.gov.ons.census.casesvc.service.RefusalService;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RefusalReceiverTest {
 
-  @Mock private RefusalProcessor refusalProcessor;
+  @Mock private RefusalService refusalService;
 
   @InjectMocks RefusalReceiver underTest;
 
@@ -32,7 +32,7 @@ public class RefusalReceiverTest {
     // THEN
     ArgumentCaptor<ResponseManagementEvent> managementEventArgumentCaptor =
         ArgumentCaptor.forClass(ResponseManagementEvent.class);
-    verify(refusalProcessor).processRefusal(managementEventArgumentCaptor.capture());
+    verify(refusalService).processRefusal(managementEventArgumentCaptor.capture());
 
     String actualCaseId =
         managementEventArgumentCaptor.getValue().getPayload().getCollectionCase().getId();

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverTest.java
@@ -8,14 +8,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ons.census.casesvc.model.dto.CreateCaseSample;
-import uk.gov.ons.census.casesvc.service.EventProcessor;
+import uk.gov.ons.census.casesvc.service.EventService;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SampleReceiverTest {
 
   @InjectMocks private SampleReceiver underTest;
 
-  @Mock private EventProcessor eventProcessor;
+  @Mock private EventService eventService;
 
   @Test
   public void testHappyPath() {
@@ -26,6 +26,6 @@ public class SampleReceiverTest {
     underTest.receiveMessage(createCaseSample);
 
     // Then
-    verify(eventProcessor).processSampleReceivedMessage(createCaseSample);
+    verify(eventService).processSampleReceivedMessage(createCaseSample);
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UacCreatedEventReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UacCreatedEventReceiverTest.java
@@ -12,11 +12,11 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.casesvc.model.entity.Case;
-import uk.gov.ons.census.casesvc.service.UacProcessor;
+import uk.gov.ons.census.casesvc.service.UacService;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UacCreatedEventReceiverTest {
-  @Mock UacProcessor uacProcessor;
+  @Mock UacService uacService;
 
   @InjectMocks UacCreatedEventReceiver underTest;
 
@@ -30,6 +30,6 @@ public class UacCreatedEventReceiverTest {
     underTest.receiveMessage(uacCreatedEvent);
 
     // Then
-    verify(uacProcessor).ingestUacCreatedEvent(eq(uacCreatedEvent));
+    verify(uacService).ingestUacCreatedEvent(eq(uacCreatedEvent));
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiverTest.java
@@ -17,12 +17,12 @@ import uk.gov.ons.census.casesvc.model.dto.EventDTO;
 import uk.gov.ons.census.casesvc.model.dto.PayloadDTO;
 import uk.gov.ons.census.casesvc.model.entity.EventType;
 import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
-import uk.gov.ons.census.casesvc.service.UacProcessor;
+import uk.gov.ons.census.casesvc.service.UacService;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UnaddressedReceiverTest {
 
-  @Mock UacProcessor uacProcessor;
+  @Mock UacService uacService;
   @Mock EventLogger eventLogger;
 
   @InjectMocks UnaddressedReceiver underTest;
@@ -34,16 +34,15 @@ public class UnaddressedReceiverTest {
     createUacQid.setQuestionnaireType("21");
     createUacQid.setBatchId(UUID.randomUUID());
     UacQidLink uacQidLink = new UacQidLink();
-    when(uacProcessor.generateAndSaveUacQidLink(null, 21, createUacQid.getBatchId()))
+    when(uacService.generateAndSaveUacQidLink(null, 21, createUacQid.getBatchId()))
         .thenReturn(uacQidLink);
-    when(uacProcessor.emitUacUpdatedEvent(any(UacQidLink.class), any()))
-        .thenReturn(new PayloadDTO());
+    when(uacService.emitUacUpdatedEvent(any(UacQidLink.class), any())).thenReturn(new PayloadDTO());
 
     // When
     underTest.receiveMessage(createUacQid);
 
     // Then
-    verify(uacProcessor).emitUacUpdatedEvent(eq(uacQidLink), eq(null));
+    verify(uacService).emitUacUpdatedEvent(eq(uacQidLink), eq(null));
     verify(eventLogger)
         .logUacQidEvent(
             eq(uacQidLink),

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.ons.census.casesvc.service.CaseProcessor.CASE_UPDATE_ROUTING_KEY;
+import static uk.gov.ons.census.casesvc.service.CaseService.CASE_UPDATE_ROUTING_KEY;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -28,7 +28,7 @@ import uk.gov.ons.census.casesvc.model.entity.CaseState;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 
 @RunWith(MockitoJUnitRunner.class)
-public class CaseProcessorTest {
+public class CaseServiceTest {
   private static final String FIELD_CORD_ID = "FIELD_CORD_ID";
   private static final String FIELD_OFFICER_ID = "FIELD_OFFICER_ID";
   private static final String CE_CAPACITY = "CE_CAPACITY";
@@ -44,7 +44,7 @@ public class CaseProcessorTest {
 
   @Mock RabbitTemplate rabbitTemplate;
 
-  @InjectMocks CaseProcessor underTest;
+  @InjectMocks CaseService underTest;
 
   @Test
   public void testSaveCase() {

--- a/src/test/java/uk/gov/ons/census/casesvc/service/EventServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/EventServiceTest.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.census.casesvc.service;
 
 import static org.mockito.Mockito.*;
-import static uk.gov.ons.census.casesvc.service.EventProcessor.CREATE_CASE_SAMPLE_RECEIVED;
+import static uk.gov.ons.census.casesvc.service.EventService.CREATE_CASE_SAMPLE_RECEIVED;
 import static uk.gov.ons.census.casesvc.utility.JsonHelper.convertObjectToJson;
 
 import java.time.OffsetDateTime;
@@ -25,15 +25,15 @@ import uk.gov.ons.census.casesvc.model.entity.EventType;
 import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 
 @RunWith(MockitoJUnitRunner.class)
-public class EventProcessorTest {
+public class EventServiceTest {
 
-  @Mock CaseProcessor caseProcessor;
+  @Mock CaseService caseService;
 
-  @Mock UacProcessor uacProcessor;
+  @Mock UacService uacService;
 
   @Mock EventLogger eventLogger;
 
-  @InjectMocks EventProcessor underTest;
+  @InjectMocks EventService underTest;
 
   @Test
   public void testHappyPath() {
@@ -41,21 +41,21 @@ public class EventProcessorTest {
     CreateCaseSample createCaseSample = new CreateCaseSample();
     Case caze = new Case();
     caze.setTreatmentCode("HH_LF2R3BE");
-    when(caseProcessor.saveCase(createCaseSample)).thenReturn(caze);
+    when(caseService.saveCase(createCaseSample)).thenReturn(caze);
     UacQidLink uacQidLink = new UacQidLink();
-    when(uacProcessor.generateAndSaveUacQidLink(caze, 1)).thenReturn(uacQidLink);
-    when(uacProcessor.emitUacUpdatedEvent(any(UacQidLink.class), any(Case.class)))
+    when(uacService.generateAndSaveUacQidLink(caze, 1)).thenReturn(uacQidLink);
+    when(uacService.emitUacUpdatedEvent(any(UacQidLink.class), any(Case.class)))
         .thenReturn(new PayloadDTO());
-    when(caseProcessor.emitCaseCreatedEvent(any(Case.class))).thenReturn(new PayloadDTO());
+    when(caseService.emitCaseCreatedEvent(any(Case.class))).thenReturn(new PayloadDTO());
 
     // When
     underTest.processSampleReceivedMessage(createCaseSample);
 
     // Then
-    verify(caseProcessor).saveCase(createCaseSample);
-    verify(uacProcessor).generateAndSaveUacQidLink(eq(caze), eq(1));
-    verify(uacProcessor).emitUacUpdatedEvent(uacQidLink, caze);
-    verify(caseProcessor).emitCaseCreatedEvent(caze);
+    verify(caseService).saveCase(createCaseSample);
+    verify(uacService).generateAndSaveUacQidLink(eq(caze), eq(1));
+    verify(uacService).emitUacUpdatedEvent(uacQidLink, caze);
+    verify(caseService).emitCaseCreatedEvent(caze);
 
     verify(eventLogger, times(1))
         .logCaseEvent(
@@ -74,23 +74,23 @@ public class EventProcessorTest {
     CreateCaseSample createCaseSample = new CreateCaseSample();
     Case caze = new Case();
     caze.setTreatmentCode("HH_QF2R1W");
-    when(caseProcessor.saveCase(createCaseSample)).thenReturn(caze);
+    when(caseService.saveCase(createCaseSample)).thenReturn(caze);
     UacQidLink uacQidLink = new UacQidLink();
     UacQidLink secondUacQidLink = new UacQidLink();
-    when(uacProcessor.generateAndSaveUacQidLink(caze, 2)).thenReturn(uacQidLink);
-    when(uacProcessor.generateAndSaveUacQidLink(caze, 3)).thenReturn(secondUacQidLink);
-    when(uacProcessor.emitUacUpdatedEvent(any(UacQidLink.class), any(Case.class)))
+    when(uacService.generateAndSaveUacQidLink(caze, 2)).thenReturn(uacQidLink);
+    when(uacService.generateAndSaveUacQidLink(caze, 3)).thenReturn(secondUacQidLink);
+    when(uacService.emitUacUpdatedEvent(any(UacQidLink.class), any(Case.class)))
         .thenReturn(new PayloadDTO());
-    when(caseProcessor.emitCaseCreatedEvent(any(Case.class))).thenReturn(new PayloadDTO());
+    when(caseService.emitCaseCreatedEvent(any(Case.class))).thenReturn(new PayloadDTO());
 
     // When
     underTest.processSampleReceivedMessage(createCaseSample);
 
     // Then
-    verify(caseProcessor).saveCase(createCaseSample);
-    verify(uacProcessor, times(1)).generateAndSaveUacQidLink(eq(caze), eq(2));
-    verify(uacProcessor, times(2)).emitUacUpdatedEvent(uacQidLink, caze);
-    verify(caseProcessor).emitCaseCreatedEvent(caze);
+    verify(caseService).saveCase(createCaseSample);
+    verify(uacService, times(1)).generateAndSaveUacQidLink(eq(caze), eq(2));
+    verify(uacService, times(2)).emitUacUpdatedEvent(uacQidLink, caze);
+    verify(caseService).emitCaseCreatedEvent(caze);
 
     verify(eventLogger, times(1))
         .logCaseEvent(
@@ -108,7 +108,7 @@ public class EventProcessorTest {
     // Given
     EasyRandom easyRandom = new EasyRandom();
     Case caze = easyRandom.nextObject(Case.class);
-    when(caseProcessor.findCase(anyInt())).thenReturn(Optional.of(caze));
+    when(caseService.findCase(anyInt())).thenReturn(Optional.of(caze));
 
     // When
     ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();

--- a/src/test/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestServiceTest.java
@@ -24,7 +24,7 @@ import uk.gov.ons.census.casesvc.model.entity.CaseState;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 
 @RunWith(MockitoJUnitRunner.class)
-public class FulfilmentRequestProcessorTest {
+public class FulfilmentRequestServiceTest {
   private static final String HOUSEHOLD_INDIVIDUAL_RESPONSE_ADDRESS_TYPE = "HI";
   private static final String HOUSEHOLD_INDIVIDUAL_RESPONSE_REQUEST_ENGLAND = "UACIT1";
   private static final String HOUSEHOLD_INDIVIDUAL_RESPONSE_REQUEST_WALES_ENGLISH = "UACIT2";
@@ -35,9 +35,9 @@ public class FulfilmentRequestProcessorTest {
 
   @Mock private EventLogger eventLogger;
 
-  @Mock private CaseProcessor caseProcessor;
+  @Mock private CaseService caseService;
 
-  @InjectMocks FulfilmentRequestProcessor underTest;
+  @InjectMocks FulfilmentRequestService underTest;
 
   @Test
   public void testGoodFulfilmentRequest() {
@@ -49,7 +49,7 @@ public class FulfilmentRequestProcessorTest {
     Case expectedCase = getRandomCase();
     expectedFulfilmentRequest.setCaseId(expectedCase.getCaseId().toString());
 
-    when(caseProcessor.getCaseByCaseId(UUID.fromString(expectedFulfilmentRequest.getCaseId())))
+    when(caseService.getCaseByCaseId(UUID.fromString(expectedFulfilmentRequest.getCaseId())))
         .thenReturn(expectedCase);
 
     // when
@@ -104,7 +104,7 @@ public class FulfilmentRequestProcessorTest {
     expectedFulfilmentRequest.setCaseId(parentCase.getCaseId().toString());
     expectedFulfilmentRequest.setFulfilmentCode(individualResponseCode);
 
-    when(caseProcessor.getCaseByCaseId(UUID.fromString(expectedFulfilmentRequest.getCaseId())))
+    when(caseService.getCaseByCaseId(UUID.fromString(expectedFulfilmentRequest.getCaseId())))
         .thenReturn(parentCase);
 
     // when
@@ -126,8 +126,8 @@ public class FulfilmentRequestProcessorTest {
     Case actualChildCase = caseArgumentCaptor.getValue();
 
     checkIndivdualFulfilmentRequestCase(parentCase, actualChildCase);
-    verify(caseProcessor).emitCaseCreatedEvent(actualChildCase);
-    verify(caseProcessor, times(1)).getUniqueCaseRef();
+    verify(caseService).emitCaseCreatedEvent(actualChildCase);
+    verify(caseService, times(1)).getUniqueCaseRef();
   }
 
   private void checkIndivdualFulfilmentRequestCase(Case parentCase, Case actualChildCase) {

--- a/src/test/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedServiceTest.java
@@ -25,7 +25,7 @@ import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
 
 @RunWith(MockitoJUnitRunner.class)
-public class QuestionnaireLinkedProcessorTest {
+public class QuestionnaireLinkedServiceTest {
 
   private final UUID TEST_CASE_ID = UUID.randomUUID();
   private final String TEST_QID = new EasyRandom().nextObject(String.class);
@@ -34,13 +34,13 @@ public class QuestionnaireLinkedProcessorTest {
 
   @Mock CaseRepository caseRepository;
 
-  @Mock UacProcessor uacProcessor;
+  @Mock UacService uacService;
 
-  @Mock CaseProcessor caseProcessor;
+  @Mock CaseService caseService;
 
   @Mock EventLogger eventLogger;
 
-  @InjectMocks QuestionnaireLinkedProcessor underTest;
+  @InjectMocks QuestionnaireLinkedService underTest;
 
   @Test
   public void testGoodQuestionnaireLinkedForUnreceiptedCase() {
@@ -59,7 +59,7 @@ public class QuestionnaireLinkedProcessorTest {
     testUacQidLink.setCaze(null);
 
     when(uacQidLinkRepository.findByQid(TEST_QID)).thenReturn(Optional.of(testUacQidLink));
-    when(caseProcessor.getCaseByCaseId(TEST_CASE_ID)).thenReturn(testCase);
+    when(caseService.getCaseByCaseId(TEST_CASE_ID)).thenReturn(testCase);
 
     // WHEN
     underTest.processQuestionnaireLinked(managementEvent);
@@ -71,7 +71,7 @@ public class QuestionnaireLinkedProcessorTest {
     assertThat(actualUacQidLink.getCaze()).isEqualTo(testCase);
     assertThat(actualUacQidLink.isActive()).isTrue();
 
-    verify(uacProcessor).emitUacUpdatedEvent(testUacQidLink, testCase);
+    verify(uacService).emitUacUpdatedEvent(testUacQidLink, testCase);
     verify(eventLogger)
         .logUacQidEvent(
             eq(testUacQidLink),
@@ -103,7 +103,7 @@ public class QuestionnaireLinkedProcessorTest {
     testUacQidLink.setCaze(null);
 
     when(uacQidLinkRepository.findByQid(TEST_QID)).thenReturn(Optional.of(testUacQidLink));
-    when(caseProcessor.getCaseByCaseId(TEST_CASE_ID)).thenReturn(testCase);
+    when(caseService.getCaseByCaseId(TEST_CASE_ID)).thenReturn(testCase);
 
     // WHEN
     underTest.processQuestionnaireLinked(managementEvent);
@@ -115,7 +115,7 @@ public class QuestionnaireLinkedProcessorTest {
     assertThat(actualCase.getCaseId()).isEqualTo(TEST_CASE_ID);
     assertThat(actualCase.isReceiptReceived()).isTrue();
 
-    verify(caseProcessor).emitCaseUpdatedEvent(testCase);
+    verify(caseService).emitCaseUpdatedEvent(testCase);
 
     ArgumentCaptor<UacQidLink> uacQidLinkCaptor = ArgumentCaptor.forClass(UacQidLink.class);
     verify(uacQidLinkRepository).saveAndFlush(uacQidLinkCaptor.capture());
@@ -123,7 +123,7 @@ public class QuestionnaireLinkedProcessorTest {
     assertThat(actualUacQidLink.getCaze()).isEqualTo(testCase);
     assertThat(actualUacQidLink.isActive()).isFalse();
 
-    verify(uacProcessor).emitUacUpdatedEvent(testUacQidLink, testCase);
+    verify(uacService).emitUacUpdatedEvent(testUacQidLink, testCase);
     verify(eventLogger)
         .logUacQidEvent(
             eq(testUacQidLink),

--- a/src/test/java/uk/gov/ons/census/casesvc/service/ReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/ReceiptServiceTest.java
@@ -2,7 +2,7 @@ package uk.gov.ons.census.casesvc.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
-import static uk.gov.ons.census.casesvc.service.ReceiptProcessor.QID_RECEIPTED;
+import static uk.gov.ons.census.casesvc.service.ReceiptService.QID_RECEIPTED;
 import static uk.gov.ons.census.casesvc.testutil.DataUtils.*;
 
 import java.time.OffsetDateTime;
@@ -22,19 +22,19 @@ import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ReceiptProcessorTest {
+public class ReceiptServiceTest {
 
-  @Mock private CaseProcessor caseProcessor;
+  @Mock private CaseService caseService;
 
   @Mock private UacQidLinkRepository uacQidLinkRepository;
 
   @Mock private CaseRepository caseRepository;
 
-  @Mock private UacProcessor uacProcessor;
+  @Mock private UacService uacService;
 
   @Mock private EventLogger eventLogger;
 
-  @InjectMocks ReceiptProcessor underTest;
+  @InjectMocks ReceiptService underTest;
 
   @Test
   public void testGoodReceipt() {
@@ -56,8 +56,8 @@ public class ReceiptProcessorTest {
     // then
     verify(uacQidLinkRepository, times(1)).saveAndFlush(expectedUacQidLink);
     verify(caseRepository, times(1)).saveAndFlush(expectedCase);
-    verify(uacProcessor, times(1)).emitUacUpdatedEvent(expectedUacQidLink, expectedCase, false);
-    verify(caseProcessor, times(1)).emitCaseUpdatedEvent(expectedCase);
+    verify(uacService, times(1)).emitUacUpdatedEvent(expectedUacQidLink, expectedCase, false);
+    verify(caseService, times(1)).emitCaseUpdatedEvent(expectedCase);
     verify(eventLogger, times(1))
         .logUacQidEvent(
             eq(expectedUacQidLink),

--- a/src/test/java/uk/gov/ons/census/casesvc/service/RefusalServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/RefusalServiceTest.java
@@ -21,17 +21,17 @@ import uk.gov.ons.census.casesvc.model.entity.EventType;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 
 @RunWith(MockitoJUnitRunner.class)
-public class RefusalProcessorTest {
+public class RefusalServiceTest {
   private static final String REFUSAL_RECEIVED = "Refusal Received";
   private static final UUID TEST_CASE_ID = UUID.randomUUID();
 
   @Mock private CaseRepository caseRepository;
 
-  @Mock private CaseProcessor caseProcessor;
+  @Mock private CaseService caseService;
 
   @Mock private EventLogger eventLogger;
 
-  @InjectMocks RefusalProcessor underTest;
+  @InjectMocks RefusalService underTest;
 
   @Test
   public void shouldProcessARefusalReceivedMessageSuccessfully() {
@@ -42,7 +42,7 @@ public class RefusalProcessorTest {
     collectionCase.setRefusalReceived(false);
     Case testCase = getRandomCase();
 
-    when(caseProcessor.getCaseByCaseId(TEST_CASE_ID)).thenReturn(testCase);
+    when(caseService.getCaseByCaseId(TEST_CASE_ID)).thenReturn(testCase);
 
     // WHEN
     underTest.processRefusal(managementEvent);
@@ -54,7 +54,7 @@ public class RefusalProcessorTest {
 
     assertThat(actualCase.isRefusalReceived()).isTrue();
 
-    verify(caseProcessor, times(1)).emitCaseUpdatedEvent(testCase);
+    verify(caseService, times(1)).emitCaseUpdatedEvent(testCase);
     verify(eventLogger, times(1))
         .logCaseEvent(
             eq(testCase),

--- a/src/test/java/uk/gov/ons/census/casesvc/service/UacServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/UacServiceTest.java
@@ -27,11 +27,11 @@ import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
 
 @RunWith(MockitoJUnitRunner.class)
-public class UacProcessorTest {
+public class UacServiceTest {
 
   @Mock UacQidLinkRepository uacQidLinkRepository;
 
-  @Mock CaseProcessor caseProcessor;
+  @Mock CaseService caseService;
 
   @Mock RabbitTemplate rabbitTemplate;
 
@@ -39,7 +39,7 @@ public class UacProcessorTest {
 
   @Mock EventLogger eventLogger;
 
-  @InjectMocks UacProcessor underTest;
+  @InjectMocks UacService underTest;
 
   @Test
   public void testSaveUacQidLinkEnglandHousehold() {
@@ -90,7 +90,7 @@ public class UacProcessorTest {
     // Given
     Case linkedCase = getRandomCase();
     ResponseManagementEvent uacCreatedEvent = generateUacCreatedEvent(linkedCase);
-    when(caseProcessor.getCaseByCaseId(uacCreatedEvent.getPayload().getUacQidCreated().getCaseId()))
+    when(caseService.getCaseByCaseId(uacCreatedEvent.getPayload().getUacQidCreated().getCaseId()))
         .thenReturn(linkedCase);
     ArgumentCaptor<UacQidLink> uacQidLinkArgumentCaptor = ArgumentCaptor.forClass(UacQidLink.class);
 
@@ -115,7 +115,7 @@ public class UacProcessorTest {
     // Given
     Case linkedCase = getRandomCase();
     ResponseManagementEvent uacCreatedEvent = generateUacCreatedEvent(linkedCase);
-    when(caseProcessor.getCaseByCaseId(uacCreatedEvent.getPayload().getUacQidCreated().getCaseId()))
+    when(caseService.getCaseByCaseId(uacCreatedEvent.getPayload().getUacQidCreated().getCaseId()))
         .thenReturn(linkedCase);
 
     ArgumentCaptor<ResponseManagementEvent> responseManagementEventArgumentCaptor =
@@ -151,7 +151,7 @@ public class UacProcessorTest {
     // Given
     Case linkedCase = getRandomCase();
     ResponseManagementEvent uacCreatedEvent = generateUacCreatedEvent(linkedCase);
-    when(caseProcessor.getCaseByCaseId(uacCreatedEvent.getPayload().getUacQidCreated().getCaseId()))
+    when(caseService.getCaseByCaseId(uacCreatedEvent.getPayload().getUacQidCreated().getCaseId()))
         .thenReturn(linkedCase);
 
     // When


### PR DESCRIPTION
# Motivation and Context
The use of "processor" was getting a bit prolific.

# What has changed
Renamed all the "processor" classes to "service".

# How to test?
Build.

# Links
Trello: https://trello.com/c/M3dVPIVL