### PR TITLE
removed testCachingTopUp unit test that was flakey in concourse due t…

### DIFF
--- a/src/test/java/uk/gov/ons/census/casesvc/cache/UacQidCacheTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/cache/UacQidCacheTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.*;
 import java.util.ArrayList;
 import java.util.List;
 import org.jeasy.random.EasyRandom;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;

--- a/src/test/java/uk/gov/ons/census/casesvc/cache/UacQidCacheTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/cache/UacQidCacheTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 import java.util.ArrayList;
 import java.util.List;
 import org.jeasy.random.EasyRandom;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -24,31 +25,6 @@ public class UacQidCacheTest {
   @Mock UacQidServiceClient uacQidServiceClient;
 
   @InjectMocks UacQidCache underTest;
-
-  @Test
-  public void testCachingTopUp() throws InterruptedException {
-    // given
-    ReflectionTestUtils.setField(underTest, "cacheFetch", CACHE_FETCH);
-    ReflectionTestUtils.setField(underTest, "cacheMin", CACHE_MIN);
-    ReflectionTestUtils.setField(underTest, "uacQidGetTimout", 10);
-
-    List<UacQidDTO> uacQids1 = populateUacQidList(1, CACHE_FETCH);
-    when(uacQidServiceClient.getUacQids(anyInt(), anyInt())).thenReturn(uacQids1);
-
-    List<UacQidDTO> actualUacQidDtos1 = new ArrayList<>();
-
-    // when  - 1st call as cache is empty
-    actualUacQidDtos1.add(underTest.getUacQidPair(1));
-    verify(uacQidServiceClient, times(1)).getUacQids(eq(1), eq(CACHE_FETCH));
-
-    // when - some more are called this should top it up
-    actualUacQidDtos1.add(underTest.getUacQidPair(1));
-    actualUacQidDtos1.add(underTest.getUacQidPair(1));
-    actualUacQidDtos1.add(underTest.getUacQidPair(1));
-
-    verify(uacQidServiceClient, atLeast(2)).getUacQids(eq(1), eq(CACHE_FETCH));
-    assertThat(actualUacQidDtos1.get(0)).isEqualTo(uacQids1.get(0));
-  }
 
   @Test
   public void testToppingUpRecoversFromFailure() {

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
@@ -122,9 +122,9 @@ public class SampleReceiverIT {
   }
 
   @Test
-  public void test1000SamplesExercisingUacQidCaching() throws InterruptedException {
+  public void test100SamplesExercisingUacQidCaching() throws InterruptedException {
     // GIVEN
-    int expectedSize = 1000;
+    int expectedSize = 100;
 
     List<String> treatmentCodes =
         Arrays.asList(
@@ -163,7 +163,7 @@ public class SampleReceiverIT {
               rabbitQueueHelper.sendMessage(inboundQueue, c);
             });
 
-    for (int i = 0; i < 20; i++) {
+    for (int i = 0; i < 10; i++) {
       Thread.sleep(2000);
       List<Case> caseList = caseRepository.findAll();
 

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
@@ -122,9 +122,9 @@ public class SampleReceiverIT {
   }
 
   @Test
-  public void test100SamplesExercisingUacQidCaching() throws InterruptedException {
+  public void test1000SamplesExercisingUacQidCaching() throws InterruptedException {
     // GIVEN
-    int expectedSize = 100;
+    int expectedSize = 1000;
 
     List<String> treatmentCodes =
         Arrays.asList(

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
@@ -163,7 +163,7 @@ public class SampleReceiverIT {
               rabbitQueueHelper.sendMessage(inboundQueue, c);
             });
 
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 20; i++) {
       Thread.sleep(2000);
       List<Case> caseList = caseRepository.findAll();
 


### PR DESCRIPTION
Flakey test removed, without reducing code coverage.

To test, all tests should still pass.  Code coverage should not be reduced

I ran the SampleReceiverIT test1000SamplesExercisingUacQidCaching in debug mode with lots of breakpoints on the UacQidCache class to prove that it's doing plenty of topping up.  The fetch count in the test .yml is very small:   uacqid-cache-min: 5, uacqid-fetch-count: 10 so the code is exercised well.

 https://trello.com/c/Zblqw0Md/658-spike-resource-dependent-test-in-case-processor-fails-in-concourse-2-days