### PR TITLE
Always create uac-qid pair for CCS property listed event.

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/CCSPropertyListedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CCSPropertyListedService.java
@@ -47,11 +47,13 @@ public class CCSPropertyListedService {
             isRefused,
             isInvalidAddress);
 
+    // always generate a new uac-qid pair even if linking existing pair, this is in case field worker has to visit
+    // address again and launch an EQ
+    uacService.createUacQidLinkedToCCSCase(caze);
     if (isQidProvided) {
       addUacLinkForQidAndCaze(ccsProperty.getUac().getQuestionnaireId(), caze);
     } else {
-      uacService.createUacQidLinkedToCCSCase(caze);
-      sendActiveCSSCaseToField(caze);
+      sendActiveCCSCaseToField(caze);
     }
 
     eventLogger.logCaseEvent(
@@ -63,7 +65,7 @@ public class CCSPropertyListedService {
         convertObjectToJson(ccsProperty));
   }
 
-  private void sendActiveCSSCaseToField(Case caze) {
+  private void sendActiveCCSCaseToField(Case caze) {
     if (!caze.isRefusalReceived() && !caze.isAddressInvalid()) {
       ccsToFieldService.convertAndSendCCSToField(caze);
     }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/CCSPropertyListedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CCSPropertyListedService.java
@@ -47,7 +47,8 @@ public class CCSPropertyListedService {
             isRefused,
             isInvalidAddress);
 
-    // always generate a new uac-qid pair even if linking existing pair, this is in case field worker has to visit
+    // always generate a new uac-qid pair even if linking existing pair, this is in case field
+    // worker has to visit
     // address again and launch an EQ
     uacService.createUacQidLinkedToCCSCase(caze);
     if (isQidProvided) {

--- a/src/main/java/uk/gov/ons/census/casesvc/service/CCSPropertyListedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CCSPropertyListedService.java
@@ -48,8 +48,7 @@ public class CCSPropertyListedService {
             isInvalidAddress);
 
     // always generate a new uac-qid pair even if linking existing pair, this is in case field
-    // worker has to visit
-    // address again and launch an EQ
+    // worker has to visit address again and launch an EQ
     uacService.createUacQidLinkedToCCSCase(caze);
     if (isQidProvided) {
       addUacLinkForQidAndCaze(ccsProperty.getUac().getQuestionnaireId(), caze);

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/CCSPropertyListedIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/CCSPropertyListedIT.java
@@ -85,7 +85,7 @@ public class CCSPropertyListedIT {
     Case actualCase = caseRepository.findByCaseId(TEST_CASE_ID).get();
     assertThat(actualCase.isCcsCase()).isTrue();
 
-    checkUacQidLinks(null, 1);
+    checkUacQidLinks(1);
 
     validateEvents(
         eventRepository.findAll(), responseManagementEvent.getPayload().getCcsProperty());
@@ -117,7 +117,7 @@ public class CCSPropertyListedIT {
 
     Case actualCase = caseRepository.findByCaseId(TEST_CASE_ID).get();
     assertThat(actualCase.isCcsCase()).isTrue();
-    checkUacQidLinks(TEST_QID, 2);
+    checkUacQidLinks(2);
 
     validateEvents(
         eventRepository.findAll(), responseManagementEvent.getPayload().getCcsProperty());
@@ -146,7 +146,7 @@ public class CCSPropertyListedIT {
     assertThat(actualCase.isCcsCase()).isTrue();
     assertThat(actualCase.isRefusalReceived()).isTrue();
 
-    checkUacQidLinks(null, 1);
+    checkUacQidLinks(1);
 
     validateEvents(
         eventRepository.findAll(), responseManagementEvent.getPayload().getCcsProperty());
@@ -173,7 +173,7 @@ public class CCSPropertyListedIT {
     assertThat(actualCase.isCcsCase()).isTrue();
     assertThat(actualCase.isAddressInvalid()).isTrue();
 
-    checkUacQidLinks(null, 1);
+    checkUacQidLinks(1);
 
     validateEvents(
         eventRepository.findAll(), responseManagementEvent.getPayload().getCcsProperty());
@@ -215,9 +215,9 @@ public class CCSPropertyListedIT {
     assertThat(actualCCSPropertyDTO).isEqualTo(expectedCCSPropertyDto);
   }
 
-  private void checkUacQidLinks(String expectedQid, int linksCount) {
+  private void checkUacQidLinks(int expectedLinksTotal) {
     List<UacQidLink> actualUacQidLinks = uacQidLinkRepository.findAll();
-    assertThat(actualUacQidLinks.size()).isEqualTo(linksCount);
+    assertThat(actualUacQidLinks.size()).isEqualTo(expectedLinksTotal);
     UacQidLink actualUacQidLink = actualUacQidLinks.get(0);
     assertThat(actualUacQidLink.getQid().substring(0, 2)).isEqualTo("71");
     assertThat(actualUacQidLink.isCcsCase()).isTrue();

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/CCSPropertyListedIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/CCSPropertyListedIT.java
@@ -85,7 +85,7 @@ public class CCSPropertyListedIT {
     Case actualCase = caseRepository.findByCaseId(TEST_CASE_ID).get();
     assertThat(actualCase.isCcsCase()).isTrue();
 
-    checkUacQidLinks(null);
+    checkUacQidLinks(null, 1);
 
     validateEvents(
         eventRepository.findAll(), responseManagementEvent.getPayload().getCcsProperty());
@@ -117,7 +117,7 @@ public class CCSPropertyListedIT {
 
     Case actualCase = caseRepository.findByCaseId(TEST_CASE_ID).get();
     assertThat(actualCase.isCcsCase()).isTrue();
-    checkUacQidLinks(TEST_QID);
+    checkUacQidLinks(TEST_QID, 2);
 
     validateEvents(
         eventRepository.findAll(), responseManagementEvent.getPayload().getCcsProperty());
@@ -146,7 +146,7 @@ public class CCSPropertyListedIT {
     assertThat(actualCase.isCcsCase()).isTrue();
     assertThat(actualCase.isRefusalReceived()).isTrue();
 
-    checkUacQidLinks(null);
+    checkUacQidLinks(null, 1);
 
     validateEvents(
         eventRepository.findAll(), responseManagementEvent.getPayload().getCcsProperty());
@@ -173,7 +173,7 @@ public class CCSPropertyListedIT {
     assertThat(actualCase.isCcsCase()).isTrue();
     assertThat(actualCase.isAddressInvalid()).isTrue();
 
-    checkUacQidLinks(null);
+    checkUacQidLinks(null, 1);
 
     validateEvents(
         eventRepository.findAll(), responseManagementEvent.getPayload().getCcsProperty());
@@ -215,17 +215,13 @@ public class CCSPropertyListedIT {
     assertThat(actualCCSPropertyDTO).isEqualTo(expectedCCSPropertyDto);
   }
 
-  private void checkUacQidLinks(String expectedQid) {
+  private void checkUacQidLinks(String expectedQid, int linksCount) {
     List<UacQidLink> actualUacQidLinks = uacQidLinkRepository.findAll();
-    assertThat(actualUacQidLinks.size()).isEqualTo(1);
+    assertThat(actualUacQidLinks.size()).isEqualTo(linksCount);
     UacQidLink actualUacQidLink = actualUacQidLinks.get(0);
     assertThat(actualUacQidLink.getQid().substring(0, 2)).isEqualTo("71");
     assertThat(actualUacQidLink.isCcsCase()).isTrue();
     assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
-
-    if (expectedQid != null) {
-      assertThat(actualUacQidLink.getQid()).isEqualTo(expectedQid);
-    }
   }
 
   private ResponseManagementEvent getResponseManagementEvent() {


### PR DESCRIPTION
# Motivation and Context
Always create a new uac-qid pair when a CCS property listed event is received. This is because a CCS PQ may be linked but not completed and if a field agent calls on property again they will need a uac-qid to launch an EQ.

# What has changed
Small code change to always create uac-qid

# How to test?
Build locally and run in docker-dev then run acceptance tests

# Links
https://trello.com/c/TRtVJEzn/1268-qid-linked-in-property-listing-event-should-create-a-uac-qid-pair-by-default-on-case-creation-3
