### PR TITLE
handles CCS Invalid Address

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/CCSPropertyDTO.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/CCSPropertyDTO.java
@@ -8,4 +8,5 @@ public class CCSPropertyDTO {
   private SampleUnitDTO sampleUnit;
   private UacDTO uac;
   private RefusalDTO refusal;
+  private InvalidAddress invalidAddress;
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
@@ -67,7 +67,8 @@ public class CaseService {
     return caze;
   }
 
-  public Case createCCSCase(String caseId, SampleUnitDTO sampleUnit, boolean isRefused) {
+  public Case createCCSCase(
+      String caseId, SampleUnitDTO sampleUnit, boolean isRefused, boolean isInvalidAddress) {
     int caseRef = getUniqueCaseRef();
 
     Case caze = mapperFacade.map(sampleUnit, Case.class);
@@ -79,6 +80,7 @@ public class CaseService {
     caze.setState(CaseState.ACTIONABLE);
     caze.setCreatedDateTime(OffsetDateTime.now());
     caze.setRefusalReceived(isRefused);
+    caze.setAddressInvalid(isInvalidAddress);
     caze.setCcsCase(true);
 
     caseRepository.saveAndFlush(caze);

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/CCSPropertyListedIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/CCSPropertyListedIT.java
@@ -15,7 +15,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -25,6 +24,7 @@ import uk.gov.ons.census.casesvc.model.dto.CcsToFwmt;
 import uk.gov.ons.census.casesvc.model.dto.CollectionCase;
 import uk.gov.ons.census.casesvc.model.dto.EventDTO;
 import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
+import uk.gov.ons.census.casesvc.model.dto.InvalidAddress;
 import uk.gov.ons.census.casesvc.model.dto.PayloadDTO;
 import uk.gov.ons.census.casesvc.model.dto.RefusalDTO;
 import uk.gov.ons.census.casesvc.model.dto.RefusalType;
@@ -43,7 +43,6 @@ import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class CCSPropertyListedIT {
   private static String FIELD_QUEUE = "Action.Field";
@@ -74,25 +73,7 @@ public class CCSPropertyListedIT {
   public void testCCSSubmittedToFieldIT() throws IOException, InterruptedException {
     // GIVEN
     BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(FIELD_QUEUE);
-
-    CCSPropertyDTO ccsPropertyDTO = new CCSPropertyDTO();
-    CollectionCase collectionCase = new CollectionCase();
-    collectionCase.setId(TEST_CASE_ID.toString());
-    ccsPropertyDTO.setCollectionCase(collectionCase);
-    ccsPropertyDTO.setSampleUnit(setUpSampleUnitDTO());
-
-    EventDTO eventDTO = new EventDTO();
-    eventDTO.setType(EventTypeDTO.CCS_ADDRESS_LISTED);
-    eventDTO.setSource("FIELDWORK_GATEWAY");
-    eventDTO.setChannel("FIELD");
-    eventDTO.setDateTime(OffsetDateTime.now());
-    eventDTO.setTransactionId(UUID.randomUUID());
-
-    ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
-    PayloadDTO payload = new PayloadDTO();
-    payload.setCcsProperty(ccsPropertyDTO);
-    responseManagementEvent.setPayload(payload);
-    responseManagementEvent.setEvent(eventDTO);
+    ResponseManagementEvent responseManagementEvent = getResponseManagementEvent();
 
     // When
     rabbitQueueHelper.sendMessage(ccsPropertyListedQueue, responseManagementEvent);
@@ -104,13 +85,10 @@ public class CCSPropertyListedIT {
     Case actualCase = caseRepository.findByCaseId(TEST_CASE_ID).get();
     assertThat(actualCase.isCcsCase()).isTrue();
 
-    List<UacQidLink> actualUacQidLinks = uacQidLinkRepository.findAll();
-    assertThat(actualUacQidLinks.size()).isEqualTo(1);
-    UacQidLink actualUacQidLink = actualUacQidLinks.get(0);
-    assertThat(actualUacQidLink.getQid().substring(0, 2)).isEqualTo("71");
-    assertThat(actualUacQidLink.isCcsCase()).isTrue();
+    checkUacQidLinks(null);
 
-    validateEvents(eventRepository.findAll(), ccsPropertyDTO);
+    validateEvents(
+        eventRepository.findAll(), responseManagementEvent.getPayload().getCcsProperty());
   }
 
   @Test
@@ -118,7 +96,6 @@ public class CCSPropertyListedIT {
     // GIVEN
     BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(FIELD_QUEUE);
     EasyRandom easyRandom = new EasyRandom();
-
     UacQidLink uacQidLink = easyRandom.nextObject(UacQidLink.class);
     uacQidLink.setQid(TEST_QID);
     uacQidLink.setCaze(null);
@@ -126,29 +103,11 @@ public class CCSPropertyListedIT {
     uacQidLink.setEvents(null);
     uacQidLinkRepository.save(uacQidLink);
 
-    CCSPropertyDTO ccsPropertyDTO = new CCSPropertyDTO();
-    CollectionCase collectionCase = new CollectionCase();
-    collectionCase.setId(TEST_CASE_ID.toString());
-    ccsPropertyDTO.setCollectionCase(collectionCase);
-
-    ccsPropertyDTO.setSampleUnit(setUpSampleUnitDTO());
-
     UacDTO uacDTO = new UacDTO();
     uacDTO.setQuestionnaireId(TEST_QID);
-    ccsPropertyDTO.setUac(uacDTO);
 
-    EventDTO eventDTO = new EventDTO();
-    eventDTO.setType(EventTypeDTO.CCS_ADDRESS_LISTED);
-    eventDTO.setSource("FIELDWORK_GATEWAY");
-    eventDTO.setChannel("FIELD");
-    eventDTO.setDateTime(OffsetDateTime.now());
-    eventDTO.setTransactionId(UUID.randomUUID());
-
-    ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
-    PayloadDTO payload = new PayloadDTO();
-    payload.setCcsProperty(ccsPropertyDTO);
-    responseManagementEvent.setPayload(payload);
-    responseManagementEvent.setEvent(eventDTO);
+    ResponseManagementEvent responseManagementEvent = getResponseManagementEvent();
+    responseManagementEvent.getPayload().getCcsProperty().setUac(uacDTO);
 
     // When
     rabbitQueueHelper.sendMessage(ccsPropertyListedQueue, responseManagementEvent);
@@ -158,16 +117,10 @@ public class CCSPropertyListedIT {
 
     Case actualCase = caseRepository.findByCaseId(TEST_CASE_ID).get();
     assertThat(actualCase.isCcsCase()).isTrue();
+    checkUacQidLinks(TEST_QID);
 
-    List<UacQidLink> actualUacQidLinks = uacQidLinkRepository.findAll();
-    assertThat(actualUacQidLinks.size()).isEqualTo(1);
-    UacQidLink actualUacQidLink = actualUacQidLinks.get(0);
-    assertThat(actualUacQidLink.getQid()).isEqualTo(TEST_QID);
-    assertThat(actualUacQidLink.getQid().substring(0, 2)).isEqualTo("71");
-    assertThat(actualUacQidLink.isCcsCase()).isTrue();
-    assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
-
-    validateEvents(eventRepository.findAll(), ccsPropertyDTO);
+    validateEvents(
+        eventRepository.findAll(), responseManagementEvent.getPayload().getCcsProperty());
   }
 
   @Test
@@ -175,32 +128,13 @@ public class CCSPropertyListedIT {
     // GIVEN
     BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(FIELD_QUEUE);
 
-    CCSPropertyDTO ccsPropertyDTO = new CCSPropertyDTO();
-    ccsPropertyDTO.setUac(null);
-    ccsPropertyDTO.setSampleUnit(setUpSampleUnitDTO());
-
-    CollectionCase collectionCase = new CollectionCase();
-    collectionCase.setId(TEST_CASE_ID.toString());
-    ccsPropertyDTO.setCollectionCase(collectionCase);
-
     RefusalDTO refusal = new RefusalDTO();
     refusal.setType(RefusalType.HARD_REFUSAL);
     refusal.setAgentId("test agent");
     refusal.setReport("test report");
-    ccsPropertyDTO.setRefusal(refusal);
 
-    EventDTO eventDTO = new EventDTO();
-    eventDTO.setType(EventTypeDTO.CCS_ADDRESS_LISTED);
-    eventDTO.setSource("FIELDWORK_GATEWAY");
-    eventDTO.setChannel("FIELD");
-    eventDTO.setDateTime(OffsetDateTime.now());
-    eventDTO.setTransactionId(UUID.randomUUID());
-
-    ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
-    PayloadDTO payload = new PayloadDTO();
-    payload.setCcsProperty(ccsPropertyDTO);
-    responseManagementEvent.setPayload(payload);
-    responseManagementEvent.setEvent(eventDTO);
+    ResponseManagementEvent responseManagementEvent = getResponseManagementEvent();
+    responseManagementEvent.getPayload().getCcsProperty().setRefusal(refusal);
 
     // When
     rabbitQueueHelper.sendMessage(ccsPropertyListedQueue, responseManagementEvent);
@@ -213,14 +147,38 @@ public class CCSPropertyListedIT {
     assertThat(actualCase.isCcsCase()).isTrue();
     assertThat(actualCase.isRefusalReceived()).isTrue();
 
-    List<UacQidLink> actualUacQidLinks = uacQidLinkRepository.findAll();
-    assertThat(actualUacQidLinks.size()).isEqualTo(1);
-    UacQidLink actualUacQidLink = actualUacQidLinks.get(0);
-    assertThat(actualUacQidLink.getQid().substring(0, 2)).isEqualTo("71");
-    assertThat(actualUacQidLink.isCcsCase()).isTrue();
-    assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
+    checkUacQidLinks(null);
 
-    validateEvents(eventRepository.findAll(), ccsPropertyDTO);
+    validateEvents(
+        eventRepository.findAll(), responseManagementEvent.getPayload().getCcsProperty());
+  }
+
+  @Test
+  public void testCCSListedEventForInvalidAddress() throws IOException, InterruptedException {
+    // GIVEN
+    BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(FIELD_QUEUE);
+
+    InvalidAddress invalidAddress = new InvalidAddress();
+    invalidAddress.setReason("HOUSE DEMOLISHED");
+
+    ResponseManagementEvent responseManagementEvent = getResponseManagementEvent();
+    responseManagementEvent.getPayload().getCcsProperty().setInvalidAddress(invalidAddress);
+
+    // When
+    rabbitQueueHelper.sendMessage(ccsPropertyListedQueue, responseManagementEvent);
+
+    // Then
+    rabbitQueueHelper.checkMessageIsNotReceived(outboundQueue, 5);
+    System.out.println(1);
+
+    Case actualCase = caseRepository.findByCaseId(TEST_CASE_ID).get();
+    assertThat(actualCase.isCcsCase()).isTrue();
+    assertThat(actualCase.isAddressInvalid()).isTrue();
+
+    checkUacQidLinks(null);
+
+    validateEvents(
+        eventRepository.findAll(), responseManagementEvent.getPayload().getCcsProperty());
   }
 
   private SampleUnitDTO setUpSampleUnitDTO() {
@@ -257,5 +215,47 @@ public class CCSPropertyListedIT {
         objectMapper.readValue(event.getEventPayload(), CCSPropertyDTO.class);
 
     assertThat(actualCCSPropertyDTO).isEqualTo(expectedCCSPropertyDto);
+  }
+
+  private void checkUacQidLinks(String expectedQid) {
+    List<UacQidLink> actualUacQidLinks = uacQidLinkRepository.findAll();
+    assertThat(actualUacQidLinks.size()).isEqualTo(1);
+    UacQidLink actualUacQidLink = actualUacQidLinks.get(0);
+    assertThat(actualUacQidLink.getQid().substring(0, 2)).isEqualTo("71");
+    assertThat(actualUacQidLink.isCcsCase()).isTrue();
+    assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
+
+    if (expectedQid != null) {
+      assertThat(actualUacQidLink.getQid()).isEqualTo(expectedQid);
+    }
+  }
+
+  private ResponseManagementEvent getResponseManagementEvent() {
+    CCSPropertyDTO ccsPropertyDTO = getCCSProperty();
+
+    EventDTO eventDTO = new EventDTO();
+    eventDTO.setType(EventTypeDTO.CCS_ADDRESS_LISTED);
+    eventDTO.setSource("FIELDWORK_GATEWAY");
+    eventDTO.setChannel("FIELD");
+    eventDTO.setDateTime(OffsetDateTime.now());
+    eventDTO.setTransactionId(UUID.randomUUID());
+
+    ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
+    PayloadDTO payload = new PayloadDTO();
+    payload.setCcsProperty(ccsPropertyDTO);
+    responseManagementEvent.setPayload(payload);
+    responseManagementEvent.setEvent(eventDTO);
+
+    return responseManagementEvent;
+  }
+
+  private CCSPropertyDTO getCCSProperty() {
+    CCSPropertyDTO ccsPropertyDTO = new CCSPropertyDTO();
+    CollectionCase collectionCase = new CollectionCase();
+    collectionCase.setId(TEST_CASE_ID.toString());
+    ccsPropertyDTO.setCollectionCase(collectionCase);
+    ccsPropertyDTO.setSampleUnit(setUpSampleUnitDTO());
+
+    return ccsPropertyDTO;
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/CCSPropertyListedIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/CCSPropertyListedIT.java
@@ -141,7 +141,6 @@ public class CCSPropertyListedIT {
 
     // Then
     rabbitQueueHelper.checkMessageIsNotReceived(outboundQueue, 5);
-    System.out.println(1);
 
     Case actualCase = caseRepository.findByCaseId(TEST_CASE_ID).get();
     assertThat(actualCase.isCcsCase()).isTrue();
@@ -169,7 +168,6 @@ public class CCSPropertyListedIT {
 
     // Then
     rabbitQueueHelper.checkMessageIsNotReceived(outboundQueue, 5);
-    System.out.println(1);
 
     Case actualCase = caseRepository.findByCaseId(TEST_CASE_ID).get();
     assertThat(actualCase.isCcsCase()).isTrue();

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CCSPropertyListedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CCSPropertyListedServiceTest.java
@@ -2,13 +2,13 @@ package uk.gov.ons.census.casesvc.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.ons.census.casesvc.testutil.DataUtils.getTestResponseManagementCCSAddressListedEvent;
+import static uk.gov.ons.census.casesvc.utility.JsonHelper.convertObjectToJson;
 
 import java.time.OffsetDateTime;
 import java.util.Collections;
@@ -21,9 +21,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ons.census.casesvc.logging.EventLogger;
-import uk.gov.ons.census.casesvc.model.dto.CCSPropertyDTO;
-import uk.gov.ons.census.casesvc.model.dto.PayloadDTO;
+import uk.gov.ons.census.casesvc.model.dto.InvalidAddress;
+import uk.gov.ons.census.casesvc.model.dto.RefusalDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
+import uk.gov.ons.census.casesvc.model.dto.UacDTO;
 import uk.gov.ons.census.casesvc.model.entity.Case;
 import uk.gov.ons.census.casesvc.model.entity.EventType;
 import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
@@ -36,31 +37,19 @@ public class CCSPropertyListedServiceTest {
   private static final String TEST_QID = "710000000043";
 
   @Mock EventLogger eventLogger;
-
   @Mock CaseService caseService;
-
   @Mock UacService uacService;
-
   @Mock CcsToFieldService ccsToFieldService;
-
   @Mock UacQidLinkRepository uacQidLinkRepository;
 
   @InjectMocks CCSPropertyListedService underTest;
 
   @Test
-  public void testGoodCCSPropertyListed() {
+  public void testCCSPropertyListedWithoutQid() {
     // Given
     ResponseManagementEvent managementEvent = getTestResponseManagementCCSAddressListedEvent();
-    PayloadDTO payload = managementEvent.getPayload();
-    payload.getCcsProperty().setRefusal(null);
-    payload.getCcsProperty().setUac(null);
-
-    String expectedCaseId =
-        managementEvent.getPayload().getCcsProperty().getCollectionCase().getId();
-
-    Case expectedCase = new Case();
-    expectedCase.setCaseId(UUID.fromString(expectedCaseId));
-    expectedCase.setCcsCase(true);
+    Case expectedCase =
+        getExpectedCase(managementEvent.getPayload().getCcsProperty().getCollectionCase().getId());
 
     UacQidLink expectedUacQidLink = new UacQidLink();
     expectedUacQidLink.setId(TEST_UAC_QID_LINK_ID);
@@ -68,78 +57,57 @@ public class CCSPropertyListedServiceTest {
     expectedUacQidLink.setCaze(expectedCase);
 
     when(caseService.createCCSCase(
-            expectedCaseId, managementEvent.getPayload().getCcsProperty().getSampleUnit(), false))
+            managementEvent.getPayload().getCcsProperty().getCollectionCase().getId(),
+            managementEvent.getPayload().getCcsProperty().getSampleUnit(),
+            false,
+            false))
         .thenReturn(expectedCase);
 
     // When
     underTest.processCCSPropertyListed(managementEvent);
 
     // Then
-    verify(caseService)
-        .createCCSCase(
-            expectedCaseId, managementEvent.getPayload().getCcsProperty().getSampleUnit(), false);
+    InOrder inOrder = inOrder(caseService, uacQidLinkRepository, uacService, eventLogger);
+    checkCorrectEventLogging(inOrder, expectedCase, managementEvent);
 
     ArgumentCaptor<Case> caseCaptor = ArgumentCaptor.forClass(Case.class);
-    verify(eventLogger)
-        .logCaseEvent(
-            caseCaptor.capture(),
-            any(OffsetDateTime.class),
-            eq("CCS Address Listed"),
-            eq(EventType.CCS_ADDRESS_LISTED),
-            eq(managementEvent.getEvent()),
-            anyString());
-    Case actualCase = caseCaptor.getValue();
-    assertThat(actualCase.getCaseId()).isEqualTo(UUID.fromString(expectedCaseId));
-    assertThat(actualCase.isCcsCase()).isTrue();
-
     verify(ccsToFieldService).convertAndSendCCSToField(caseCaptor.capture());
-    actualCase = caseCaptor.getValue();
-    assertThat(actualCase.getCaseId()).isEqualTo(UUID.fromString(expectedCaseId));
-    assertThat(actualCase.isCcsCase()).isTrue();
+    Case actualCaseToFieldService = caseCaptor.getValue();
+    assertThat(actualCaseToFieldService.getCaseId())
+        .isEqualTo(UUID.fromString(expectedCase.getCaseId().toString()));
+    assertThat(actualCaseToFieldService.isCcsCase()).isTrue();
   }
 
   @Test
   public void testCaseListedWithQidSet() {
     // Given
     ResponseManagementEvent managementEvent = getTestResponseManagementCCSAddressListedEvent();
-
-    managementEvent.getPayload().getCcsProperty().getUac().setQuestionnaireId(TEST_QID);
-    CCSPropertyDTO ccsProperty = managementEvent.getPayload().getCcsProperty();
-    ccsProperty.setRefusal(null);
-
-    String expectedCaseId = ccsProperty.getCollectionCase().getId();
+    UacDTO uacDTO = new UacDTO();
+    uacDTO.setQuestionnaireId(TEST_QID);
+    managementEvent.getPayload().getCcsProperty().setUac(uacDTO);
 
     UacQidLink uacQidLink = new UacQidLink();
     uacQidLink.setId(TEST_UAC_QID_LINK_ID);
     uacQidLink.setQid(TEST_QID);
     when(uacService.findByQid(TEST_QID)).thenReturn(uacQidLink);
 
-    Case expectedCase = new Case();
-    expectedCase.setCaseId(UUID.fromString(expectedCaseId));
-    expectedCase.setCcsCase(true);
+    Case expectedCase =
+        getExpectedCase(managementEvent.getPayload().getCcsProperty().getCollectionCase().getId());
     expectedCase.setUacQidLinks(Collections.singletonList(uacQidLink));
 
     when(caseService.createCCSCase(
-            expectedCaseId, managementEvent.getPayload().getCcsProperty().getSampleUnit(), false))
+            expectedCase.getCaseId().toString(),
+            managementEvent.getPayload().getCcsProperty().getSampleUnit(),
+            false,
+            false))
         .thenReturn(expectedCase);
 
     // When
     underTest.processCCSPropertyListed(managementEvent);
 
     // Then
-    ArgumentCaptor<Case> caseCaptor = ArgumentCaptor.forClass(Case.class);
-    verify(eventLogger)
-        .logCaseEvent(
-            caseCaptor.capture(),
-            any(OffsetDateTime.class),
-            eq("CCS Address Listed"),
-            eq(EventType.CCS_ADDRESS_LISTED),
-            eq(managementEvent.getEvent()),
-            anyString());
-
-    Case actualCase = caseCaptor.getValue();
-    assertThat(actualCase.getCaseId()).isEqualTo(UUID.fromString(expectedCaseId));
-    assertThat(actualCase.isCcsCase()).isTrue();
+    InOrder inOrder = inOrder(caseService, uacService, uacQidLinkRepository, eventLogger);
+    checkCorrectEventLogging(inOrder, expectedCase, managementEvent);
 
     ArgumentCaptor<UacQidLink> uacQidLinkArgumentCaptor = ArgumentCaptor.forClass(UacQidLink.class);
     verify(uacQidLinkRepository).saveAndFlush(uacQidLinkArgumentCaptor.capture());
@@ -154,18 +122,18 @@ public class CCSPropertyListedServiceTest {
   public void testRefusedCaseListed() {
     // Given
     ResponseManagementEvent managementEvent = getTestResponseManagementCCSAddressListedEvent();
-    managementEvent.getPayload().getCcsProperty().setUac(null);
+    RefusalDTO refusalDto = new RefusalDTO();
+    managementEvent.getPayload().getCcsProperty().setRefusal(refusalDto);
 
-    String expectedCaseId =
-        managementEvent.getPayload().getCcsProperty().getCollectionCase().getId();
-
-    Case expectedCase = new Case();
-    expectedCase.setCaseId(UUID.fromString(expectedCaseId));
-    expectedCase.setCcsCase(true);
+    Case expectedCase =
+        getExpectedCase(managementEvent.getPayload().getCcsProperty().getCollectionCase().getId());
     expectedCase.setRefusalReceived(true);
 
     when(caseService.createCCSCase(
-            expectedCaseId, managementEvent.getPayload().getCcsProperty().getSampleUnit(), true))
+            expectedCase.getCaseId().toString(),
+            managementEvent.getPayload().getCcsProperty().getSampleUnit(),
+            true,
+            false))
         .thenReturn(expectedCase);
 
     // When
@@ -173,27 +141,63 @@ public class CCSPropertyListedServiceTest {
 
     // Then
     InOrder inOrder = inOrder(caseService, eventLogger);
+    checkCorrectEventLogging(inOrder, expectedCase, managementEvent);
+    verifyZeroInteractions(ccsToFieldService);
+  }
 
-    inOrder
-        .verify(caseService)
-        .createCCSCase(
-            expectedCaseId, managementEvent.getPayload().getCcsProperty().getSampleUnit(), true);
+  @Test
+  public void testInvalidAddressCaseListed() {
+    // Given
+    ResponseManagementEvent managementEvent = getTestResponseManagementCCSAddressListedEvent();
+    InvalidAddress invalidAddress = new InvalidAddress();
+    managementEvent.getPayload().getCcsProperty().setInvalidAddress(invalidAddress);
 
-    ArgumentCaptor<Case> caseCaptor = ArgumentCaptor.forClass(Case.class);
+    Case expectedCase =
+        getExpectedCase(managementEvent.getPayload().getCcsProperty().getCollectionCase().getId());
+    expectedCase.setAddressInvalid(true);
+
+    when(caseService.createCCSCase(
+            expectedCase.getCaseId().toString(),
+            managementEvent.getPayload().getCcsProperty().getSampleUnit(),
+            false,
+            true))
+        .thenReturn(expectedCase);
+
+    // When
+    underTest.processCCSPropertyListed(managementEvent);
+
+    // Then
+    InOrder inOrder = inOrder(caseService, eventLogger);
+    checkCorrectEventLogging(inOrder, expectedCase, managementEvent);
+    verifyZeroInteractions(ccsToFieldService);
+  }
+
+  private Case getExpectedCase(String id) {
+    Case caze = new Case();
+    caze.setCaseId(UUID.fromString(id));
+    caze.setCcsCase(true);
+    caze.setRefusalReceived(false);
+    caze.setAddressInvalid(false);
+
+    return caze;
+  }
+
+  private void checkCorrectEventLogging(
+      InOrder inOrder, Case expectedCase, ResponseManagementEvent managementEvent) {
+    ArgumentCaptor<String> ccsPayload = ArgumentCaptor.forClass(String.class);
+
     inOrder
         .verify(eventLogger)
         .logCaseEvent(
-            caseCaptor.capture(),
+            eq(expectedCase),
             any(OffsetDateTime.class),
             eq("CCS Address Listed"),
             eq(EventType.CCS_ADDRESS_LISTED),
             eq(managementEvent.getEvent()),
-            anyString());
+            ccsPayload.capture());
 
-    Case actualCase = caseCaptor.getValue();
-    assertThat(actualCase.getCaseId().toString()).isEqualTo(expectedCaseId);
-    assertThat(actualCase.isRefusalReceived()).isTrue();
-
-    verifyZeroInteractions(ccsToFieldService);
+    String actualLoggedPayload = ccsPayload.getValue();
+    assertThat(actualLoggedPayload)
+        .isEqualTo(convertObjectToJson(managementEvent.getPayload().getCcsProperty()));
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
@@ -88,7 +88,7 @@ public class CaseServiceTest {
         underTest, "collectionExerciseId", TEST_COLLECTION_EXERCISE_ID.toString());
 
     // When
-    Case actualCase = underTest.createCCSCase(caseId, sampleUnit, false);
+    Case actualCase = underTest.createCCSCase(caseId, sampleUnit, false, false);
 
     // Then
     verify(mapperFacade).map(sampleUnit, Case.class);
@@ -111,7 +111,7 @@ public class CaseServiceTest {
         underTest, "collectionExerciseId", TEST_COLLECTION_EXERCISE_ID.toString());
 
     // When
-    Case actualCase = underTest.createCCSCase(caseId, sampleUnit, true);
+    Case actualCase = underTest.createCCSCase(caseId, sampleUnit, true, false);
 
     // Then
     verify(mapperFacade).map(sampleUnit, Case.class);

--- a/src/test/java/uk/gov/ons/census/casesvc/testutil/DataUtils.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/testutil/DataUtils.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.UUID;
 import org.jeasy.random.EasyRandom;
 import org.jeasy.random.EasyRandomParameters;
+import uk.gov.ons.census.casesvc.model.dto.CCSPropertyDTO;
 import uk.gov.ons.census.casesvc.model.dto.EventDTO;
 import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
 import uk.gov.ons.census.casesvc.model.dto.FulfilmentRequestDTO;
@@ -206,11 +207,12 @@ public class DataUtils {
 
   public static ResponseManagementEvent getTestResponseManagementCCSAddressListedEvent() {
     ResponseManagementEvent managementEvent = easyRandom.nextObject(ResponseManagementEvent.class);
-    managementEvent
-        .getPayload()
-        .getCcsProperty()
-        .getCollectionCase()
-        .setId(TEST_CASE_ID.toString());
+    CCSPropertyDTO ccsPropertyDTO = managementEvent.getPayload().getCcsProperty();
+    ccsPropertyDTO.getCollectionCase().setId(TEST_CASE_ID.toString());
+    ccsPropertyDTO.setRefusal(null);
+    ccsPropertyDTO.setInvalidAddress(null);
+    ccsPropertyDTO.setUac(null);
+    managementEvent.getPayload().setCcsProperty(ccsPropertyDTO);
 
     return managementEvent;
   }


### PR DESCRIPTION
# Motivation and Context
Handle a CCSPropertyListed Event with an Invalid Address attached


# What has changed
Added code and tests to handle InvalidAddress
Removed DirtiesContext from CCS ITs


# How to test?
install locally and run with same AT branch
https://github.com/ONSdigital/census-rm-acceptance-tests/tree/1103-rmc-1665-handle-an-invalid-address-ccs

# Links
https://trello.com/c/quLd0TdT/1103-rmc-1665-handle-an-invalid-address-in-a-ccspropertylisted-event-5

# Screenshots (if appropriate):