### PR TITLE
Add missing indexes and fix other DDL mismatch

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.Data;
@@ -15,7 +16,12 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 @Data
 @Entity
-@Table(name = "cases")
+@Table(
+    name = "cases",
+    indexes = {
+      @Index(name = "cases_case_ref_idx", columnList = "case_ref"),
+      @Index(name = "lsoa_idx", columnList = "lsoa")
+    })
 public class Case {
 
   @Id private UUID caseId;
@@ -25,7 +31,8 @@ public class Case {
   @Generated(GenerationTime.INSERT)
   private int secretSequenceNumber;
 
-  @Column private Integer caseRef;
+  @Column(name = "case_ref")
+  private Integer caseRef;
 
   @Column private String arid;
 
@@ -61,7 +68,8 @@ public class Case {
 
   @Column private String oa;
 
-  @Column private String lsoa;
+  @Column(name = "lsoa")
+  private String lsoa;
 
   @Column private String msoa;
 

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/Event.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/Event.java
@@ -8,7 +8,9 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 import lombok.Data;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
@@ -17,6 +19,11 @@ import org.hibernate.annotations.TypeDefs;
 @Data
 @TypeDefs({@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)})
 @Entity
+@Table(
+    indexes = {
+      @Index(name = "event_type_idx", columnList = "event_type"),
+      @Index(name = "rm_event_processed_idx", columnList = "rm_event_processed")
+    })
 public class Event {
   @Id private UUID id;
 
@@ -29,10 +36,10 @@ public class Event {
 
   @Column private String eventDescription;
 
-  @Column(columnDefinition = "timestamp with time zone")
+  @Column(name = "rm_event_processed", columnDefinition = "timestamp with time zone")
   private OffsetDateTime rmEventProcessed;
 
-  @Column
+  @Column(name = "event_type")
   @Enumerated(EnumType.STRING)
   private EventType eventType;
 

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/UacQidLink.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/UacQidLink.java
@@ -5,16 +5,20 @@ import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.Table;
 import lombok.Data;
 
 @Data
 @Entity
+@Table(indexes = {@Index(name = "qid_idx", columnList = "qid")})
 public class UacQidLink {
   @Id private UUID id;
 
-  @Column private String qid;
+  @Column(name = "qid")
+  private String qid;
 
   @Column private String uac;
 


### PR DESCRIPTION
# Motivation and Context
Hibernate does not set up the same database config in a dev GCP env as it does in an env built from the DDL scripts.

# What has changed
Fixed mismatches.

# How to test?
Build and run into empty database. Using a **reliable** DB inspection tool (i.e. not DataGrip) check the missing indexes are present.

# Links
Trello: https://trello.com/c/ybEYuI66