### PR TITLE
Set field decision CREATE on UAA case updates

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiver.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.census.casesvc.messaging;
 
 import static uk.gov.ons.census.casesvc.utility.JsonHelper.convertObjectToJson;
+import static uk.gov.ons.census.casesvc.utility.MetadataHelper.buildMetadata;
 import static uk.gov.ons.census.casesvc.utility.MsgDateHelper.getMsgTimeStamp;
 
 import java.time.OffsetDateTime;
@@ -10,6 +11,7 @@ import org.springframework.messaging.Message;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import uk.gov.ons.census.casesvc.logging.EventLogger;
+import uk.gov.ons.census.casesvc.model.dto.ActionInstructionType;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.casesvc.model.entity.Case;
 import uk.gov.ons.census.casesvc.model.entity.EventType;
@@ -51,7 +53,8 @@ public class UndeliveredMailReceiver {
     }
 
     caze.setUndeliveredAsAddressed(true);
-    caseService.saveCaseAndEmitCaseUpdatedEvent(caze);
+    caseService.saveCaseAndEmitCaseUpdatedEvent(
+        caze, buildMetadata(event.getEvent().getType(), ActionInstructionType.CREATE));
 
     if (uacQidLink != null) {
       eventLogger.logUacQidEvent(

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiverIT.java
@@ -23,6 +23,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.ons.census.casesvc.model.dto.ActionInstructionType;
 import uk.gov.ons.census.casesvc.model.dto.CollectionCase;
 import uk.gov.ons.census.casesvc.model.dto.EventDTO;
 import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
@@ -111,6 +112,10 @@ public class UndeliveredMailReceiverIT {
         rabbitQueueHelper.checkExpectedMessageReceived(outboundQueue);
 
     assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_UPDATED);
+    assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
+        .isEqualTo(ActionInstructionType.CREATE);
+    assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
+        .isEqualTo(EventTypeDTO.UNDELIVERED_MAIL_REPORTED);
     CollectionCase actualCase = responseManagementEvent.getPayload().getCollectionCase();
     assertThat(actualCase.getId()).isEqualTo(TEST_CASE_ID.toString());
     assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
@@ -162,6 +167,10 @@ public class UndeliveredMailReceiverIT {
         rabbitQueueHelper.checkExpectedMessageReceived(outboundQueue);
 
     assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_UPDATED);
+    assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
+        .isEqualTo(ActionInstructionType.CREATE);
+    assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
+        .isEqualTo(EventTypeDTO.UNDELIVERED_MAIL_REPORTED);
     CollectionCase actualCase = responseManagementEvent.getPayload().getCollectionCase();
     assertThat(actualCase.getId()).isEqualTo(TEST_CASE_ID.toString());
     assertThat(actualCase.getCaseRef()).isEqualTo(Long.toString(TEST_CASE_REF));

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiverTest.java
@@ -9,14 +9,18 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.ons.census.casesvc.testutil.MessageConstructor.constructMessageWithValidTimeStamp;
+import static uk.gov.ons.census.casesvc.utility.MetadataHelper.buildMetadata;
 
 import java.time.OffsetDateTime;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.messaging.Message;
 import uk.gov.ons.census.casesvc.logging.EventLogger;
+import uk.gov.ons.census.casesvc.model.dto.ActionInstructionType;
 import uk.gov.ons.census.casesvc.model.dto.EventDTO;
+import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
 import uk.gov.ons.census.casesvc.model.dto.FulfilmentInformation;
+import uk.gov.ons.census.casesvc.model.dto.Metadata;
 import uk.gov.ons.census.casesvc.model.dto.PayloadDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.casesvc.model.entity.Case;
@@ -34,6 +38,7 @@ public class UndeliveredMailReceiverTest {
     ResponseManagementEvent event = new ResponseManagementEvent();
     event.setEvent(new EventDTO());
     event.getEvent().setDateTime(OffsetDateTime.now());
+    event.getEvent().setType(EventTypeDTO.UNDELIVERED_MAIL_REPORTED);
     event.setPayload(new PayloadDTO());
     event.getPayload().setFulfilmentInformation(new FulfilmentInformation());
     event.getPayload().getFulfilmentInformation().setCaseRef(Long.toString(TEST_CASE_REF));
@@ -57,7 +62,10 @@ public class UndeliveredMailReceiverTest {
 
     // Then
     ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
-    verify(caseService).saveCaseAndEmitCaseUpdatedEvent(caseArgumentCaptor.capture());
+    Metadata expectedMetadata =
+        buildMetadata(EventTypeDTO.UNDELIVERED_MAIL_REPORTED, ActionInstructionType.CREATE);
+    verify(caseService)
+        .saveCaseAndEmitCaseUpdatedEvent(caseArgumentCaptor.capture(), eq(expectedMetadata));
     Case actualCase = caseArgumentCaptor.getValue();
     assertThat(actualCase).isEqualTo(caze);
     assertThat(caseArgumentCaptor.getValue().isUndeliveredAsAddressed()).isTrue();
@@ -81,6 +89,7 @@ public class UndeliveredMailReceiverTest {
     ResponseManagementEvent event = new ResponseManagementEvent();
     event.setEvent(new EventDTO());
     event.getEvent().setDateTime(OffsetDateTime.now());
+    event.getEvent().setType(EventTypeDTO.UNDELIVERED_MAIL_REPORTED);
     event.setPayload(new PayloadDTO());
     event.getPayload().setFulfilmentInformation(new FulfilmentInformation());
     event.getPayload().getFulfilmentInformation().setQuestionnaireId("76543");
@@ -105,7 +114,10 @@ public class UndeliveredMailReceiverTest {
 
     // Then
     ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
-    verify(caseService).saveCaseAndEmitCaseUpdatedEvent(caseArgumentCaptor.capture());
+    Metadata expectedMetadata =
+        buildMetadata(EventTypeDTO.UNDELIVERED_MAIL_REPORTED, ActionInstructionType.CREATE);
+    verify(caseService)
+        .saveCaseAndEmitCaseUpdatedEvent(caseArgumentCaptor.capture(), eq(expectedMetadata));
     Case actualCase = caseArgumentCaptor.getValue();
     assertThat(actualCase).isEqualTo(caze);
     assertThat(caseArgumentCaptor.getValue().isUndeliveredAsAddressed()).isTrue();


### PR DESCRIPTION
# Motivation and Context
UAA fieldwork updates will now be handled through the case processor field decision on case updated events.

# What has changed
* Set field decision CREATE on UAA case updates

# How to test?
Build and run AT's with other linked branches

# Links
https://trello.com/c/1EAHHRAR/635-rmc-345-ce-and-spg-uaa-5
https://github.com/ONSdigital/census-rm-docker-dev/pull/50
https://github.com/ONSdigital/census-rm-action-scheduler/pull/70
https://github.com/ONSdigital/census-rm-kubernetes/pull/214
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/214