### PR TITLE
Handle estab address level refusal

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/RefusalService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/RefusalService.java
@@ -27,6 +27,16 @@ public class RefusalService {
       ResponseManagementEvent refusalEvent, OffsetDateTime messageTimestamp) {
     RefusalDTO refusal = refusalEvent.getPayload().getRefusal();
     Case caze = caseService.getCaseByCaseId(UUID.fromString(refusal.getCollectionCase().getId()));
+
+    String channel = refusalEvent.getEvent().getChannel();
+    if (isEstabLevelAddressAndChannelIsNotField(caze.getAddressLevel(), channel)) {
+      throw new RuntimeException(String
+          .format(
+              "Refusal received for Estab level case ID '%s' from channel '%s'. "
+                  + "This type of refusal should ONLY come from Field",
+              caze.getCaseId(), channel));
+    }
+
     caze.setRefusalReceived(true);
     caseService.saveAndEmitCaseUpdatedEvent(caze);
 
@@ -38,5 +48,9 @@ public class RefusalService {
         refusalEvent.getEvent(),
         convertObjectToJson(refusalEvent.getPayload().getRefusal()),
         messageTimestamp);
+  }
+
+  private boolean isEstabLevelAddressAndChannelIsNotField(String addressLevel, String channel) {
+    return addressLevel.equals("E") && !"FIELD".equalsIgnoreCase(channel);
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/RefusalService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/RefusalService.java
@@ -30,8 +30,8 @@ public class RefusalService {
 
     String channel = refusalEvent.getEvent().getChannel();
     if (isEstabLevelAddressAndChannelIsNotField(caze.getAddressLevel(), channel)) {
-      throw new RuntimeException(String
-          .format(
+      throw new RuntimeException(
+          String.format(
               "Refusal received for Estab level case ID '%s' from channel '%s'. "
                   + "This type of refusal should ONLY come from Field",
               caze.getCaseId(), channel));

--- a/src/main/java/uk/gov/ons/census/casesvc/service/RefusalService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/RefusalService.java
@@ -33,7 +33,7 @@ public class RefusalService {
 
     String channel = refusalEvent.getEvent().getChannel();
     if (isEstabLevelAddressAndChannelIsNotField(caze.getAddressLevel(), channel)) {
-      throw new RuntimeException(
+      throw new IllegalArgumentException(
           String.format(
               "Refusal received for Estab level case ID '%s' from channel '%s'. "
                   + "This type of refusal should ONLY come from Field",

--- a/src/main/java/uk/gov/ons/census/casesvc/service/RefusalService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/RefusalService.java
@@ -15,6 +15,8 @@ import uk.gov.ons.census.casesvc.model.entity.EventType;
 public class RefusalService {
 
   private static final String REFUSAL_RECEIVED = "Refusal Received";
+  private static final String ESTAB_ADDRESS_LEVEL = "E";
+
   private final CaseService caseService;
   private final EventLogger eventLogger;
 
@@ -51,6 +53,6 @@ public class RefusalService {
   }
 
   private boolean isEstabLevelAddressAndChannelIsNotField(String addressLevel, String channel) {
-    return addressLevel.equals("E") && !"FIELD".equalsIgnoreCase(channel);
+    return addressLevel.equals(ESTAB_ADDRESS_LEVEL) && !"FIELD".equalsIgnoreCase(channel);
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/RefusalService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/RefusalService.java
@@ -16,6 +16,7 @@ public class RefusalService {
 
   private static final String REFUSAL_RECEIVED = "Refusal Received";
   private static final String ESTAB_ADDRESS_LEVEL = "E";
+  private static final String FIELD_CHANNEL = "FIELD";
 
   private final CaseService caseService;
   private final EventLogger eventLogger;
@@ -53,6 +54,6 @@ public class RefusalService {
   }
 
   private boolean isEstabLevelAddressAndChannelIsNotField(String addressLevel, String channel) {
-    return addressLevel.equals(ESTAB_ADDRESS_LEVEL) && !"FIELD".equalsIgnoreCase(channel);
+    return addressLevel.equals(ESTAB_ADDRESS_LEVEL) && !FIELD_CHANNEL.equalsIgnoreCase(channel);
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverIT.java
@@ -82,6 +82,7 @@ public class RefusalReceiverIT {
     caze.setSurvey("CENSUS");
     caze.setUacQidLinks(null);
     caze.setEvents(null);
+    caze.setAddressLevel("U");
     caseRepository.saveAndFlush(caze);
 
     OffsetDateTime cazeCreatedTime =

--- a/src/test/java/uk/gov/ons/census/casesvc/service/RefusalServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/RefusalServiceTest.java
@@ -73,8 +73,8 @@ public class RefusalServiceTest {
     verifyNoMoreInteractions(eventLogger);
   }
 
-  @Test(expected = RuntimeException.class)
-  public void testRefusalNotFromFieldForEstabAddressLevelCaseThrowsException() {
+  @Test
+  public void testRefusalNotFromFieldForEstabAddressLevelCaseThrowsIllegalArgException() {
     // GIVEN
     ResponseManagementEvent managementEvent = getTestResponseManagementRefusalEvent();
     managementEvent.getEvent().setChannel("NOT FROM FIELD");
@@ -92,17 +92,17 @@ public class RefusalServiceTest {
             testCase.getCaseId(), managementEvent.getEvent().getChannel());
 
     // WHEN
+    boolean actualExceptionThrown = false;
     try {
       underTest.processRefusal(managementEvent, messageTimestamp);
-    } catch (RuntimeException expectedException) {
+    } catch (IllegalArgumentException expectedException) {
       // THEN
+      actualExceptionThrown = true;
       assertThat(expectedException.getMessage()).isEqualTo(expectedErrorMessage);
-
-      verify(caseService, times(1)).getCaseByCaseId(any(UUID.class));
-      verifyNoMoreInteractions(caseService);
-      verifyZeroInteractions(eventLogger);
-
-      throw expectedException;
     }
+    assertThat(actualExceptionThrown).isTrue();
+    verify(caseService, times(1)).getCaseByCaseId(any(UUID.class));
+    verifyNoMoreInteractions(caseService);
+    verifyZeroInteractions(eventLogger);
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/service/RefusalServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/RefusalServiceTest.java
@@ -24,6 +24,7 @@ import uk.gov.ons.census.casesvc.model.entity.EventType;
 public class RefusalServiceTest {
 
   private static final String REFUSAL_RECEIVED = "Refusal Received";
+  private static final String ESTAB_ADDRESS_LEVEL = "E";
   private static final UUID TEST_CASE_ID = UUID.randomUUID();
 
   @Mock private CaseService caseService;
@@ -80,7 +81,7 @@ public class RefusalServiceTest {
     managementEvent.getPayload().getRefusal().getCollectionCase().setId(TEST_CASE_ID.toString());
 
     Case testCase = getRandomCase();
-    testCase.setAddressLevel("E");
+    testCase.setAddressLevel(ESTAB_ADDRESS_LEVEL);
     OffsetDateTime messageTimestamp = OffsetDateTime.now();
 
     when(caseService.getCaseByCaseId(TEST_CASE_ID)).thenReturn(testCase);

--- a/src/test/java/uk/gov/ons/census/casesvc/service/RefusalServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/RefusalServiceTest.java
@@ -6,7 +6,6 @@ import static uk.gov.ons.census.casesvc.testutil.DataUtils.getRandomCase;
 import static uk.gov.ons.census.casesvc.testutil.DataUtils.getTestResponseManagementRefusalEvent;
 
 import java.time.OffsetDateTime;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,14 +26,11 @@ public class RefusalServiceTest {
   private static final String REFUSAL_RECEIVED = "Refusal Received";
   private static final UUID TEST_CASE_ID = UUID.randomUUID();
 
-  @Mock
-  private CaseService caseService;
+  @Mock private CaseService caseService;
 
-  @Mock
-  private EventLogger eventLogger;
+  @Mock private EventLogger eventLogger;
 
-  @InjectMocks
-  RefusalService underTest;
+  @InjectMocks RefusalService underTest;
 
   @Test
   public void testRefusalForCase() {
@@ -88,10 +84,11 @@ public class RefusalServiceTest {
     OffsetDateTime messageTimestamp = OffsetDateTime.now();
 
     when(caseService.getCaseByCaseId(TEST_CASE_ID)).thenReturn(testCase);
-    String expectedErrorMessage = String.format(
-        "Refusal received for Estab level case ID '%s' from channel '%s'. "
-            + "This type of refusal should ONLY come from Field",
-        testCase.getCaseId(), managementEvent.getEvent().getChannel());
+    String expectedErrorMessage =
+        String.format(
+            "Refusal received for Estab level case ID '%s' from channel '%s'. "
+                + "This type of refusal should ONLY come from Field",
+            testCase.getCaseId(), managementEvent.getEvent().getChannel());
 
     // WHEN
     try {

--- a/src/test/java/uk/gov/ons/census/casesvc/service/RefusalServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/RefusalServiceTest.java
@@ -6,6 +6,7 @@ import static uk.gov.ons.census.casesvc.testutil.DataUtils.getRandomCase;
 import static uk.gov.ons.census.casesvc.testutil.DataUtils.getTestResponseManagementRefusalEvent;
 
 import java.time.OffsetDateTime;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,14 +23,18 @@ import uk.gov.ons.census.casesvc.model.entity.EventType;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RefusalServiceTest {
+
   private static final String REFUSAL_RECEIVED = "Refusal Received";
   private static final UUID TEST_CASE_ID = UUID.randomUUID();
 
-  @Mock private CaseService caseService;
+  @Mock
+  private CaseService caseService;
 
-  @Mock private EventLogger eventLogger;
+  @Mock
+  private EventLogger eventLogger;
 
-  @InjectMocks RefusalService underTest;
+  @InjectMocks
+  RefusalService underTest;
 
   @Test
   public void testRefusalForCase() {
@@ -69,5 +74,37 @@ public class RefusalServiceTest {
             anyString(),
             eq(messageTimestamp));
     verifyNoMoreInteractions(eventLogger);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testRefusalNotFromFieldForEstabAddressLevelCaseThrowsException() {
+    // GIVEN
+    ResponseManagementEvent managementEvent = getTestResponseManagementRefusalEvent();
+    managementEvent.getEvent().setChannel("NOT FROM FIELD");
+    managementEvent.getPayload().getRefusal().getCollectionCase().setId(TEST_CASE_ID.toString());
+
+    Case testCase = getRandomCase();
+    testCase.setAddressLevel("E");
+    OffsetDateTime messageTimestamp = OffsetDateTime.now();
+
+    when(caseService.getCaseByCaseId(TEST_CASE_ID)).thenReturn(testCase);
+    String expectedErrorMessage = String.format(
+        "Refusal received for Estab level case ID '%s' from channel '%s'. "
+            + "This type of refusal should ONLY come from Field",
+        testCase.getCaseId(), managementEvent.getEvent().getChannel());
+
+    // WHEN
+    try {
+      underTest.processRefusal(managementEvent, messageTimestamp);
+    } catch (RuntimeException expectedException) {
+      // THEN
+      assertThat(expectedException.getMessage()).isEqualTo(expectedErrorMessage);
+
+      verify(caseService, times(1)).getCaseByCaseId(any(UUID.class));
+      verifyNoMoreInteractions(caseService);
+      verifyZeroInteractions(eventLogger);
+
+      throw expectedException;
+    }
   }
 }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to throw a RunTimeException if we receive a refusal message for an estab address level case from a non-Field channel, which shouldn't happen. This is to allow ops support to identify which channel sent the message (as we're only expecting these to come from Field).

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Add check after retrieving the case to see if the address level is `E`.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run maven build and acceptance tests against the links in this PR. There should be no regression.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/i0aebEJC/534-handle-ce-and-spg-refusals-for-estab-address-level-cases-5

https://github.com/ONSdigital/census-rm-fieldwork-adapter/pull/27