### PR TITLE
Assign SPG case types to household questionnaires

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/utility/QuestionnaireTypeHelper.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/utility/QuestionnaireTypeHelper.java
@@ -45,7 +45,7 @@ public class QuestionnaireTypeHelper {
           String.format("Unknown Country for treatment code %s", treatmentCode));
     }
 
-    if (treatmentCode.startsWith("HH")) {
+    if (treatmentCode.startsWith("HH") || treatmentCode.startsWith("SPG")) {
       switch (country) {
         case "E":
           return 1;

--- a/src/test/java/uk/gov/ons/census/casesvc/utility/QuestionnaireTypeHelperTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/utility/QuestionnaireTypeHelperTest.java
@@ -40,6 +40,28 @@ public class QuestionnaireTypeHelperTest {
   }
 
   @Test
+  public void testValidQuestionnaireTypeEnglandSPG() {
+    // Given
+
+    // When
+    int actualQuestionnaireType = QuestionnaireTypeHelper.calculateQuestionnaireType("SPG_QDHSE");
+
+    // Then
+    assertEquals(1, actualQuestionnaireType);
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeWalesSPG() {
+    // Given
+
+    // When
+    int actualQuestionnaireType = QuestionnaireTypeHelper.calculateQuestionnaireType("SPG_QDHSW");
+
+    // Then
+    assertEquals(2, actualQuestionnaireType);
+  }
+
+  @Test
   public void testValidQuestionnaireTypeEnglandIndividual() {
     // Given
 


### PR DESCRIPTION
# Motivation and Context
Handle SPG cases - they'll be assigned to the standard HH questionnaire types

# What has changed
If it's an SPG case (i.e. the treatment code starts with `SPG` then it'll be linked to a HH questionnaire type, like a standard HH case type.

# How to test?
- All unit and integration tests should pass
- Run the SPG branch of the acceptance tests with this branch --> https://github.com/ONSdigital/census-rm-acceptance-tests/pull/158

# Links
- https://trello.com/c/1IB69qys