### PR TITLE
Use case events for unscheduled field notifications

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiver.java
@@ -51,7 +51,7 @@ public class UndeliveredMailReceiver {
     }
 
     caze.setUndeliveredAsAddressed(true);
-    caseService.saveAndEmitCaseUpdatedEvent(caze);
+    caseService.saveCaseAndEmitCaseUpdatedEvent(caze);
 
     if (uacQidLink != null) {
       eventLogger.logUacQidEvent(

--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/ActionInstructionType.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/ActionInstructionType.java
@@ -1,0 +1,9 @@
+package uk.gov.ons.census.casesvc.model.dto;
+
+public enum ActionInstructionType {
+  CREATE,
+  UPDATE,
+  PAUSE,
+  REACTIVATE,
+  CLOSE
+}

--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/Metadata.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/Metadata.java
@@ -1,0 +1,9 @@
+package uk.gov.ons.census.casesvc.model.dto;
+
+import lombok.Data;
+
+@Data
+public class Metadata {
+  private ActionInstructionType fieldDecision;
+  private EventTypeDTO causeEventType;
+}

--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/PayloadDTO.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/PayloadDTO.java
@@ -19,6 +19,7 @@ public class PayloadDTO {
   private InvalidAddress invalidAddress;
   private FieldCaseSelected fieldCaseSelected;
   private FulfilmentInformation fulfilmentInformation;
+  private Metadata metadata;
 
   @JsonProperty("CCSProperty")
   private CCSPropertyDTO ccsProperty;

--- a/src/main/java/uk/gov/ons/census/casesvc/service/CaseReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CaseReceiptService.java
@@ -1,8 +1,11 @@
 package uk.gov.ons.census.casesvc.service;
 
+import static uk.gov.ons.census.casesvc.utility.MetadataHelper.buildMetadata;
 import static uk.gov.ons.census.casesvc.utility.QuestionnaireTypeHelper.iscontinuationQuestionnaireTypes;
 
 import org.springframework.stereotype.Component;
+import uk.gov.ons.census.casesvc.model.dto.ActionInstructionType;
+import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
 import uk.gov.ons.census.casesvc.model.entity.Case;
 import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 
@@ -14,14 +17,15 @@ public class CaseReceiptService {
     this.caseService = caseService;
   }
 
-  public void receiptCase(UacQidLink uacQidLink) {
+  public void receiptCase(UacQidLink uacQidLink, EventTypeDTO causeEventType) {
     Case caze = uacQidLink.getCaze();
 
     if (caze.isReceiptReceived()) return;
 
     if (!iscontinuationQuestionnaireTypes(uacQidLink.getQid())) {
       caze.setReceiptReceived(true);
-      caseService.saveAndEmitCaseUpdatedEvent(caze);
+      caseService.saveCaseAndEmitCaseUpdatedEvent(
+          caze, buildMetadata(causeEventType, ActionInstructionType.CLOSE));
     }
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/CaseReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CaseReceiptService.java
@@ -1,17 +1,16 @@
 package uk.gov.ons.census.casesvc.service;
 
+import static uk.gov.ons.census.casesvc.utility.MetadataHelper.buildMetadata;
+import static uk.gov.ons.census.casesvc.utility.QuestionnaireTypeHelper.isIndividualQuestionnaireType;
+import static uk.gov.ons.census.casesvc.utility.QuestionnaireTypeHelper.iscontinuationQuestionnaireTypes;
+
+import java.util.Optional;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.census.casesvc.model.dto.ActionInstructionType;
 import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
 import uk.gov.ons.census.casesvc.model.entity.Case;
 import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
-
-import java.util.Optional;
-
-import static uk.gov.ons.census.casesvc.utility.MetadataHelper.buildMetadata;
-import static uk.gov.ons.census.casesvc.utility.QuestionnaireTypeHelper.isIndividualQuestionnaireType;
-import static uk.gov.ons.census.casesvc.utility.QuestionnaireTypeHelper.iscontinuationQuestionnaireTypes;
 
 @Component
 public class CaseReceiptService {

--- a/src/main/java/uk/gov/ons/census/casesvc/service/EventService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/EventService.java
@@ -36,7 +36,7 @@ public class EventService {
         QuestionnaireTypeHelper.calculateQuestionnaireType(caze.getTreatmentCode());
     UacQidLink uacQidLink = uacService.buildUacQidLink(caze, questionnaireType);
     uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
-    caseService.saveAndEmitCaseCreatedEvent(caze);
+    caseService.saveCaseAndEmitCaseCreatedEvent(caze);
 
     eventLogger.logCaseEvent(
         caze,

--- a/src/main/java/uk/gov/ons/census/casesvc/service/QidReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/QidReceiptService.java
@@ -40,7 +40,7 @@ public class QidReceiptService {
     Case caze = uacQidLink.getCaze();
 
     if (caze != null) {
-      caseReceiptService.receiptCase(uacQidLink);
+      caseReceiptService.receiptCase(uacQidLink, receiptEvent.getEvent().getType());
     } else {
       log.with("qid", receiptPayload.getQuestionnaireId())
           .with("tx_id", receiptEvent.getEvent().getTransactionId())

--- a/src/main/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedService.java
@@ -52,7 +52,7 @@ public class QuestionnaireLinkedService {
     uacQidLink.setCaze(caze);
 
     if (!uacQidLink.isActive()) {
-      caseReceiptService.receiptCase(uacQidLink);
+      caseReceiptService.receiptCase(uacQidLink, questionnaireLinkedEvent.getEvent().getType());
     }
 
     uacService.saveAndEmitUacUpdatedEvent(uacQidLink);

--- a/src/main/java/uk/gov/ons/census/casesvc/utility/EventHelper.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/utility/EventHelper.java
@@ -4,11 +4,13 @@ import java.time.OffsetDateTime;
 import java.util.UUID;
 import uk.gov.ons.census.casesvc.model.dto.EventDTO;
 import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
+import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 
 public class EventHelper {
 
   private static final String EVENT_SOURCE = "CASE_SERVICE";
   private static final String EVENT_CHANNEL = "RM";
+  private static final String FIELD_CHANNEL = "FIELD";
 
   public static EventDTO createEventDTO(EventTypeDTO eventType) {
     EventDTO eventDTO = new EventDTO();
@@ -20,5 +22,9 @@ public class EventHelper {
     eventDTO.setType(eventType);
 
     return eventDTO;
+  }
+
+  public static boolean isEventChannelField(ResponseManagementEvent event) {
+    return event.getEvent().getChannel().equalsIgnoreCase(FIELD_CHANNEL);
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/utility/MetadataHelper.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/utility/MetadataHelper.java
@@ -1,0 +1,16 @@
+package uk.gov.ons.census.casesvc.utility;
+
+import uk.gov.ons.census.casesvc.model.dto.ActionInstructionType;
+import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
+import uk.gov.ons.census.casesvc.model.dto.Metadata;
+
+public class MetadataHelper {
+
+  public static Metadata buildMetadata(
+      EventTypeDTO eventType, ActionInstructionType actionInstructionType) {
+    Metadata metadata = new Metadata();
+    metadata.setCauseEventType(eventType);
+    metadata.setFieldDecision(actionInstructionType);
+    return metadata;
+  }
+}

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/InvalidAddressReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/InvalidAddressReceiverIT.java
@@ -35,6 +35,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.ons.census.casesvc.model.dto.ActionInstructionType;
 import uk.gov.ons.census.casesvc.model.dto.CollectionCase;
 import uk.gov.ons.census.casesvc.model.dto.CollectionCaseCaseId;
 import uk.gov.ons.census.casesvc.model.dto.EventDTO;
@@ -132,6 +133,12 @@ public class InvalidAddressReceiverIT {
     Case actualCase = caseRepository.findByCaseId(TEST_CASE_ID).get();
     assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
     assertThat(actualCase.isAddressInvalid()).isTrue();
+
+    // check the metadata is included with field close decision
+    assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
+        .isEqualTo(ActionInstructionType.CLOSE);
+    assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
+        .isEqualTo(EventTypeDTO.ADDRESS_NOT_VALID);
 
     // check database for log eventDTO
     List<Event> events = eventRepository.findAll();

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
@@ -28,6 +28,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.ons.census.casesvc.model.dto.ActionInstructionType;
 import uk.gov.ons.census.casesvc.model.dto.CollectionCase;
 import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
@@ -126,6 +127,12 @@ public class ReceiptReceiverIT {
     CollectionCase actualCollectionCase = responseManagementEvent.getPayload().getCollectionCase();
     assertThat(actualCollectionCase.getId()).isEqualTo(TEST_CASE_ID.toString());
     assertThat(actualCollectionCase.getReceiptReceived()).isTrue();
+
+    // check the metadata is included with field close decision
+    assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
+        .isEqualTo(ActionInstructionType.CLOSE);
+    assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
+        .isEqualTo(EventTypeDTO.RESPONSE_RECEIVED);
 
     responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(rhUacOutboundQueue);
     assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.UAC_UPDATED);

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverIT.java
@@ -25,6 +25,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.ons.census.casesvc.model.dto.ActionInstructionType;
 import uk.gov.ons.census.casesvc.model.dto.EventDTO;
 import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
 import uk.gov.ons.census.casesvc.model.dto.RefusalDTO;
@@ -115,6 +116,12 @@ public class RefusalReceiverIT {
     assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
     assertThat(actualCase.isRefusalReceived()).isTrue();
     assertThat(actualCase.getLastUpdated()).isNotEqualTo(cazeCreatedTime);
+
+    // check the metadata is included with field close decision
+    assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
+        .isEqualTo(ActionInstructionType.CLOSE);
+    assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
+        .isEqualTo(EventTypeDTO.REFUSAL_RECEIVED);
 
     List<Event> events = eventRepository.findAll();
     assertThat(events.size()).isEqualTo(1);

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiverTest.java
@@ -56,7 +56,7 @@ public class UndeliveredMailReceiverTest {
 
     // Then
     ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
-    verify(caseService).saveAndEmitCaseUpdatedEvent(caseArgumentCaptor.capture());
+    verify(caseService).saveCaseAndEmitCaseUpdatedEvent(caseArgumentCaptor.capture());
     Case actualCase = caseArgumentCaptor.getValue();
     assertThat(actualCase).isEqualTo(caze);
     assertThat(caseArgumentCaptor.getValue().isUndeliveredAsAddressed()).isTrue();
@@ -104,7 +104,7 @@ public class UndeliveredMailReceiverTest {
 
     // Then
     ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
-    verify(caseService).saveAndEmitCaseUpdatedEvent(caseArgumentCaptor.capture());
+    verify(caseService).saveCaseAndEmitCaseUpdatedEvent(caseArgumentCaptor.capture());
     Case actualCase = caseArgumentCaptor.getValue();
     assertThat(actualCase).isEqualTo(caze);
     assertThat(caseArgumentCaptor.getValue().isUndeliveredAsAddressed()).isTrue();

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTest.java
@@ -3,6 +3,7 @@ package uk.gov.ons.census.casesvc.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
+import static uk.gov.ons.census.casesvc.model.dto.EventTypeDTO.RESPONSE_RECEIVED;
 
 import java.util.UUID;
 import org.junit.Test;
@@ -11,6 +12,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.ons.census.casesvc.model.dto.ActionInstructionType;
+import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
+import uk.gov.ons.census.casesvc.model.dto.Metadata;
 import uk.gov.ons.census.casesvc.model.entity.Case;
 import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 
@@ -35,13 +39,19 @@ public class CaseReceiptServiceTest {
     uacQidLink.setQid(HOUSEHOLD_INDIVIDUAL_QUESTIONNAIRE_REQUEST_ENGLAND);
     uacQidLink.setCaze(caze);
 
-    underTest.receiptCase(uacQidLink);
+    underTest.receiptCase(uacQidLink, EventTypeDTO.RESPONSE_RECEIVED);
 
     ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
-    verify(caseService).saveAndEmitCaseUpdatedEvent(caseArgumentCaptor.capture());
+    ArgumentCaptor<Metadata> metadataArgumentCaptor = ArgumentCaptor.forClass(Metadata.class);
+    verify(caseService)
+        .saveCaseAndEmitCaseUpdatedEvent(
+            caseArgumentCaptor.capture(), metadataArgumentCaptor.capture());
     Case actualCase = caseArgumentCaptor.getValue();
     assertThat(actualCase.getCaseId()).as("Case Id saved").isEqualTo(caze.getCaseId());
     assertThat(actualCase.isReceiptReceived()).as("Case Reecipted").isEqualTo(true);
+    Metadata metadata = metadataArgumentCaptor.getValue();
+    assertThat(metadata.getCauseEventType()).isEqualTo(RESPONSE_RECEIVED);
+    assertThat(metadata.getFieldDecision()).isEqualTo(ActionInstructionType.CLOSE);
   }
 
   @Test
@@ -56,7 +66,7 @@ public class CaseReceiptServiceTest {
     uacQidLink.setQid(HOUSEHOLD_INDIVIDUAL_QUESTIONNAIRE_REQUEST_ENGLAND);
     uacQidLink.setCaze(caze);
 
-    underTest.receiptCase(uacQidLink);
+    underTest.receiptCase(uacQidLink, EventTypeDTO.RESPONSE_RECEIVED);
     verifyZeroInteractions(caseService);
   }
 
@@ -72,7 +82,7 @@ public class CaseReceiptServiceTest {
     uacQidLink.setQid(ENGLAND_HOUSEHOLD_CONTINUATION);
     uacQidLink.setCaze(caze);
 
-    underTest.receiptCase(uacQidLink);
+    underTest.receiptCase(uacQidLink, EventTypeDTO.RESPONSE_RECEIVED);
     verifyZeroInteractions(caseService);
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTest.java
@@ -112,7 +112,7 @@ public class CaseReceiptServiceTest {
     verify(caseRepository).getCaseAndLockByCaseId(caze.getCaseId());
 
     ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
-    verify(caseService).saveCaseAndEmitCaseUpdatedEvent(caseArgumentCaptor.capture());
+    verify(caseService).saveCaseAndEmitCaseUpdatedEvent(caseArgumentCaptor.capture(), any());
     Case actualCase = caseArgumentCaptor.getValue();
     assertThat(actualCase.getCaseId()).isEqualTo(caze.getCaseId());
     assertThat(actualCase.getCeActualResponses()).isEqualTo(2);
@@ -143,7 +143,7 @@ public class CaseReceiptServiceTest {
     verify(caseRepository).getCaseAndLockByCaseId(caze.getCaseId());
 
     ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
-    verify(caseService).saveCaseAndEmitCaseUpdatedEvent(caseArgumentCaptor.capture());
+    verify(caseService).saveCaseAndEmitCaseUpdatedEvent(caseArgumentCaptor.capture(), any());
     Case actualCase = caseArgumentCaptor.getValue();
     assertThat(actualCase.getCaseId()).isEqualTo(caze.getCaseId());
     assertThat(actualCase.getCeActualResponses()).isEqualTo(2);

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
@@ -185,7 +185,7 @@ public class CaseServiceTest {
     ReflectionTestUtils.setField(underTest, "outboundExchange", TEST_EXCHANGE);
 
     // When
-    underTest.saveAndEmitCaseCreatedEvent(caze);
+    underTest.saveCaseAndEmitCaseCreatedEvent(caze);
 
     // Then
     verify(caseRepository).saveAndFlush(eq(caze));

--- a/src/test/java/uk/gov/ons/census/casesvc/service/EventServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/EventServiceTest.java
@@ -45,7 +45,7 @@ public class EventServiceTest {
     UacQidLink uacQidLink = new UacQidLink();
     when(uacService.buildUacQidLink(caze, 1)).thenReturn(uacQidLink);
     when(uacService.saveAndEmitUacUpdatedEvent(any(UacQidLink.class))).thenReturn(new PayloadDTO());
-    when(caseService.saveAndEmitCaseCreatedEvent(any(Case.class))).thenReturn(new PayloadDTO());
+    when(caseService.saveCaseAndEmitCaseCreatedEvent(any(Case.class))).thenReturn(new PayloadDTO());
 
     OffsetDateTime messageTimestamp = OffsetDateTime.now();
 
@@ -56,7 +56,7 @@ public class EventServiceTest {
     verify(caseService).saveCaseSample(createCaseSample);
     verify(uacService).buildUacQidLink(eq(caze), eq(1));
     verify(uacService).saveAndEmitUacUpdatedEvent(uacQidLink);
-    verify(caseService).saveAndEmitCaseCreatedEvent(caze);
+    verify(caseService).saveCaseAndEmitCaseCreatedEvent(caze);
 
     verify(eventLogger, times(1))
         .logCaseEvent(
@@ -81,7 +81,7 @@ public class EventServiceTest {
     when(uacService.buildUacQidLink(caze, 2)).thenReturn(uacQidLink);
     when(uacService.buildUacQidLink(caze, 3)).thenReturn(secondUacQidLink);
     when(uacService.saveAndEmitUacUpdatedEvent(any(UacQidLink.class))).thenReturn(new PayloadDTO());
-    when(caseService.saveAndEmitCaseCreatedEvent(any(Case.class))).thenReturn(new PayloadDTO());
+    when(caseService.saveCaseAndEmitCaseCreatedEvent(any(Case.class))).thenReturn(new PayloadDTO());
 
     OffsetDateTime messageTimestamp = OffsetDateTime.now();
 
@@ -92,7 +92,7 @@ public class EventServiceTest {
     verify(caseService).saveCaseSample(createCaseSample);
     verify(uacService, times(1)).buildUacQidLink(eq(caze), eq(2));
     verify(uacService, times(2)).saveAndEmitUacUpdatedEvent(uacQidLink);
-    verify(caseService).saveAndEmitCaseCreatedEvent(caze);
+    verify(caseService).saveCaseAndEmitCaseCreatedEvent(caze);
 
     verify(eventLogger, times(1))
         .logCaseEvent(

--- a/src/test/java/uk/gov/ons/census/casesvc/service/QidReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/QidReceiptServiceTest.java
@@ -57,7 +57,8 @@ public class QidReceiptServiceTest {
     verify(uacService).findByQid(anyString());
 
     ArgumentCaptor<UacQidLink> uacQidLinkArgumentCaptor = ArgumentCaptor.forClass(UacQidLink.class);
-    verify(caseReceiptService).receiptCase(uacQidLinkArgumentCaptor.capture());
+    verify(caseReceiptService)
+        .receiptCase(uacQidLinkArgumentCaptor.capture(), eq(managementEvent.getEvent().getType()));
     Case actualCase = uacQidLinkArgumentCaptor.getValue().getCaze();
     assertThat(actualCase.isReceiptReceived()).isFalse();
     assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");

--- a/src/test/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedServiceTest.java
@@ -130,7 +130,9 @@ public class QuestionnaireLinkedServiceTest {
     verifyNoMoreInteractions(caseService);
 
     ArgumentCaptor<UacQidLink> uacQidLinkArgumentCaptor = ArgumentCaptor.forClass(UacQidLink.class);
-    inOrder.verify(caseReceiptService).receiptCase(uacQidLinkArgumentCaptor.capture());
+    inOrder
+        .verify(caseReceiptService)
+        .receiptCase(uacQidLinkArgumentCaptor.capture(), eq(managementEvent.getEvent().getType()));
     assertThat(uacQidLinkArgumentCaptor.getValue().getCaze().getCaseId()).isEqualTo(TEST_CASE_ID_1);
     assertThat(uacQidLinkArgumentCaptor.getValue().getQid()).isEqualTo(TEST_HI_QID);
     verifyNoMoreInteractions(caseReceiptService);
@@ -408,7 +410,8 @@ public class QuestionnaireLinkedServiceTest {
     verifyNoMoreInteractions(caseService);
 
     ArgumentCaptor<UacQidLink> uacQidLinkArgumentCaptor = ArgumentCaptor.forClass(UacQidLink.class);
-    verify(caseReceiptService).receiptCase(uacQidLinkArgumentCaptor.capture());
+    verify(caseReceiptService)
+        .receiptCase(uacQidLinkArgumentCaptor.capture(), eq(linkingEvent.getEvent().getType()));
     assertThat(uacQidLinkArgumentCaptor.getValue().getCaze().getCaseId())
         .as("CaseReceipter receiptHandler Case Id")
         .isEqualTo(TEST_CASE_ID_1);


### PR DESCRIPTION
# Motivation and Context
We are refactoring the way unscheduled field notifications are sent. The fieldwork adapter now subscribes to case events and sends whatever field notification is specified by a new fieldDecision metadata field.

# What has changed
* Add metadata DTO and action instruction type enum
* Set field instruction and cause event type on receipts, refusals and address invalid case updated events
* Don't set field decision if it is  if the source channel of refusal and invalid address events is field
* Update unit tests

# How to test?
Build and run with the linked branches of docker dev, fieldwork adapter, acceptance tests

# Links
https://trello.com/c/K9lfLHAs/609-refactor-fieldwork-receipting-21
https://github.com/ONSdigital/census-rm-fieldwork-adapter/pull/29
https://github.com/ONSdigital/census-rm-docker-dev/pull/48
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/184