### PR TITLE
Send CLOSE to FWMT for CE U where AR >= ER

### DIFF
--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTest.java
@@ -52,7 +52,7 @@ public class CaseReceiptServiceTest {
       {new Key("CE", "E", "CE1"), new Expectation("N", "Y", ActionInstructionType.UPDATE)},
       {new Key("CE", "E", "Cont"), new Expectation(RuntimeException.class)},
       {new Key("CE", "E", "HH"), new Expectation(RuntimeException.class)},
-      {new Key("CE", "U", "Ind"), new Expectation("Y", "Y AR >= ER", ActionInstructionType.UPDATE)},
+      {new Key("CE", "U", "Ind"), new Expectation("Y", "Y AR >= ER", ActionInstructionType.CLOSE)},
       {new Key("CE", "U", "Ind"), new Expectation("Y", "N AR < ER", ActionInstructionType.UPDATE)},
       {new Key("CE", "U", "CE1"), new Expectation(RuntimeException.class)},
       {new Key("CE", "U", "Cont"), new Expectation(RuntimeException.class)},


### PR DESCRIPTION
# Motivation and Context
When we reach the number of actual responses for a Communal Establishment Unit (e.g. a university halls of residence dorm) then we want to send FWMT a CLOSE instead of an UPDATE.

# What has changed
Created a new bespoke rule which kindly does the needful.

# How to test?
Run the ATs.

Create a CE U case with an expected response count of 2. Link 2 uac-qid pairs to the case. Receipt the QIDs. When the second QID is receipted, a FWMT CLOSE should be sent.

# Links
Trello: https://trello.com/c/GapIaH4L