### PR TITLE
Changed CLOSE to CANCEL

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/ActionInstructionType.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/ActionInstructionType.java
@@ -5,5 +5,5 @@ public enum ActionInstructionType {
   UPDATE,
   PAUSE,
   REACTIVATE,
-  CLOSE
+  CANCEL
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/CaseReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CaseReceiptService.java
@@ -41,7 +41,7 @@ public class CaseReceiptService {
      This table is based on: https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=SDC&title=Receipting
     */
 
-    rules.put(new Key("HH", "U", HH), new Rule(receiptCase, ActionInstructionType.CLOSE));
+    rules.put(new Key("HH", "U", HH), new Rule(receiptCase, ActionInstructionType.CANCEL));
     rules.put(new Key("HH", "U", CONT), new NoActionRequired());
     rules.put(new Key("HI", "U", IND), new Rule(receiptCase, null));
     rules.put(new Key("CE", "E", IND), new Rule(incrementNoReceipt, ActionInstructionType.UPDATE));
@@ -49,7 +49,7 @@ public class CaseReceiptService {
     rules.put(new Key("CE", "U", IND), new CeUnitRule());
     rules.put(new Key("SPG", "E", HH), new NoActionRequired());
     rules.put(new Key("SPG", "E", IND), new NoActionRequired());
-    rules.put(new Key("SPG", "U", HH), new Rule(receiptCase, ActionInstructionType.CLOSE));
+    rules.put(new Key("SPG", "U", HH), new Rule(receiptCase, ActionInstructionType.CANCEL));
     rules.put(new Key("SPG", "U", IND), new NoActionRequired());
     rules.put(new Key("SPG", "U", CONT), new NoActionRequired());
   }
@@ -140,7 +140,7 @@ public class CaseReceiptService {
 
       if (lockedCase.getCeActualResponses() >= lockedCase.getCeExpectedCapacity()) {
         lockedCase.setReceiptReceived(true);
-        fieldInstruction = ActionInstructionType.CLOSE;
+        fieldInstruction = ActionInstructionType.CANCEL;
       }
 
       caseService.saveCaseAndEmitCaseUpdatedEvent(

--- a/src/main/java/uk/gov/ons/census/casesvc/service/InvalidAddressService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/InvalidAddressService.java
@@ -49,7 +49,7 @@ public class InvalidAddressService {
 
   private Metadata buildMetadataForInvalidAddress(ResponseManagementEvent event) {
     if (!isEventChannelField(event)) {
-      return buildMetadata(event.getEvent().getType(), ActionInstructionType.CLOSE);
+      return buildMetadata(event.getEvent().getType(), ActionInstructionType.CANCEL);
     }
     return buildMetadata(event.getEvent().getType(), null);
   }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/RefusalService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/RefusalService.java
@@ -51,7 +51,7 @@ public class RefusalService {
 
   private Metadata buildMetadataForRefusal(ResponseManagementEvent event) {
     if (!isEventChannelField(event)) {
-      return buildMetadata(event.getEvent().getType(), ActionInstructionType.CLOSE);
+      return buildMetadata(event.getEvent().getType(), ActionInstructionType.CANCEL);
     }
     return buildMetadata(event.getEvent().getType(), null);
   }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
@@ -133,9 +133,9 @@ public class AddressReceiverIT {
     assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
     assertThat(actualCase.isAddressInvalid()).isTrue();
 
-    // check the metadata is included with field close decision
+    // check the metadata is included with field CANCEL decision
     assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
-        .isEqualTo(ActionInstructionType.CLOSE);
+        .isEqualTo(ActionInstructionType.CANCEL);
     assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
         .isEqualTo(EventTypeDTO.ADDRESS_NOT_VALID);
 

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
@@ -138,15 +138,15 @@ public class ReceiptReceiverIT {
     assertThat(actualCollectionCase.getId()).isEqualTo(TEST_CASE_ID.toString());
     assertThat(actualCollectionCase.getReceiptReceived()).isTrue();
 
-    // check the metadata is included with field close decision
+    // check the metadata is included with field CANCEL decision
     assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
-        .isEqualTo(ActionInstructionType.CLOSE);
+        .isEqualTo(ActionInstructionType.CANCEL);
     assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
         .isEqualTo(EventTypeDTO.RESPONSE_RECEIVED);
 
     Metadata metaData = responseManagementEvent.getPayload().getMetadata();
     assertThat(metaData.getCauseEventType()).isEqualTo(RESPONSE_RECEIVED);
-    assertThat(metaData.getFieldDecision()).isEqualTo(ActionInstructionType.CLOSE);
+    assertThat(metaData.getFieldDecision()).isEqualTo(ActionInstructionType.CANCEL);
 
     responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(rhUacOutboundQueue);
     assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.UAC_UPDATED);

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverIT.java
@@ -117,9 +117,9 @@ public class RefusalReceiverIT {
     assertThat(actualCase.isRefusalReceived()).isTrue();
     assertThat(actualCase.getLastUpdated()).isNotEqualTo(cazeCreatedTime);
 
-    // check the metadata is included with field close decision
+    // check the metadata is included with field CANCEL decision
     assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
-        .isEqualTo(ActionInstructionType.CLOSE);
+        .isEqualTo(ActionInstructionType.CANCEL);
     assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
         .isEqualTo(EventTypeDTO.REFUSAL_RECEIVED);
 

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTest.java
@@ -39,7 +39,7 @@ public class CaseReceiptServiceTest {
   @Parameterized.Parameters(name = "Test Key: {0}")
   public static Collection<Object[]> data() {
     Object[][] ruleToTest = {
-      {new Key("HH", "U", "HH"), new Expectation("N", "Y", ActionInstructionType.CLOSE)},
+      {new Key("HH", "U", "HH"), new Expectation("N", "Y", ActionInstructionType.CANCEL)},
       {new Key("HH", "U", "Ind"), new Expectation(RuntimeException.class)},
       {new Key("HH", "U", "CE1"), new Expectation(RuntimeException.class)},
       {new Key("HH", "U", "Cont"), new Expectation("N", "N", null)},
@@ -52,7 +52,7 @@ public class CaseReceiptServiceTest {
       {new Key("CE", "E", "CE1"), new Expectation("N", "Y", ActionInstructionType.UPDATE)},
       {new Key("CE", "E", "Cont"), new Expectation(RuntimeException.class)},
       {new Key("CE", "E", "HH"), new Expectation(RuntimeException.class)},
-      {new Key("CE", "U", "Ind"), new Expectation("Y", "Y AR >= ER", ActionInstructionType.CLOSE)},
+      {new Key("CE", "U", "Ind"), new Expectation("Y", "Y AR >= ER", ActionInstructionType.CANCEL)},
       {new Key("CE", "U", "Ind"), new Expectation("Y", "N AR < ER", ActionInstructionType.UPDATE)},
       {new Key("CE", "U", "CE1"), new Expectation(RuntimeException.class)},
       {new Key("CE", "U", "Cont"), new Expectation(RuntimeException.class)},
@@ -60,7 +60,7 @@ public class CaseReceiptServiceTest {
       {new Key("SPG", "E", "Ind"), new Expectation("N", "N", null)},
       {new Key("SPG", "E", "CE1"), new Expectation(RuntimeException.class)},
       {new Key("SPG", "E", "Cont"), new Expectation(RuntimeException.class)},
-      {new Key("SPG", "U", "HH"), new Expectation("N", "Y", ActionInstructionType.CLOSE)},
+      {new Key("SPG", "U", "HH"), new Expectation("N", "Y", ActionInstructionType.CANCEL)},
       {new Key("SPG", "U", "Ind"), new Expectation("N", "N", null)},
       {new Key("SPG", "U", "CE1"), new Expectation(RuntimeException.class)},
       {new Key("SPG", "U", "Cont"), new Expectation("N", "N", null)}

--- a/src/test/java/uk/gov/ons/census/casesvc/service/InvalidAddressServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/InvalidAddressServiceTest.java
@@ -70,7 +70,7 @@ public class InvalidAddressServiceTest {
     assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
     Metadata metadata = metadataArgumentCaptor.getValue();
     assertThat(metadata.getCauseEventType()).isEqualTo(ADDRESS_NOT_VALID);
-    assertThat(metadata.getFieldDecision()).isEqualTo(ActionInstructionType.CLOSE);
+    assertThat(metadata.getFieldDecision()).isEqualTo(ActionInstructionType.CANCEL);
 
     verify(eventLogger)
         .logCaseEvent(

--- a/src/test/java/uk/gov/ons/census/casesvc/service/RefusalServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/RefusalServiceTest.java
@@ -69,7 +69,7 @@ public class RefusalServiceTest {
 
     assertThat(actualCase.isRefusalReceived()).isTrue();
     assertThat(metadata.getCauseEventType()).isEqualTo(EventTypeDTO.REFUSAL_RECEIVED);
-    assertThat(metadata.getFieldDecision()).isEqualTo(ActionInstructionType.CLOSE);
+    assertThat(metadata.getFieldDecision()).isEqualTo(ActionInstructionType.CANCEL);
     inOrder
         .verify(eventLogger, times(1))
         .logCaseEvent(


### PR DESCRIPTION
# Motivation and Context
Better wording - less ambiguous 

# What has changed
Any reference to a CLOSE event has been changed to CANCEL

# How to test?
Clone branch and build/test it

# Links
https://trello.com/c/3PljKzC2/770-change-field-close-message-to-cancels-5
