### PR TITLE
Suppress nulls in payload

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/UacDTO.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/UacDTO.java
@@ -1,12 +1,15 @@
 package uk.gov.ons.census.casesvc.model.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import lombok.Data;
 
 @Data
+@JsonInclude(Include.NON_NULL)
 public class UacDTO {
   private String uacHash;
   private String uac;
-  private boolean active;
+  private Boolean active;
   private String questionnaireId;
   private String caseType;
   private String region;


### PR DESCRIPTION
# Motivation and Context
"caseId" & "questionnaireId" should be the only fields serialised to the event_payload field.
<!--- Why is this change required? What problem does it solve? -->

# What has changed
Suppress null values in UacDTO
Changed UacDTO.active type to Boolean to allow null suppression
Improved Integration tests
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
Build local docker image of this branch and run with docker dev
Run tests
Run acceptance tests
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
[Acceptance Tests](https://github.com/ONSdigital/census-rm-acceptance-tests/pull/111)
[Trello](https://trello.com/c/2YY1TOKj/1068-extra-fields-being-shown-on-uac-object-when-qid-linked-event-stored)
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):