### PR TITLE
Set unreceipt flag to Boolean to stop being stored in event payload json

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/ResponseDTO.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/ResponseDTO.java
@@ -16,7 +16,8 @@ public class ResponseDTO {
 
   private String questionnaireId;
 
-  private boolean unreceipt;
+  @JsonInclude(Include.NON_NULL)
+  private Boolean unreceipt;
 
   private String agentId;
 

--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/ResponseDTO.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/ResponseDTO.java
@@ -9,19 +9,17 @@ import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
+@JsonInclude(Include.NON_NULL)
 public class ResponseDTO {
 
-  @JsonInclude(Include.NON_NULL)
   private String caseId;
 
   private String questionnaireId;
 
-  @JsonInclude(Include.NON_NULL)
   private Boolean unreceipt;
 
   private String agentId;
 
-  @JsonInclude(Include.NON_NULL)
   @JsonProperty("dateTime")
   private OffsetDateTime responseDateTime;
 }


### PR DESCRIPTION

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently, the json payload in a Survey Launched event contains unreceipt: false. This should not be there.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
The unreceipt type has been changed to Boolean (from boolean) to allow nulls so that it can be excluded from the json.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run acceptance tests. Have a look in your DB for a survey launched event and see if "unreceipt": false is not present.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/H2V1Mb8f/1111-survey-launched-event-storing-unreceipt-flag-in-json-payload-in-case-events

# Screenshots (if appropriate):