### PR TITLE
Don't receipt continuation questionnaire types

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/ReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/ReceiptService.java
@@ -2,6 +2,7 @@ package uk.gov.ons.census.casesvc.service;
 
 import static uk.gov.ons.census.casesvc.utility.JsonHelper.convertObjectToJson;
 import static uk.gov.ons.census.casesvc.utility.QuestionnaireTypeHelper.isCCSQuestionnaireType;
+import static uk.gov.ons.census.casesvc.utility.QuestionnaireTypeHelper.iscontinuationQuestionnaireTypes;
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
@@ -35,12 +36,14 @@ public class ReceiptService {
     Case caze = uacQidLink.getCaze();
 
     if (caze != null) {
-      caze.setReceiptReceived(true);
+      if (!iscontinuationQuestionnaireTypes(uacQidLink.getQid())) {
+        caze.setReceiptReceived(true);
 
-      if (caze.isCcsCase()) {
-        caseService.saveCase(caze);
-      } else {
-        caseService.saveAndEmitCaseUpdatedEvent(caze);
+        if (caze.isCcsCase()) {
+          caseService.saveCase(caze);
+        } else {
+          caseService.saveAndEmitCaseUpdatedEvent(caze);
+        }
       }
     } else {
       log.with("qid", receiptPayload.getQuestionnaireId())

--- a/src/main/java/uk/gov/ons/census/casesvc/utility/QuestionnaireTypeHelper.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/utility/QuestionnaireTypeHelper.java
@@ -43,6 +43,9 @@ public class QuestionnaireTypeHelper {
               CCS_INTERVIEWER_CE_MANAGER_FOR_WALES_WELSH));
 
   private static final String HOLDER11 = "11";
+  private static final String HOLDER12 = "12";
+  private static final String HOLDER13 = "13";
+  private static final String HOLDER14 = "14";
   private static final Set<String> continutationQuestionnaireTypes =
       new HashSet<>(
           Arrays.asList(

--- a/src/main/java/uk/gov/ons/census/casesvc/utility/QuestionnaireTypeHelper.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/utility/QuestionnaireTypeHelper.java
@@ -42,6 +42,17 @@ public class QuestionnaireTypeHelper {
               CCS_INTERVIEWER_CE_MANAGER_FOR_ENGLAND_AND_WALES_ENGLISH,
               CCS_INTERVIEWER_CE_MANAGER_FOR_WALES_WELSH));
 
+  private static final String HOLDER11 = "11";
+  private static final Set<String> continutationQuestionnaireTypes =
+      new HashSet<>(
+          Arrays.asList(
+              CCS_POSTBACK_CONTINUATION_QUESTIONNAIRE_FOR_ENGLAND_AND_WALES,
+              CCS_POSTBACK_CONTINUATION_QUESTIONNAIRE_FOR_WALES_WELSH,
+              HOLDER11,
+              "12",
+              "13",
+              "14"));
+
   public static int calculateQuestionnaireType(String treatmentCode) {
     String country = treatmentCode.substring(treatmentCode.length() - 1);
     if (!country.equals("E") && !country.equals("W") && !country.equals("N")) {
@@ -98,5 +109,11 @@ public class QuestionnaireTypeHelper {
     String questionnaireType = questionnaireId.substring(0, 2);
 
     return ccsQuestionnaireTypes.contains(questionnaireType);
+  }
+
+  public static boolean iscontinuationQuestionnaireTypes(String questionnaireId) {
+    String questionnaireType = questionnaireId.substring(0, 2);
+
+    return continutationQuestionnaireTypes.contains(questionnaireType);
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/utility/QuestionnaireTypeHelper.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/utility/QuestionnaireTypeHelper.java
@@ -42,19 +42,19 @@ public class QuestionnaireTypeHelper {
               CCS_INTERVIEWER_CE_MANAGER_FOR_ENGLAND_AND_WALES_ENGLISH,
               CCS_INTERVIEWER_CE_MANAGER_FOR_WALES_WELSH));
 
-  private static final String HOLDER11 = "11";
-  private static final String HOLDER12 = "12";
-  private static final String HOLDER13 = "13";
-  private static final String HOLDER14 = "14";
+  private static final String ENGLAND_HOUSEHOLD_CONTINUATION = "11";
+  private static final String WALES_HOUSEHOLD_CONTINUATION = "12";
+  private static final String WALES_HOUSEHOLD_CONTINUATION_WELSH = "13";
+  private static final String NORTHERN_IRELAND_HOUSEHOLD_CONTINUATION = "14";
   private static final Set<String> continutationQuestionnaireTypes =
       new HashSet<>(
           Arrays.asList(
+              ENGLAND_HOUSEHOLD_CONTINUATION,
+              WALES_HOUSEHOLD_CONTINUATION,
+              WALES_HOUSEHOLD_CONTINUATION_WELSH,
+              NORTHERN_IRELAND_HOUSEHOLD_CONTINUATION,
               CCS_POSTBACK_CONTINUATION_QUESTIONNAIRE_FOR_ENGLAND_AND_WALES,
-              CCS_POSTBACK_CONTINUATION_QUESTIONNAIRE_FOR_WALES_WELSH,
-              HOLDER11,
-              "12",
-              "13",
-              "14"));
+              CCS_POSTBACK_CONTINUATION_QUESTIONNAIRE_FOR_WALES_WELSH));
 
   public static int calculateQuestionnaireType(String treatmentCode) {
     String country = treatmentCode.substring(treatmentCode.length() - 1);

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
@@ -48,7 +48,7 @@ import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 public class ReceiptReceiverIT {
   private static final UUID TEST_CASE_ID = UUID.randomUUID();
   private static final EasyRandom easyRandom = new EasyRandom();
-  private final String TEST_NON_CCS_QID_ID = "1234567890123456";
+  private final String TEST_NON_CCS_QID_ID = "0134567890123456";
   private final String TEST_CCS_QID_ID = "7134567890123456";
   private static final String TEST_UAC = easyRandom.nextObject(String.class);
 

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverTest.java
@@ -19,7 +19,4 @@ public class ReceiptReceiverTest {
 
     verify(receiptService, times(1)).processReceipt(managementEvent);
   }
-
-
-
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverTest.java
@@ -19,4 +19,7 @@ public class ReceiptReceiverTest {
 
     verify(receiptService, times(1)).processReceipt(managementEvent);
   }
+
+
+
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/service/ReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/ReceiptServiceTest.java
@@ -23,8 +23,9 @@ import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 @RunWith(MockitoJUnitRunner.class)
 public class ReceiptServiceTest {
 
-  private final String TEST_NON_CCS_QID_ID = "1234567890123456";
+  private final String TEST_NON_CCS_QID_ID = "0134567890123456";
   private final String TEST_CCS_QID_ID = "7134567890123456";
+  private final String TEST_CONTINUATION_QID = "113456789023";
 
   @Mock private CaseService caseService;
 
@@ -129,4 +130,48 @@ public class ReceiptServiceTest {
             anyString());
     verifyNoMoreInteractions(eventLogger);
   }
+
+  @Test
+  public void testReceiptForContinuationQID() {
+    ResponseManagementEvent managementEvent = getTestResponseManagementEvent();
+    ResponseDTO expectedReceipt = managementEvent.getPayload().getResponse();
+
+    // Given
+    Case expectedCase = getRandomCase();
+    expectedCase.setReceiptReceived(false);
+    expectedCase.setCcsCase(false);
+    UacQidLink expectedUacQidLink = generateRandomUacQidLinkedToCase(expectedCase);
+    expectedUacQidLink.setQid(TEST_CONTINUATION_QID);
+
+    managementEvent.getPayload().getResponse().setResponseDateTime(OffsetDateTime.now());
+
+    when(uacService.findByQid(expectedReceipt.getQuestionnaireId())).thenReturn(expectedUacQidLink);
+
+    // when
+    underTest.processReceipt(managementEvent);
+
+    // then
+    InOrder inOrder = inOrder(uacService, eventLogger);
+
+    inOrder.verify(uacService).findByQid(anyString());
+
+    ArgumentCaptor<UacQidLink> uacQidLinkCaptor = ArgumentCaptor.forClass(UacQidLink.class);
+    inOrder.verify(uacService).saveAndEmitUacUpdatedEvent(uacQidLinkCaptor.capture());
+    UacQidLink actualUacQidLink = uacQidLinkCaptor.getValue();
+    assertThat(actualUacQidLink.getQid()).isEqualTo(expectedUacQidLink.getQid());
+    assertThat(actualUacQidLink.getUac()).isEqualTo(expectedUacQidLink.getUac());
+
+    verify(eventLogger)
+            .logUacQidEvent(
+                    eq(expectedUacQidLink),
+                    any(OffsetDateTime.class),
+                    eq(QID_RECEIPTED),
+                    eq(EventType.RESPONSE_RECEIVED),
+                    eq(managementEvent.getEvent()),
+                    anyString());
+    verifyNoMoreInteractions(eventLogger);
+
+    verifyZeroInteractions(caseService);
+  }
+
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/service/ReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/ReceiptServiceTest.java
@@ -162,16 +162,15 @@ public class ReceiptServiceTest {
     assertThat(actualUacQidLink.getUac()).isEqualTo(expectedUacQidLink.getUac());
 
     verify(eventLogger)
-            .logUacQidEvent(
-                    eq(expectedUacQidLink),
-                    any(OffsetDateTime.class),
-                    eq(QID_RECEIPTED),
-                    eq(EventType.RESPONSE_RECEIVED),
-                    eq(managementEvent.getEvent()),
-                    anyString());
+        .logUacQidEvent(
+            eq(expectedUacQidLink),
+            any(OffsetDateTime.class),
+            eq(QID_RECEIPTED),
+            eq(EventType.RESPONSE_RECEIVED),
+            eq(managementEvent.getEvent()),
+            anyString());
     verifyNoMoreInteractions(eventLogger);
 
     verifyZeroInteractions(caseService);
   }
-
 }


### PR DESCRIPTION
# Motivation and Context
Don't want the continuation questionnaire types to get a receipt received 

# What has changed
Identified QID first 2 digits that relate to continuation types that wont receive a receipt and created a test for it

# How to test?
Clone repo and check it works on machine

# Links
https://trello.com/c/fcEkdqbL
https://collaborate2.ons.gov.uk/confluence/display/SDC/Receipting+of+Continuation+Questionnaires