### PR TITLE
Allow null region in address DTO builder

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
@@ -166,7 +166,6 @@ public class CaseService {
     address.setAddressType(caze.getAddressType());
     address.setArid(caze.getArid());
     address.setEstabArid(caze.getEstabArid());
-    address.setRegion(caze.getRegion().substring(0, 1));
     address.setEstabType(caze.getEstabType());
     address.setLatitude(caze.getLatitude());
     address.setLongitude(caze.getLongitude());
@@ -176,7 +175,9 @@ public class CaseService {
     address.setOrganisationName(caze.getOrganisationName());
     address.setUprn(caze.getUprn());
     address.setAddressLevel(caze.getAddressLevel());
-
+    if (caze.getRegion() != null) {
+      address.setRegion(caze.getRegion().substring(0, 1));
+    }
     return address;
   }
 

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.ons.census.casesvc.model.dto.CollectionCase;
 import uk.gov.ons.census.casesvc.model.dto.CreateCaseSample;
+import uk.gov.ons.census.casesvc.model.dto.PayloadDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.casesvc.model.dto.SampleUnitDTO;
 import uk.gov.ons.census.casesvc.model.entity.Case;
@@ -249,5 +250,18 @@ public class CaseServiceTest {
 
     // Then
     assertThat(treatmentCodeResult).isFalse();
+  }
+
+  @Test
+  public void testSaveAndEmitCaseEventWithNullRegion() {
+    // Given
+    Case caze = getRandomCase();
+    caze.setRegion(null);
+
+    // When
+    PayloadDTO payload = underTest.saveCaseAndEmitCaseCreatedEvent(caze);
+
+    // Then
+    assertThat(payload.getCollectionCase().getAddress().getRegion()).isNull();
   }
 }


### PR DESCRIPTION
# Motivation and Context
We were getting null pointer exceptions because the address builder relied on region being set

# What has changed
* Allow null region in address DTO builder
* Add unit test

# How to test?
Build and run acceptance tests

# Links
https://trello.com/c/1F5lJNLo/630-ccs-refusal-messages-fail-in-case-processor