### PR TITLE
Add handDelivery to outbound CCS msgs

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/CcsToFwmt.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/CcsToFwmt.java
@@ -21,4 +21,5 @@ public class CcsToFwmt {
   private String surveyName;
   private Boolean undeliveredAsAddress;
   private Boolean blankQreReturned;
+  private boolean handDelivery;
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/CcsToFieldService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CcsToFieldService.java
@@ -44,6 +44,7 @@ public class CcsToFieldService {
     ccsToField.setUndeliveredAsAddress(false);
     ccsToField.setSurveyName(caze.getSurvey());
     ccsToField.setBlankQreReturned(false);
+    ccsToField.setHandDelivery(caze.isHandDelivery());
 
     return ccsToField;
   }

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CcsToFieldServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CcsToFieldServiceTest.java
@@ -69,6 +69,7 @@ public class CcsToFieldServiceTest {
     ccsToField.setUndeliveredAsAddress(false);
     ccsToField.setSurveyName(caze.getSurvey());
     ccsToField.setBlankQreReturned(false);
+    ccsToField.setHandDelivery(caze.isHandDelivery());
 
     return ccsToField;
   }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As we're (currently) including the `handDelivery` flag on all outgoing messages to fieldwork, we need to make sure this is also set for CCS cases as well.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Add handDelivery attribute to CCS to FWMT bits

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run against branches below

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/esdStYzJ/514-rmc-317-make-hand-delivery-flag-in-outbound-field-messages-dynamic-based-on-treatment-code-8

ONSdigital/census-rm-fieldwork-adapter#30
ONSdigital/census-rm-acceptance-tests#191
ONSdigital/census-rm-ddl#38
ONSdigital/census-rm-action-worker#10
https://github.com/ONSdigital/census-rm-action-scheduler/pull/65