### PR TITLE
stop return Cont from FormTypeHelper

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/CaseReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CaseReceiptService.java
@@ -2,6 +2,7 @@ package uk.gov.ons.census.casesvc.service;
 
 import static uk.gov.ons.census.casesvc.utility.FormTypeHelper.mapQuestionnaireTypeToFormType;
 import static uk.gov.ons.census.casesvc.utility.MetadataHelper.buildMetadata;
+import static uk.gov.ons.census.casesvc.utility.QuestionnaireTypeHelper.iscontinuationQuestionnaireTypes;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -86,7 +87,14 @@ public class CaseReceiptService {
   }
 
   private Key makeRulesKey(Case caze, UacQidLink uacQidLink) {
-    String formType = mapQuestionnaireTypeToFormType(uacQidLink.getQid());
+    String formType;
+
+    if (iscontinuationQuestionnaireTypes(uacQidLink.getQid())) {
+      formType = "Cont";
+    } else {
+      formType = mapQuestionnaireTypeToFormType(uacQidLink.getQid());
+    }
+
     return new Key(caze.getCaseType(), caze.getAddressLevel(), formType);
   }
 

--- a/src/main/java/uk/gov/ons/census/casesvc/utility/FormTypeHelper.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/utility/FormTypeHelper.java
@@ -4,7 +4,6 @@ public class FormTypeHelper {
   private static final String HH_FORM_TYPE = "H";
   private static final String IND_FORM_TYPE = "I";
   private static final String CE1_FORM_TYPE = "C";
-  private static final String CONTINUATION = "Cont";
 
   public static String mapQuestionnaireTypeToFormType(String qid) {
     int questionnaireType = Integer.parseInt(qid.substring(0, 2));
@@ -15,11 +14,6 @@ public class FormTypeHelper {
       case 3:
       case 4:
         return HH_FORM_TYPE;
-      case 11:
-      case 12:
-      case 13:
-      case 14:
-        return CONTINUATION;
       case 21:
       case 22:
       case 23:
@@ -35,9 +29,6 @@ public class FormTypeHelper {
       case 53:
       case 54:
         return HH_FORM_TYPE;
-      case 61:
-      case 63:
-        return CONTINUATION;
       case 71:
       case 72:
       case 73:


### PR DESCRIPTION
# Motivation and Context
Was returning a Cont for Continuation Types from FormTypeHelper, should be null

# What has changed
returns null from FormTypeHelper for Continuation Types

# How to test?
With master ATs
