### PR TITLE
fix sample loading for ceExpectedCapacity

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/CreateCaseSample.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/CreateCaseSample.java
@@ -29,7 +29,7 @@ public class CreateCaseSample {
   private String fieldCoordinatorId;
   private String fieldOfficerId;
   private String treatmentCode;
-  private String ceExpectedCapacity;
+  private Integer ceExpectedCapacity;
   private String collectionExerciseId;
   private String actionPlanId;
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
@@ -3,6 +3,7 @@ package uk.gov.ons.census.casesvc.messaging;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -78,7 +79,7 @@ public class SampleReceiverIT {
     createCaseSample.setPostcode("ABC123");
     createCaseSample.setRegion("E12000009");
     createCaseSample.setTreatmentCode("HH_LF3R2E");
-
+    createCaseSample.setCeExpectedCapacity(null);
     // WHEN
     rabbitQueueHelper.sendMessage(inboundQueue, createCaseSample);
 
@@ -102,6 +103,7 @@ public class SampleReceiverIT {
     List<Case> caseList = caseRepository.findAll();
     assertEquals(1, caseList.size());
     assertEquals("ABC123", caseList.get(0).getPostcode());
+    assertNull(caseList.get(0).getCeExpectedCapacity());
 
     List<Event> eventList = eventRepository.findAll();
     assertThat(eventList.size()).isEqualTo(1);

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
@@ -80,7 +80,7 @@ public class CaseServiceTest {
     createCaseSample.setTreatmentCode(TEST_TREATMENT_CODE);
     createCaseSample.setFieldCoordinatorId(FIELD_CORD_ID);
     createCaseSample.setFieldOfficerId(FIELD_OFFICER_ID);
-    createCaseSample.setCeExpectedCapacity(CE_CAPACITY.toString());
+    createCaseSample.setCeExpectedCapacity(CE_CAPACITY);
     createCaseSample.setAddressType(TEST_ADDRESS_TYPE);
 
     ReflectionTestUtils.setField(underTest, "caserefgeneratorkey", caserefgeneratorkey);


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When a sample unit has a blank CE_EXPECTED_CAPACITY in the sample file, case processor cannot ingest it and rejects the message. This change is to enable case processor to accept these sample units. 

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
ceExpectedCapacity changed to Integer in CreateCaseSample.
Unit test updated to allow this and is also checked in an integration test.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Maven clean install
Run [acceptance tests on branch of the same name](https://github.com/ONSdigital/census-rm-acceptance-tests/pull/157) - they should pass.
Run performance tests - they should pass now.
Push case processor image to your GCP if you fancy, then run acceptance tests and performance tests.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/iPx9qCU5/495-fix-sample-files-or-sample-file-loading-for-ceexpectedcapacity-3
# Screenshots (if appropriate):