### PR TITLE
Remove case state

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/CollectionCase.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/CollectionCase.java
@@ -14,7 +14,6 @@ public class CollectionCase {
   private String survey;
   private String collectionExerciseId;
   private Address address;
-  private String state;
   private OffsetDateTime actionableFrom;
   private Boolean receiptReceived;
   private Boolean refusalReceived;

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
@@ -5,8 +5,6 @@ import java.util.List;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
@@ -94,10 +92,6 @@ public class Case {
 
   @Column(columnDefinition = "timestamp with time zone")
   private OffsetDateTime createdDateTime;
-
-  @Column
-  @Enumerated(EnumType.STRING)
-  private CaseState state;
 
   @OneToMany(mappedBy = "caze")
   List<UacQidLink> uacQidLinks;

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/CaseState.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/CaseState.java
@@ -1,5 +1,0 @@
-package uk.gov.ons.census.casesvc.model.entity;
-
-public enum CaseState {
-  ACTIONABLE
-}

--- a/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
@@ -17,7 +17,6 @@ import uk.gov.ons.census.casesvc.model.dto.PayloadDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.casesvc.model.dto.SampleUnitDTO;
 import uk.gov.ons.census.casesvc.model.entity.Case;
-import uk.gov.ons.census.casesvc.model.entity.CaseState;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 import uk.gov.ons.census.casesvc.utility.CaseRefGenerator;
 import uk.gov.ons.census.casesvc.utility.EventHelper;
@@ -69,7 +68,6 @@ public class CaseService {
     Case caze = mapperFacade.map(createCaseSample, Case.class);
     caze.setCaseType(createCaseSample.getAddressType());
     caze.setCaseId(UUID.randomUUID());
-    caze.setState(CaseState.ACTIONABLE);
     caze.setCreatedDateTime(OffsetDateTime.now());
     caze.setReceiptReceived(false);
     caze.setSurvey(CENSUS_SURVEY);
@@ -85,7 +83,6 @@ public class CaseService {
     caze.setCaseId(UUID.fromString(caseId));
     caze.setActionPlanId(actionPlanId);
     caze.setCollectionExerciseId(collectionExerciseId);
-    caze.setState(CaseState.ACTIONABLE);
     caze.setCreatedDateTime(OffsetDateTime.now());
     caze.setRefusalReceived(isRefused);
     caze.setAddressInvalid(isInvalidAddress);
@@ -172,7 +169,6 @@ public class CaseService {
     collectionCase.setCaseType(caze.getCaseType());
     collectionCase.setCollectionExerciseId(caze.getCollectionExerciseId());
     collectionCase.setId(caze.getCaseId().toString());
-    collectionCase.setState(caze.getState().toString());
     collectionCase.setSurvey(caze.getSurvey());
     // Stop. No. Don't put anything else here unless it's in the event dictionary. Look down!
 
@@ -202,7 +198,6 @@ public class CaseService {
     Case individualResponseCase = new Case();
 
     individualResponseCase.setCaseId(UUID.randomUUID());
-    individualResponseCase.setState(CaseState.ACTIONABLE);
     individualResponseCase.setCreatedDateTime(OffsetDateTime.now());
     individualResponseCase.setAddressType(parentCase.getAddressType());
     individualResponseCase.setCaseType(HOUSEHOLD_INDIVIDUAL_RESPONSE_CASE_TYPE);

--- a/src/main/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestService.java
@@ -14,7 +14,6 @@ import uk.gov.ons.census.casesvc.model.dto.EventDTO;
 import uk.gov.ons.census.casesvc.model.dto.FulfilmentRequestDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.casesvc.model.entity.Case;
-import uk.gov.ons.census.casesvc.model.entity.CaseState;
 
 @Service
 public class FulfilmentRequestService {
@@ -97,7 +96,6 @@ public class FulfilmentRequestService {
     Case individualResponseCase = new Case();
 
     individualResponseCase.setCaseId(newCaseId);
-    individualResponseCase.setState(CaseState.ACTIONABLE);
     individualResponseCase.setCreatedDateTime(OffsetDateTime.now());
     individualResponseCase.setAddressType(parentCase.getAddressType());
     individualResponseCase.setCaseType(HOUSEHOLD_INDIVIDUAL_RESPONSE_CASE_TYPE);

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
@@ -28,7 +28,6 @@ import uk.gov.ons.census.casesvc.model.dto.CreateCaseSample;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.casesvc.model.dto.SampleUnitDTO;
 import uk.gov.ons.census.casesvc.model.entity.Case;
-import uk.gov.ons.census.casesvc.model.entity.CaseState;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -178,7 +177,6 @@ public class CaseServiceTest {
     caze.setRegion("E");
     caze.setCaseRef(123);
     caze.setCaseId(UUID.randomUUID());
-    caze.setState(CaseState.ACTIONABLE);
     caze.setPostcode(TEST_POSTCODE);
     caze.setFieldCoordinatorId(FIELD_CORD_ID);
     caze.setFieldOfficerId(FIELD_OFFICER_ID);

--- a/src/test/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestServiceTest.java
@@ -19,7 +19,6 @@ import uk.gov.ons.census.casesvc.logging.EventLogger;
 import uk.gov.ons.census.casesvc.model.dto.FulfilmentRequestDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.casesvc.model.entity.Case;
-import uk.gov.ons.census.casesvc.model.entity.CaseState;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FulfilmentRequestServiceTest {
@@ -122,7 +121,6 @@ public class FulfilmentRequestServiceTest {
     parentCase.setUacQidLinks(new ArrayList<>());
     parentCase.setEvents(new ArrayList<>());
     parentCase.setCreatedDateTime(OffsetDateTime.now().minusDays(1));
-    parentCase.setState(null);
     parentCase.setReceiptReceived(true);
     parentCase.setRefusalReceived(true);
     parentCase.setAddressType("HH");
@@ -184,7 +182,6 @@ public class FulfilmentRequestServiceTest {
     parentCase.setUacQidLinks(new ArrayList<>());
     parentCase.setEvents(new ArrayList<>());
     parentCase.setCreatedDateTime(OffsetDateTime.now().minusDays(1));
-    parentCase.setState(null);
     parentCase.setReceiptReceived(true);
     parentCase.setRefusalReceived(true);
     parentCase.setAddressType("HH");
@@ -244,7 +241,6 @@ public class FulfilmentRequestServiceTest {
     assertThat(actualChildCase.getCollectionExerciseId())
         .isEqualTo(parentCase.getCollectionExerciseId());
     assertThat(actualChildCase.getActionPlanId()).isEqualTo(parentCase.getActionPlanId());
-    assertThat(actualChildCase.getState()).isEqualTo(CaseState.ACTIONABLE);
     assertThat(actualChildCase.isReceiptReceived()).isFalse();
     assertThat(actualChildCase.isRefusalReceived()).isFalse();
     assertThat(actualChildCase.getArid()).isEqualTo(parentCase.getArid());


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We can now safely remove the redundant case `state` column from our schemas.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Removed `state` from the repo

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Make sure tests and acceptance tests still pass from the links below

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/dBJe87ZS/481-get-rid-of-casestate-from-case-table-8

https://github.com/ONSdigital/census-rm-case-api/pull/53
https://github.com/ONSdigital/census-rm-action-scheduler/pull/64
https://github.com/ONSdigital/census-rm-action-worker/pull/9
https://github.com/ONSdigital/census-rm-ddl/pull/32
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/169