### PR TITLE
Rabbit msg persistence dlq config

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/config/MessageConsumerConfig.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/config/MessageConsumerConfig.java
@@ -36,9 +36,6 @@ public class MessageConsumerConfig {
   @Value("${queueconfig.retry-delay}")
   private int retryDelay;
 
-  @Value("${queueconfig.retry-exchange}")
-  private String retryExchange;
-
   @Value("${queueconfig.quarantine-exchange}")
   private String quarantineExchange;
 
@@ -327,7 +324,6 @@ public class MessageConsumerConfig {
             logStackTraces,
             "Case Processor",
             queueName,
-            retryExchange,
             quarantineExchange,
             rabbitTemplate);
 

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/ManagedMessageRecoverer.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/ManagedMessageRecoverer.java
@@ -41,7 +41,6 @@ public class ManagedMessageRecoverer implements MessageRecoverer {
   private final boolean logStackTraces;
   private final String serviceName;
   private final String queueName;
-  private final String delayExchangeName;
   private final String quarantineExchangeName;
   private final RabbitTemplate rabbitTemplate;
 
@@ -51,7 +50,6 @@ public class ManagedMessageRecoverer implements MessageRecoverer {
       boolean logStackTraces,
       String serviceName,
       String queueName,
-      String delayExchangeName,
       String quarantineExchangeName,
       RabbitTemplate rabbitTemplate) {
     this.exceptionManagerClient = exceptionManagerClient;
@@ -59,7 +57,6 @@ public class ManagedMessageRecoverer implements MessageRecoverer {
     this.logStackTraces = logStackTraces;
     this.serviceName = serviceName;
     this.queueName = queueName;
-    this.delayExchangeName = delayExchangeName;
     this.quarantineExchangeName = quarantineExchangeName;
     this.rabbitTemplate = rabbitTemplate;
   }

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/ManagedMessageRecoverer.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/ManagedMessageRecoverer.java
@@ -89,8 +89,7 @@ public class ManagedMessageRecoverer implements MessageRecoverer {
       logMessage(
           reportResult, listenerExecutionFailedException.getCause(), messageHash, rawMessageBody);
 
-      // Send the originating message to an exchange where it'll be retried at some future point in
-      // time
+      // Reject the original message where it'll be retried at some future point in time
       throw new AmqpRejectAndDontRequeueException(
           String.format("Message sent to DLQ exchange, message_hash is: %s", messageHash));
     } else {

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/ManagedMessageRecoverer.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/ManagedMessageRecoverer.java
@@ -89,9 +89,8 @@ public class ManagedMessageRecoverer implements MessageRecoverer {
       logMessage(
           reportResult, listenerExecutionFailedException.getCause(), messageHash, rawMessageBody);
 
-      // At this point message is not persistent, we need it to be persistent
-      message.getMessageProperties().setDeliveryMode(MessageDeliveryMode.PERSISTENT);
-      // Send the bad message to an exchange where it'll be retried at some future point in time
+      // Send the originating message to an exchange where it'll be retried at some future point in
+      // time
       throw new AmqpRejectAndDontRequeueException(
           String.format("Message sent to DLQ exchange, message_hash is: %s", messageHash));
     } else {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,7 +49,6 @@ queueconfig:
   consumers: 50
   retry-attempts: 3
   retry-delay: 1000 #milliseconds
-  retry-exchange: delayedRedeliveryExchange
   quarantine-exchange: quarantineExchange
 
 ccsconfig:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -74,3 +74,7 @@ exceptionmanager:
 
 messagelogging:
   logstacktraces: false
+
+logging:
+  level:
+    org.springframework.amqp.rabbit.listener.ConditionalRejectingErrorHandler: ERROR

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/ManagedMessageRecovererTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/ManagedMessageRecovererTest.java
@@ -40,7 +40,6 @@ public class ManagedMessageRecovererTest {
             false,
             "test service",
             "test queue",
-            "test delay exchange",
             "test quarantine exchange",
             rabbitTemplate);
 
@@ -84,7 +83,6 @@ public class ManagedMessageRecovererTest {
             false,
             "test service",
             "test queue",
-            "test delay exchange",
             "test quarantine exchange",
             rabbitTemplate);
 
@@ -121,7 +119,6 @@ public class ManagedMessageRecovererTest {
             false,
             "test service",
             "test queue",
-            "test delay exchange",
             "test quarantine exchange",
             rabbitTemplate);
 
@@ -183,7 +180,6 @@ public class ManagedMessageRecovererTest {
             false,
             "test service",
             "test queue",
-            "test delay exchange",
             "test quarantine exchange",
             rabbitTemplate);
 

--- a/src/test/resources/definitions.json
+++ b/src/test/resources/definitions.json
@@ -31,112 +31,160 @@
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+      }
     },
     {
       "name": "case.invalidAddressQueue",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+      }
     },
     {
       "name": "case.undeliveredMailQueue",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+      }
     },
     {
       "name": "case.action",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+      }
     },
     {
       "name": "unaddressedRequestQueue",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+      }
     },
     {
       "name": "Case.Responses",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+      }
     },
     {
       "name": "action.events",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+      }
     },
     {
       "name": "case.rh.uac",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+      }
     },
     {
       "name": "case.fulfilments",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+      }
     },
     {
       "name": "case.sample.inbound",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+      }
     },
     {
       "name": "case.uac-qid-created",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+      }
     },
     {
       "name": "case.refusals",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+      }
     },
     {
       "name": "case.questionnairelinked",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+      }
     },
     {
       "name": "survey.launched",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+      }
     },
     {
       "name": "case.ccsPropertyListedQueue",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+      }
     },
     {
       "name": "Action.Field",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+      }
     }
   ],
   "exchanges": [

--- a/src/test/resources/definitions.json
+++ b/src/test/resources/definitions.json
@@ -33,7 +33,7 @@
       "auto_delete": false,
       "arguments": {
         "x-dead-letter-exchange": "delayedRedeliveryExchange",
-        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+        "x-dead-letter-routing-key": "case.rh.case"
       }
     },
     {
@@ -43,7 +43,7 @@
       "auto_delete": false,
       "arguments": {
         "x-dead-letter-exchange": "delayedRedeliveryExchange",
-        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+        "x-dead-letter-routing-key": "case.invalidAddressQueue"
       }
     },
     {
@@ -53,7 +53,7 @@
       "auto_delete": false,
       "arguments": {
         "x-dead-letter-exchange": "delayedRedeliveryExchange",
-        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+        "x-dead-letter-routing-key": "case.undeliveredMailQueue"
       }
     },
     {
@@ -63,7 +63,7 @@
       "auto_delete": false,
       "arguments": {
         "x-dead-letter-exchange": "delayedRedeliveryExchange",
-        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+        "x-dead-letter-routing-key": "case.action"
       }
     },
     {
@@ -73,7 +73,7 @@
       "auto_delete": false,
       "arguments": {
         "x-dead-letter-exchange": "delayedRedeliveryExchange",
-        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+        "x-dead-letter-routing-key": "unaddressedRequestQueue"
       }
     },
     {
@@ -83,7 +83,7 @@
       "auto_delete": false,
       "arguments": {
         "x-dead-letter-exchange": "delayedRedeliveryExchange",
-        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+        "x-dead-letter-routing-key": "Case.Responses"
       }
     },
     {
@@ -93,7 +93,7 @@
       "auto_delete": false,
       "arguments": {
         "x-dead-letter-exchange": "delayedRedeliveryExchange",
-        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+        "x-dead-letter-routing-key": "action.events"
       }
     },
     {
@@ -103,7 +103,7 @@
       "auto_delete": false,
       "arguments": {
         "x-dead-letter-exchange": "delayedRedeliveryExchange",
-        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+        "x-dead-letter-routing-key": "case.rh.uac"
       }
     },
     {
@@ -113,7 +113,7 @@
       "auto_delete": false,
       "arguments": {
         "x-dead-letter-exchange": "delayedRedeliveryExchange",
-        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+        "x-dead-letter-routing-key": "case.fulfilments"
       }
     },
     {
@@ -123,7 +123,7 @@
       "auto_delete": false,
       "arguments": {
         "x-dead-letter-exchange": "delayedRedeliveryExchange",
-        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+        "x-dead-letter-routing-key": "case.sample.inbound"
       }
     },
     {
@@ -133,7 +133,7 @@
       "auto_delete": false,
       "arguments": {
         "x-dead-letter-exchange": "delayedRedeliveryExchange",
-        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+        "x-dead-letter-routing-key": "case.uac-qid-created"
       }
     },
     {
@@ -143,7 +143,7 @@
       "auto_delete": false,
       "arguments": {
         "x-dead-letter-exchange": "delayedRedeliveryExchange",
-        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+        "x-dead-letter-routing-key": "case.refusals"
       }
     },
     {
@@ -153,7 +153,7 @@
       "auto_delete": false,
       "arguments": {
         "x-dead-letter-exchange": "delayedRedeliveryExchange",
-        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+        "x-dead-letter-routing-key": "case.questionnairelinked"
       }
     },
     {
@@ -163,7 +163,7 @@
       "auto_delete": false,
       "arguments": {
         "x-dead-letter-exchange": "delayedRedeliveryExchange",
-        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+        "x-dead-letter-routing-key": "survey.launched"
       }
     },
     {
@@ -173,7 +173,7 @@
       "auto_delete": false,
       "arguments": {
         "x-dead-letter-exchange": "delayedRedeliveryExchange",
-        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+        "x-dead-letter-routing-key": "case.ccsPropertyListedQueue"
       }
     },
     {
@@ -183,7 +183,17 @@
       "auto_delete": false,
       "arguments": {
         "x-dead-letter-exchange": "delayedRedeliveryExchange",
-        "x-dead-letter-routing-key": "action.undeliveredMailQueue"
+        "x-dead-letter-routing-key": "Action.Field"
+      }
+    },
+    {
+      "name": "delayedRedeliveryQueue",
+      "vhost": "/",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {
+        "x-dead-letter-exchange": "",
+        "x-message-ttl": 2000
       }
     }
   ],
@@ -210,6 +220,15 @@
       "name": "action-outbound-exchange",
       "vhost": "/",
       "type": "direct",
+      "durable": true,
+      "auto_delete": false,
+      "internal": false,
+      "arguments": {}
+    },
+    {
+      "name": "delayedRedeliveryExchange",
+      "vhost": "/",
+      "type": "headers",
       "durable": true,
       "auto_delete": false,
       "internal": false,
@@ -327,6 +346,14 @@
       "destination": "Action.Field",
       "destination_type": "queue",
       "routing_key": "Action.Field.binding",
+      "arguments": {}
+    },
+    {
+      "source": "delayedRedeliveryExchange",
+      "vhost": "/",
+      "destination": "delayedRedeliveryQueue",
+      "destination_type": "queue",
+      "routing_key": "",
       "arguments": {}
     }
   ]


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to make RabbitMQ responsible for routing bad messages to a DLQ instead of manually doing this in our application code. This PR makes use of `AmqpRejectAndDontRequeueException` to reject a bad message, allowing Rabbit to take care of routing and redelivering that message.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Reject the message by throwing an exception
* Remove retry exchange from code 
* Suppress 'noisy' stack trace logging at warning level when the exception is thrown
*  Update tests and test queue config

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build this branch, checkout the [docker-dev PR](https://github.com/ONSdigital/census-rm-docker-dev/pull/40) and post a bad message to a queue this service consumes from. Check the message is redelivered continuously.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/hG9Mi8tA/315-rabbit-message-persistence-dlq-config-8