### PR TITLE
Add last updated column to case entity

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
@@ -13,6 +13,7 @@ import javax.persistence.Table;
 import lombok.Data;
 import org.hibernate.annotations.Generated;
 import org.hibernate.annotations.GenerationTime;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Data
 @Entity
@@ -115,4 +116,6 @@ public class Case {
 
   @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
   private boolean undeliveredAsAddressed;
+
+  @Column @UpdateTimestamp private OffsetDateTime lastUpdated;
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
@@ -117,5 +117,7 @@ public class Case {
   @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
   private boolean undeliveredAsAddressed;
 
-  @Column @UpdateTimestamp private OffsetDateTime lastUpdated;
+  @Column(columnDefinition = "timestamp with time zone")
+  @UpdateTimestamp
+  private OffsetDateTime lastUpdated;
 }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adding this lastUpdated time stamp will provide the capability to do 'delta' based extracts from RM for data that is sent to DAP for use by processing and the RCA/FPA algorithms as opposed to exported the full set each time.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
lastUpdated column added to Case entity, this is annotated so that the lastUpdated time is updated when the row is updated.
An integration test has been modified to check that the lastUpdated is different from when a case is created and it is updated with a refusal event.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build case processor, run acceptance tests. 
Get some data in your database and check the last_updated column for a specific case. Submit a message to rabbitmq that will update this case (refusal, receipt etc) and check the last_updated field has changed.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/YHny5NEN/223-add-lastupdated-field-to-case-db-cases-table-3
# Screenshots (if appropriate):