### PR TITLE
Qid linking to non hh cases

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedService.java
@@ -37,17 +37,18 @@ public class QuestionnaireLinkedService {
 
     checkQidNotLinkedToAnotherCase(uac, uacQidLink);
 
-    Case caze;
+    Case caze = caseService.getCaseByCaseId(UUID.fromString(uac.getCaseId()));
 
     if (isIndividualQuestionnaireType(questionnaireId)) {
-      Case householdCase = caseService.getCaseByCaseId(UUID.fromString(uac.getCaseId()));
-      caze = caseService.prepareIndividualResponseCaseFromParentCase(householdCase);
+      // We only want to create an HI case if the parent is an HH case
+      if (caze.getCaseType().equals("HH")) {
+        caze = caseService.prepareIndividualResponseCaseFromParentCase(caze);
 
-      caseService.emitCaseCreatedEvent(caze);
-    } else {
-      caze = caseService.getCaseByCaseId(UUID.fromString(uac.getCaseId()));
+        caseService.emitCaseCreatedEvent(caze);
+      }
     }
 
+    // TODO: This is wrong for CEs and SPGs but there is another ticket which deals with fixing this
     // If UAC/QID has been receipted before case, update case
     if (!uacQidLink.isActive() && !caze.isReceiptReceived()) {
       caze.setReceiptReceived(true);

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverIT.java
@@ -385,7 +385,7 @@ public class QuestionnaireLinkedReceiverIT {
     // THEN
     Case actualHHCase = caseRepository.findByCaseId(TEST_CASE_ID).get();
 
-    // Check database that HH Case is linked to UacQidLink
+    // Check database that CE Case is linked to UacQidLink
     List<UacQidLink> uacQidLinks = uacQidLinkRepository.findAll();
     assertThat(uacQidLinks.size()).isEqualTo(1);
     UacQidLink actualUacQidLink = uacQidLinks.get(0);
@@ -436,7 +436,7 @@ public class QuestionnaireLinkedReceiverIT {
     // THEN
     Case actualHHCase = caseRepository.findByCaseId(TEST_CASE_ID).get();
 
-    // Check database that HH Case is linked to UacQidLink
+    // Check database that SPG Case is linked to UacQidLink
     List<UacQidLink> uacQidLinks = uacQidLinkRepository.findAll();
     assertThat(uacQidLinks.size()).isEqualTo(1);
     UacQidLink actualUacQidLink = uacQidLinks.get(0);

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverIT.java
@@ -383,10 +383,9 @@ public class QuestionnaireLinkedReceiverIT {
         questionnaireLinkedQueue, managementEvent, outboundCaseQueue);
 
     // THEN
-    // Check database HI Case created as expected
     Case actualHHCase = caseRepository.findByCaseId(TEST_CASE_ID).get();
 
-    // Check database that HI Case is linked to UacQidLink
+    // Check database that HH Case is linked to UacQidLink
     List<UacQidLink> uacQidLinks = uacQidLinkRepository.findAll();
     assertThat(uacQidLinks.size()).isEqualTo(1);
     UacQidLink actualUacQidLink = uacQidLinks.get(0);
@@ -435,10 +434,9 @@ public class QuestionnaireLinkedReceiverIT {
         questionnaireLinkedQueue, managementEvent, outboundCaseQueue);
 
     // THEN
-    // Check database HI Case created as expected
     Case actualHHCase = caseRepository.findByCaseId(TEST_CASE_ID).get();
 
-    // Check database that HI Case is linked to UacQidLink
+    // Check database that HH Case is linked to UacQidLink
     List<UacQidLink> uacQidLinks = uacQidLinkRepository.findAll();
     assertThat(uacQidLinks.size()).isEqualTo(1);
     UacQidLink actualUacQidLink = uacQidLinks.get(0);


### PR DESCRIPTION
# Motivation and Context
SPG & CE cases shouldn't create child HI cases when we link unaddressed questionnaires.

# What has changed
Limited individual case creation to HH cases only.

# How to test?
Run the ATs.

# Links
Trello: https://trello.com/c/GJvtm94j