### PR TITLE
Refactor to handle new UAC-QIDs as part of fulfilment messages

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/UacCreatedEventReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/UacCreatedEventReceiver.java
@@ -22,6 +22,9 @@ public class UacCreatedEventReceiver {
   @ServiceActivator(inputChannel = "uacCreatedInputChannel")
   public void receiveMessage(Message<ResponseManagementEvent> message) {
     OffsetDateTime messageTimestamp = getMsgTimeStamp(message);
-    uacService.ingestUacCreatedEvent(message.getPayload(), messageTimestamp);
+    uacService.ingestUacCreatedEvent(
+        message.getPayload(),
+        messageTimestamp,
+        message.getPayload().getPayload().getUacQidCreated());
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/FulfilmentRequestDTO.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/FulfilmentRequestDTO.java
@@ -18,4 +18,6 @@ public class FulfilmentRequestDTO {
   private String individualCaseId;
 
   private Contact contact;
+
+  private UacCreatedDTO uacQidCreated;
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestService.java
@@ -13,6 +13,7 @@ import uk.gov.ons.census.casesvc.logging.EventLogger;
 import uk.gov.ons.census.casesvc.model.dto.EventDTO;
 import uk.gov.ons.census.casesvc.model.dto.FulfilmentRequestDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
+import uk.gov.ons.census.casesvc.model.dto.UacCreatedDTO;
 import uk.gov.ons.census.casesvc.model.entity.Case;
 import uk.gov.ons.census.casesvc.model.entity.CaseState;
 
@@ -47,10 +48,13 @@ public class FulfilmentRequestService {
 
   private final EventLogger eventLogger;
   private final CaseService caseService;
+  private final UacService uacService;
 
-  public FulfilmentRequestService(EventLogger eventLogger, CaseService caseService) {
+  public FulfilmentRequestService(
+      EventLogger eventLogger, CaseService caseService, UacService uacService) {
     this.eventLogger = eventLogger;
     this.caseService = caseService;
+    this.uacService = uacService;
   }
 
   public void processFulfilmentRequest(
@@ -61,7 +65,12 @@ public class FulfilmentRequestService {
 
     Case caze = caseService.getCaseByCaseId(UUID.fromString(fulfilmentRequestPayload.getCaseId()));
 
+    // As part of a fulfilment, we might need to create a 'child' case (an individual)
     handleIndividualFulfilment(fulfilmentRequestPayload, caze);
+
+    // As part of a fulfilment, we might have created a new UAC-QID pair, which needs to be linked
+    // to the case it belongs to
+    handleUacQidCreated(fulfilmentRequest, messageTimestamp);
 
     // we do not want to log contact details for fulfillment requests
     fulfilmentRequestPayload.setContact(null);
@@ -74,6 +83,17 @@ public class FulfilmentRequestService {
         fulfilmentRequestEvent,
         convertObjectToJson(fulfilmentRequestPayload),
         messageTimestamp);
+  }
+
+  private void handleUacQidCreated(
+      ResponseManagementEvent responseManagementEvent, OffsetDateTime messageTimestamp) {
+    UacCreatedDTO uacQidCreated =
+        responseManagementEvent.getPayload().getFulfilmentRequest().getUacQidCreated();
+
+    // There might not always be a new UAC-QID as part of a fulfilment
+    if (uacQidCreated != null) {
+      uacService.ingestUacCreatedEvent(responseManagementEvent, messageTimestamp, uacQidCreated);
+    }
   }
 
   private void handleIndividualFulfilment(

--- a/src/main/java/uk/gov/ons/census/casesvc/service/UacService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/UacService.java
@@ -15,6 +15,7 @@ import uk.gov.ons.census.casesvc.model.dto.EventDTO;
 import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
 import uk.gov.ons.census.casesvc.model.dto.PayloadDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
+import uk.gov.ons.census.casesvc.model.dto.UacCreatedDTO;
 import uk.gov.ons.census.casesvc.model.dto.UacDTO;
 import uk.gov.ons.census.casesvc.model.dto.UacQidDTO;
 import uk.gov.ons.census.casesvc.model.entity.Case;
@@ -121,26 +122,23 @@ public class UacService {
   }
 
   public void ingestUacCreatedEvent(
-      ResponseManagementEvent uacCreatedEvent, OffsetDateTime messageTimestamp) {
-    Case linkedCase =
-        caseService.getCaseByCaseId(uacCreatedEvent.getPayload().getUacQidCreated().getCaseId());
+      ResponseManagementEvent responseManagementEvent,
+      OffsetDateTime messageTimestamp,
+      UacCreatedDTO uacCreated) {
+    Case linkedCase = caseService.getCaseByCaseId(uacCreated.getCaseId());
 
     UacQidLink uacQidLink =
-        buildUacQidLink(
-            linkedCase,
-            null,
-            uacCreatedEvent.getPayload().getUacQidCreated().getUac(),
-            uacCreatedEvent.getPayload().getUacQidCreated().getQid());
+        buildUacQidLink(linkedCase, null, uacCreated.getUac(), uacCreated.getQid());
 
     saveAndEmitUacUpdatedEvent(uacQidLink);
 
     eventLogger.logUacQidEvent(
         uacQidLink,
-        uacCreatedEvent.getEvent().getDateTime(),
+        responseManagementEvent.getEvent().getDateTime(),
         "RM UAC QID pair created",
         EventType.RM_UAC_CREATED,
-        uacCreatedEvent.getEvent(),
-        convertObjectToJson(uacCreatedEvent.getPayload()),
+        responseManagementEvent.getEvent(),
+        convertObjectToJson(responseManagementEvent.getPayload()),
         messageTimestamp);
   }
 

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverIT.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.census.casesvc.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.ons.census.casesvc.testutil.DataUtils.convertJsonToRefusalDTO;
+import static uk.gov.ons.census.casesvc.testutil.DataUtils.convertJsonToObject;
 import static uk.gov.ons.census.casesvc.testutil.DataUtils.getRandomCase;
 import static uk.gov.ons.census.casesvc.testutil.DataUtils.getTestResponseManagementRefusalEvent;
 import static uk.gov.ons.census.casesvc.utility.JsonHelper.convertObjectToJson;
@@ -118,7 +118,8 @@ public class RefusalReceiverIT {
     List<Event> events = eventRepository.findAll();
     assertThat(events.size()).isEqualTo(1);
 
-    RefusalDTO actualRefusal = convertJsonToRefusalDTO(events.get(0).getEventPayload());
+    RefusalDTO actualRefusal =
+        convertJsonToObject(events.get(0).getEventPayload(), RefusalDTO.class);
     assertThat(actualRefusal.getType()).isEqualTo(expectedRefusal.getType());
     assertThat(actualRefusal.getReport()).isEqualTo(expectedRefusal.getReport());
     assertThat(actualRefusal.getAgentId()).isEqualTo(expectedRefusal.getAgentId());

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UacCreatedEventReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UacCreatedEventReceiverTest.java
@@ -37,6 +37,10 @@ public class UacCreatedEventReceiverTest {
     underTest.receiveMessage(message);
 
     // Then
-    verify(uacService).ingestUacCreatedEvent(eq(uacCreatedEvent), eq(expectedDate));
+    verify(uacService)
+        .ingestUacCreatedEvent(
+            eq(uacCreatedEvent),
+            eq(expectedDate),
+            eq(uacCreatedEvent.getPayload().getUacQidCreated()));
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestServiceTest.java
@@ -39,6 +39,8 @@ public class FulfilmentRequestServiceTest {
 
   @Mock private CaseService caseService;
 
+  @Mock private UacService uacService;
+
   @InjectMocks FulfilmentRequestService underTest;
 
   @Test

--- a/src/test/java/uk/gov/ons/census/casesvc/service/UacServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/UacServiceTest.java
@@ -122,7 +122,8 @@ public class UacServiceTest {
     ArgumentCaptor<UacQidLink> uacQidLinkArgumentCaptor = ArgumentCaptor.forClass(UacQidLink.class);
 
     // When
-    underTest.ingestUacCreatedEvent(uacCreatedEvent, messageTimestamp);
+    underTest.ingestUacCreatedEvent(
+        uacCreatedEvent, messageTimestamp, uacCreatedEvent.getPayload().getUacQidCreated());
 
     // Then
     verify(uacQidLinkRepository).save(uacQidLinkArgumentCaptor.capture());
@@ -152,7 +153,8 @@ public class UacServiceTest {
     ReflectionTestUtils.setField(underTest, "outboundExchange", "TEST_EXCHANGE");
 
     // When
-    underTest.ingestUacCreatedEvent(uacCreatedEvent, messageTimestamp);
+    underTest.ingestUacCreatedEvent(
+        uacCreatedEvent, messageTimestamp, uacCreatedEvent.getPayload().getUacQidCreated());
 
     // Then
     verify(rabbitTemplate)
@@ -185,7 +187,8 @@ public class UacServiceTest {
     OffsetDateTime messageTimestamp = OffsetDateTime.now();
 
     // When
-    underTest.ingestUacCreatedEvent(uacCreatedEvent, messageTimestamp);
+    underTest.ingestUacCreatedEvent(
+        uacCreatedEvent, messageTimestamp, uacCreatedEvent.getPayload().getUacQidCreated());
 
     // Then
     verify(eventLogger)

--- a/src/test/java/uk/gov/ons/census/casesvc/testutil/DataUtils.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/testutil/DataUtils.java
@@ -181,6 +181,7 @@ public class DataUtils {
     payload.setResponse(null);
     payload.setPrintCaseSelected(null);
     payload.setRefusal(null);
+    payload.setCcsProperty(null);
 
     FulfilmentRequestDTO fulfilmentRequest = payload.getFulfilmentRequest();
     fulfilmentRequest.setCaseId(null);
@@ -222,17 +223,9 @@ public class DataUtils {
     return managementEvent;
   }
 
-  public static RefusalDTO convertJsonToRefusalDTO(String json) {
+  public static <T> T convertJsonToObject(String json, Class<T> clazz) {
     try {
-      return objectMapper.readValue(json, RefusalDTO.class);
-    } catch (IOException e) {
-      throw new RuntimeException("Failed converting Json To RefusalDTO", e);
-    }
-  }
-
-  public static FulfilmentRequestDTO convertJsonToFulfilmentRequestDTO(String json) {
-    try {
-      return objectMapper.readValue(json, FulfilmentRequestDTO.class);
+      return objectMapper.readValue(json, clazz);
     } catch (IOException e) {
       throw new RuntimeException("Failed converting Json To FulfilmentRequestDTO", e);
     }

--- a/src/test/java/uk/gov/ons/census/casesvc/testutil/DataUtils.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/testutil/DataUtils.java
@@ -185,6 +185,7 @@ public class DataUtils {
     FulfilmentRequestDTO fulfilmentRequest = payload.getFulfilmentRequest();
     fulfilmentRequest.setCaseId(null);
     fulfilmentRequest.setFulfilmentCode(null);
+    fulfilmentRequest.setUacQidCreated(null);
 
     return managementEvent;
   }


### PR DESCRIPTION
# Motivation and Context
The order that we received the UAC created and fulfilment messages resulted in either success or failure. Given that we have no control over which message we process first, we needed to refactor.

# What has changed
Combined the UAC-QID created details into the fulfilment message, so it can be linked to a new case, should one need to be created.

# How to test?
Run the acceptance tests. There should be zero regression (and a whole lot less errors in the logs).

# Links
Trello: https://trello.com/c/yNjry5aD