### PR TITLE
use caseType not addressType to set the caseType field in uac_updated message

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/UacService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/UacService.java
@@ -87,7 +87,7 @@ public class UacService {
     Case caze = uacQidLink.getCaze();
     if (caze != null) {
       uac.setCaseId(caze.getCaseId().toString());
-      uac.setCaseType(caze.getAddressType());
+      uac.setCaseType(caze.getCaseType());
       uac.setCollectionExerciseId(caze.getCollectionExerciseId());
       uac.setRegion(caze.getRegion());
     }


### PR DESCRIPTION
# Motivation and Context
We are currently using the addressType field from case data to populate the caseType field that is part of the uac_updated event that gets emitted, this should be using the recently added caseType field

# What has changed
Changed code to set the caseType field on the uac_updated event from the caseType field from the case data

# How to test?
- run acceptance tests