### PR TITLE
Log poison messages

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/config/AppConfig.java
@@ -318,11 +318,13 @@ public class AppConfig {
 
   @Bean
   public SimpleMessageListenerContainer invalidAddressContainer(
-      ConnectionFactory connectionFactory) {
+      ConnectionFactory connectionFactory,
+      MangledMessageErrorHandler mangledMessageErrorHandler) {
     SimpleMessageListenerContainer container =
         new SimpleMessageListenerContainer(connectionFactory);
     container.setQueueNames(invalidAddressInboundQueue);
     container.setConcurrentConsumers(consumers);
+    container.setErrorHandler(mangledMessageErrorHandler);
     return container;
   }
 

--- a/src/main/java/uk/gov/ons/census/casesvc/config/MangledMessageErrorHandler.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/config/MangledMessageErrorHandler.java
@@ -1,0 +1,36 @@
+package uk.gov.ons.census.casesvc.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import java.io.IOException;
+import org.springframework.amqp.rabbit.listener.exception.ListenerExecutionFailedException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ErrorHandler;
+
+@Component
+public class MangledMessageErrorHandler implements ErrorHandler {
+  private static final Logger log = LoggerFactory.getLogger(MangledMessageErrorHandler.class);
+
+  @Override
+  public void handleError(Throwable throwable) {
+    if (throwable instanceof ListenerExecutionFailedException) {
+      ListenerExecutionFailedException failedException = (ListenerExecutionFailedException)throwable;
+      String messageBody = new String(failedException.getFailedMessage().getBody());
+      log.with("message_body", messageBody).error("Could not process message");
+
+      ObjectMapper objectMapper = new ObjectMapper();
+      objectMapper.registerModule(new JavaTimeModule());
+      objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+      try {
+        objectMapper.readValue(messageBody, JsonNode.class);
+      } catch (IOException e) {
+        log.error("Total garbage mangled invalid JSON rubbish on our darn queue", e);
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Motivation and Context
We have no idea why Spring was unable to process JSON messages which are malformed or unmarshallable, and we have no log output to see which the offending message is, which makes operational support really difficult.

# What has changed
Added a global error handler for bad messages and checked JSON validity before logging meaningful error output and the offending message payload.

# How to test?
Publish a dodgy message. Check the logs.

# Links
Trello: https://trello.com/c/eXQ4PkKa