### PR TITLE
791 am1 why are some fields copied error msgs for missing fields

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/CollectionCase.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/CollectionCase.java
@@ -33,7 +33,6 @@ public class CollectionCase {
   private Integer ceExpectedCapacity;
   private Integer ceActualResponses;
   private Boolean addressInvalid;
-  private Boolean undeliveredAsAddressed;
   private boolean handDelivery;
   private boolean skeleton;
   private CaseMetadata metadata;

--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -46,7 +46,6 @@ public class NewAddressReportedService {
     Case skeletonCase = new Case();
     skeletonCase.setSkeleton(true);
     skeletonCase.setCaseId(UUID.fromString(collectionCase.getId()));
-    skeletonCase.setCollectionExerciseId(collectionCase.getCollectionExerciseId());
     skeletonCase.setAddressLine1(collectionCase.getAddress().getAddressLine1());
     skeletonCase.setAddressLine2(collectionCase.getAddress().getAddressLine2());
     skeletonCase.setAddressLine3(collectionCase.getAddress().getAddressLine3());
@@ -57,28 +56,19 @@ public class NewAddressReportedService {
     skeletonCase.setLongitude(collectionCase.getAddress().getLongitude());
     skeletonCase.setUprn(collectionCase.getAddress().getUprn());
     skeletonCase.setRegion(collectionCase.getAddress().getRegion());
-    skeletonCase.setActionPlanId(collectionCase.getActionPlanId()); // This is essential
-    skeletonCase.setTreatmentCode(collectionCase.getTreatmentCode()); // This is essential
     skeletonCase.setAddressLevel(collectionCase.getAddress().getAddressLevel());
-    skeletonCase.setAbpCode(collectionCase.getAddress().getApbCode());
     skeletonCase.setCaseType(collectionCase.getCaseType());
     skeletonCase.setAddressType(collectionCase.getAddress().getAddressType());
     skeletonCase.setUprn(collectionCase.getAddress().getUprn());
     skeletonCase.setEstabArid(collectionCase.getAddress().getEstabArid());
     skeletonCase.setEstabType(collectionCase.getAddress().getEstabType());
     skeletonCase.setOrganisationName(collectionCase.getAddress().getOrganisationName());
-    skeletonCase.setOa(collectionCase.getOa());
-    skeletonCase.setLsoa(collectionCase.getLsoa());
-    skeletonCase.setMsoa(collectionCase.getMsoa());
-    skeletonCase.setLad(collectionCase.getLad());
-    skeletonCase.setHtcWillingness(collectionCase.getHtcWillingness());
-    skeletonCase.setHtcDigital(collectionCase.getHtcDigital());
     skeletonCase.setFieldCoordinatorId(collectionCase.getFieldCoordinatorId());
     skeletonCase.setFieldOfficerId(collectionCase.getFieldOfficerId());
     skeletonCase.setCeExpectedCapacity(collectionCase.getCeExpectedCapacity());
-    skeletonCase.setHandDelivery(collectionCase.isHandDelivery());
 
     skeletonCase.setSurvey("CENSUS");
+    skeletonCase.setHandDelivery(false);
     skeletonCase.setRefusalReceived(false);
     skeletonCase.setReceiptReceived(false);
     skeletonCase.setAddressInvalid(false);

--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -2,6 +2,7 @@ package uk.gov.ons.census.casesvc.service;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import uk.gov.ons.census.casesvc.logging.EventLogger;
@@ -15,6 +16,9 @@ import uk.gov.ons.census.casesvc.utility.JsonHelper;
 public class NewAddressReportedService {
   private final CaseService caseService;
   private final EventLogger eventLogger;
+
+  @Value("${collectionexerciseid}")
+  private String collectionExerciseId;
 
   public NewAddressReportedService(CaseService caseService, EventLogger eventLogger) {
     this.caseService = caseService;
@@ -46,6 +50,19 @@ public class NewAddressReportedService {
     Case skeletonCase = new Case();
     skeletonCase.setSkeleton(true);
     skeletonCase.setCaseId(UUID.fromString(collectionCase.getId()));
+
+    if (StringUtils.isEmpty(collectionCase.getCaseType())) {
+      skeletonCase.setCaseType(collectionCase.getAddress().getAddressType());
+    } else {
+      skeletonCase.setCaseType(collectionCase.getCaseType());
+    }
+
+    if (StringUtils.isEmpty(collectionCase.getCollectionExerciseId())) {
+      skeletonCase.setCollectionExerciseId(collectionExerciseId);
+    } else {
+      skeletonCase.setCollectionExerciseId(collectionCase.getCollectionExerciseId());
+    }
+
     skeletonCase.setAddressLine1(collectionCase.getAddress().getAddressLine1());
     skeletonCase.setAddressLine2(collectionCase.getAddress().getAddressLine2());
     skeletonCase.setAddressLine3(collectionCase.getAddress().getAddressLine3());
@@ -57,15 +74,14 @@ public class NewAddressReportedService {
     skeletonCase.setEstabType(collectionCase.getAddress().getEstabType());
     skeletonCase.setRegion(collectionCase.getAddress().getRegion());
     skeletonCase.setAddressLevel(collectionCase.getAddress().getAddressLevel());
-    skeletonCase.setCaseType(collectionCase.getCaseType());
     skeletonCase.setAddressType(collectionCase.getAddress().getAddressType());
     skeletonCase.setEstabType(collectionCase.getAddress().getEstabType());
     skeletonCase.setOrganisationName(collectionCase.getAddress().getOrganisationName());
     skeletonCase.setFieldCoordinatorId(collectionCase.getFieldCoordinatorId());
     skeletonCase.setFieldOfficerId(collectionCase.getFieldOfficerId());
     skeletonCase.setCeExpectedCapacity(collectionCase.getCeExpectedCapacity());
-    skeletonCase.setSurvey(collectionCase.getSurvey());
 
+    skeletonCase.setSurvey("CENSUS");
     skeletonCase.setHandDelivery(false);
     skeletonCase.setRefusalReceived(false);
     skeletonCase.setReceiptReceived(false);

--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -17,8 +17,11 @@ public class NewAddressReportedService {
   private final CaseService caseService;
   private final EventLogger eventLogger;
 
-  @Value("${collectionexerciseid}")
-  private String collectionExerciseId;
+  @Value("${censusconfig.collectionexerciseid}")
+  private String censusCollectionExerciseId;
+
+  @Value("${censusconfig.actionplanid}")
+  private String censusActionPlanId;
 
   public NewAddressReportedService(CaseService caseService, EventLogger eventLogger) {
     this.caseService = caseService;
@@ -58,7 +61,7 @@ public class NewAddressReportedService {
     }
 
     if (StringUtils.isEmpty(collectionCase.getCollectionExerciseId())) {
-      skeletonCase.setCollectionExerciseId(collectionExerciseId);
+      skeletonCase.setCollectionExerciseId(censusCollectionExerciseId);
     } else {
       skeletonCase.setCollectionExerciseId(collectionCase.getCollectionExerciseId());
     }
@@ -81,6 +84,7 @@ public class NewAddressReportedService {
     skeletonCase.setFieldOfficerId(collectionCase.getFieldOfficerId());
     skeletonCase.setCeExpectedCapacity(collectionCase.getCeExpectedCapacity());
 
+    skeletonCase.setActionPlanId(censusActionPlanId);
     skeletonCase.setSurvey("CENSUS");
     skeletonCase.setHandDelivery(false);
     skeletonCase.setRefusalReceived(false);

--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -76,13 +76,14 @@ public class NewAddressReportedService {
     skeletonCase.setFieldCoordinatorId(collectionCase.getFieldCoordinatorId());
     skeletonCase.setFieldOfficerId(collectionCase.getFieldOfficerId());
     skeletonCase.setCeExpectedCapacity(collectionCase.getCeExpectedCapacity());
-    skeletonCase.setCeActualResponses(collectionCase.getCeActualResponses());
     skeletonCase.setHandDelivery(collectionCase.isHandDelivery());
 
     skeletonCase.setSurvey("CENSUS");
     skeletonCase.setRefusalReceived(false);
     skeletonCase.setReceiptReceived(false);
     skeletonCase.setAddressInvalid(false);
+    skeletonCase.setCeActualResponses(0);
+
     return skeletonCase;
   }
 

--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -64,8 +64,8 @@ public class NewAddressReportedService {
     skeletonCase.setFieldCoordinatorId(collectionCase.getFieldCoordinatorId());
     skeletonCase.setFieldOfficerId(collectionCase.getFieldOfficerId());
     skeletonCase.setCeExpectedCapacity(collectionCase.getCeExpectedCapacity());
+    skeletonCase.setSurvey(collectionCase.getSurvey());
 
-    skeletonCase.setSurvey("CENSUS");
     skeletonCase.setHandDelivery(false);
     skeletonCase.setRefusalReceived(false);
     skeletonCase.setReceiptReceived(false);
@@ -76,7 +76,6 @@ public class NewAddressReportedService {
   }
 
   // https://collaborate2.ons.gov.uk/confluence/display/SDC/Handle+New+Address+Reported+Events
-  // Only a small number of mandatory fields to create a skeleton case
   private void checkManadatoryFieldsPresent(CollectionCase newCollectionCase) {
 
     if (StringUtils.isEmpty(newCollectionCase.getId())) {

--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -54,7 +54,6 @@ public class NewAddressReportedService {
     skeletonCase.setLatitude(collectionCase.getAddress().getLatitude());
     skeletonCase.setLongitude(collectionCase.getAddress().getLongitude());
     skeletonCase.setUprn(collectionCase.getAddress().getUprn());
-    skeletonCase.setEstabUprn(collectionCase.getAddress().getEstabUprn());
     skeletonCase.setEstabType(collectionCase.getAddress().getEstabType());
     skeletonCase.setRegion(collectionCase.getAddress().getRegion());
     skeletonCase.setAddressLevel(collectionCase.getAddress().getAddressLevel());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -84,3 +84,6 @@ logging:
 # that tests it. Once the direct delivery treatment codes have been finalised then we can add
 # them to the list.
 directdeliverytreatmentcodes: CE_LDIEE
+
+# Skeleton cases need to know the collection exercise id, this is the universal collection exercise id from now on
+collectionexerciseid: 34d7f3bb-91c9-45d0-bb2d-90afce4fc790

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,5 +85,7 @@ logging:
 # them to the list.
 directdeliverytreatmentcodes: CE_LDIEE
 
-# Skeleton cases need to know the collection exercise id, this is the universal collection exercise id from now on
-collectionexerciseid: 34d7f3bb-91c9-45d0-bb2d-90afce4fc790
+# Skeleton cases need to know the collection exercise id and action_plan_id
+censusconfig:
+  collectionexerciseid: 34d7f3bb-91c9-45d0-bb2d-90afce4fc790
+  actionplanid: c4415287-0e37-447b-9c3d-1a011c9fa3db

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
@@ -65,8 +65,11 @@ public class AddressReceiverIT {
   @Value("${queueconfig.rh-case-queue}")
   private String rhCaseQueue;
 
-  @Value("${collectionexerciseid}")
-  private String collectionExerciseId;
+  @Value("${censusconfig.collectionexerciseid}")
+  private String censuscollectionExerciseId;
+
+  @Value("${censusconfig.actionplanid}")
+  private String censusActionPlanId;
 
   @Autowired private RabbitQueueHelper rabbitQueueHelper;
   @Autowired private CaseRepository caseRepository;
@@ -220,7 +223,8 @@ public class AddressReceiverIT {
     assertThat(actualPayloadCase.isSkeleton()).isTrue().as("Is Skeleton Case");
 
     Case actualCase = caseRepository.findById(UUID.fromString(collectionCase.getId())).get();
-    assertThat(actualCase.getCollectionExerciseId()).isEqualTo(collectionExerciseId);
+    assertThat(actualCase.getCollectionExerciseId()).isEqualTo(censuscollectionExerciseId);
+    assertThat(actualCase.getActionPlanId()).isEqualTo(censusActionPlanId);
     assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
     assertThat(actualCase.getCaseType()).isEqualTo("HH");
     assertThat(actualCase.isSkeleton()).isTrue().as("Is Skeleton Case In DB");

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
@@ -65,6 +65,9 @@ public class AddressReceiverIT {
   @Value("${queueconfig.rh-case-queue}")
   private String rhCaseQueue;
 
+  @Value("${collectionexerciseid}")
+  private String collectionExerciseId;
+
   @Autowired private RabbitQueueHelper rabbitQueueHelper;
   @Autowired private CaseRepository caseRepository;
   @Autowired private UacQidLinkRepository uacQidLinkRepository;
@@ -175,8 +178,7 @@ public class AddressReceiverIT {
   }
 
   @Test
-  public void testNewAddressCallsNewAddressReportedService()
-      throws InterruptedException, IOException {
+  public void testNewAddressCreatesSkeletonCase() throws InterruptedException, IOException {
     // GIVEN
     BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(rhCaseQueue);
 
@@ -187,7 +189,6 @@ public class AddressReceiverIT {
 
     CollectionCase collectionCase = new CollectionCase();
     collectionCase.setId(UUID.randomUUID().toString());
-    collectionCase.setCaseType("HH");
     collectionCase.setAddress(address);
 
     NewAddress newAddress = new NewAddress();
@@ -219,7 +220,9 @@ public class AddressReceiverIT {
     assertThat(actualPayloadCase.isSkeleton()).isTrue().as("Is Skeleton Case");
 
     Case actualCase = caseRepository.findById(UUID.fromString(collectionCase.getId())).get();
+    assertThat(actualCase.getCollectionExerciseId()).isEqualTo(collectionExerciseId);
     assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
+    assertThat(actualCase.getCaseType()).isEqualTo("HH");
     assertThat(actualCase.isSkeleton()).isTrue().as("Is Skeleton Case In DB");
 
     // check database for log eventDTO

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
@@ -219,7 +219,7 @@ public class AddressReceiverIT {
         actualResponseManagementEvent.getPayload().getCollectionCase();
     assertThat(actualPayloadCase.getId()).isEqualTo(collectionCase.getId());
     assertThat(actualPayloadCase.isSkeleton()).isTrue().as("Is Skeleton Case");
-    
+
     Case actualCase = caseRepository.findById(UUID.fromString(collectionCase.getId())).get();
     assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
     assertThat(actualCase.isSkeleton()).isTrue().as("Is Skeleton Case In DB");

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
+
+import org.assertj.core.api.Assertions;
 import org.jeasy.random.EasyRandom;
 import org.json.JSONException;
 import org.junit.Before;
@@ -217,7 +219,7 @@ public class AddressReceiverIT {
         actualResponseManagementEvent.getPayload().getCollectionCase();
     assertThat(actualPayloadCase.getId()).isEqualTo(collectionCase.getId());
     assertThat(actualPayloadCase.isSkeleton()).isTrue().as("Is Skeleton Case");
-
+    
     Case actualCase = caseRepository.findById(UUID.fromString(collectionCase.getId())).get();
     assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
     assertThat(actualCase.isSkeleton()).isTrue().as("Is Skeleton Case In DB");

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
@@ -14,8 +14,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
-
-import org.assertj.core.api.Assertions;
 import org.jeasy.random.EasyRandom;
 import org.json.JSONException;
 import org.junit.Before;

--- a/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
@@ -216,13 +216,14 @@ public class NewAddressReportedServiceTest {
     expectedCase.setFieldCoordinatorId(collectionCase.getFieldCoordinatorId());
     expectedCase.setFieldOfficerId(collectionCase.getFieldOfficerId());
     expectedCase.setCeExpectedCapacity(collectionCase.getCeExpectedCapacity());
-    expectedCase.setCeActualResponses(collectionCase.getCeActualResponses());
+
     expectedCase.setHandDelivery(collectionCase.isHandDelivery());
     expectedCase.setSurvey("CENSUS");
     expectedCase.setRefusalReceived(false);
     expectedCase.setReceiptReceived(false);
     expectedCase.setAddressInvalid(false);
     expectedCase.setSkeleton(true);
+    expectedCase.setCeActualResponses(0);
 
     return expectedCase;
   }

--- a/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
@@ -204,9 +204,9 @@ public class NewAddressReportedServiceTest {
     expectedCase.setFieldCoordinatorId(collectionCase.getFieldCoordinatorId());
     expectedCase.setFieldOfficerId(collectionCase.getFieldOfficerId());
     expectedCase.setCeExpectedCapacity(collectionCase.getCeExpectedCapacity());
+    expectedCase.setSurvey(collectionCase.getSurvey());
 
     expectedCase.setHandDelivery(false);
-    expectedCase.setSurvey("CENSUS");
     expectedCase.setRefusalReceived(false);
     expectedCase.setReceiptReceived(false);
     expectedCase.setAddressInvalid(false);

--- a/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
@@ -187,9 +187,6 @@ public class NewAddressReportedServiceTest {
     Case expectedCase = new Case();
     expectedCase.setCaseId(UUID.fromString(collectionCase.getId()));
     expectedCase.setCaseType(collectionCase.getCaseType());
-    expectedCase.setActionPlanId(collectionCase.getActionPlanId());
-    expectedCase.setCollectionExerciseId(collectionCase.getCollectionExerciseId());
-    expectedCase.setTreatmentCode(collectionCase.getTreatmentCode());
     expectedCase.setAddressLine1(collectionCase.getAddress().getAddressLine1());
     expectedCase.setAddressLine2(collectionCase.getAddress().getAddressLine2());
     expectedCase.setAddressLine3(collectionCase.getAddress().getAddressLine3());
@@ -200,14 +197,7 @@ public class NewAddressReportedServiceTest {
     expectedCase.setLongitude(collectionCase.getAddress().getLongitude());
     expectedCase.setUprn(collectionCase.getAddress().getUprn());
     expectedCase.setRegion(collectionCase.getAddress().getRegion());
-    expectedCase.setOa(collectionCase.getOa());
-    expectedCase.setLsoa(collectionCase.getLsoa());
-    expectedCase.setMsoa(collectionCase.getMsoa());
-    expectedCase.setLad(collectionCase.getLad());
-    expectedCase.setHtcWillingness(collectionCase.getHtcWillingness());
-    expectedCase.setHtcDigital(collectionCase.getHtcDigital());
     expectedCase.setAddressLevel(collectionCase.getAddress().getAddressLevel());
-    expectedCase.setAbpCode(collectionCase.getAddress().getApbCode());
     expectedCase.setAddressType(collectionCase.getAddress().getAddressType());
     expectedCase.setUprn(collectionCase.getAddress().getUprn());
     expectedCase.setEstabArid(collectionCase.getAddress().getEstabArid());
@@ -217,7 +207,7 @@ public class NewAddressReportedServiceTest {
     expectedCase.setFieldOfficerId(collectionCase.getFieldOfficerId());
     expectedCase.setCeExpectedCapacity(collectionCase.getCeExpectedCapacity());
 
-    expectedCase.setHandDelivery(collectionCase.isHandDelivery());
+    expectedCase.setHandDelivery(false);
     expectedCase.setSurvey("CENSUS");
     expectedCase.setRefusalReceived(false);
     expectedCase.setReceiptReceived(false);

--- a/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
@@ -195,7 +195,6 @@ public class NewAddressReportedServiceTest {
     expectedCase.setLatitude(collectionCase.getAddress().getLatitude());
     expectedCase.setLongitude(collectionCase.getAddress().getLongitude());
     expectedCase.setUprn(collectionCase.getAddress().getUprn());
-    expectedCase.setEstabUprn(collectionCase.getAddress().getEstabUprn());
     expectedCase.setRegion(collectionCase.getAddress().getRegion());
     expectedCase.setAddressLevel(collectionCase.getAddress().getAddressLevel());
     expectedCase.setAddressType(collectionCase.getAddress().getAddressType());

--- a/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
@@ -35,6 +35,8 @@ public class NewAddressReportedServiceTest {
   @Mock CaseService caseService;
   @Mock EventLogger eventLogger;
 
+  private String EXPECTED_ACTION_PLAN_ID = UUID.randomUUID().toString();
+
   @Test
   public void testCreatingSkeletonCaseWithAllEventFields() {
     // given
@@ -62,6 +64,8 @@ public class NewAddressReportedServiceTest {
     newAddressEvent.setEvent(eventDTO);
 
     Case casetoEmit = new Case();
+    ReflectionTestUtils.setField(underTest, "censusActionPlanId", EXPECTED_ACTION_PLAN_ID);
+
     when(caseService.saveNewCaseAndStampCaseRef(any(Case.class))).thenReturn(casetoEmit);
     OffsetDateTime expectedDateTime = OffsetDateTime.now();
 
@@ -92,7 +96,7 @@ public class NewAddressReportedServiceTest {
   @Test
   public void testRequiredFieldsSetIfNotOnEvent() {
     String collectionExerciseId = UUID.randomUUID().toString();
-    ReflectionTestUtils.setField(underTest, "collectionExerciseId", collectionExerciseId);
+    ReflectionTestUtils.setField(underTest, "censusCollectionExerciseId", collectionExerciseId);
 
     ResponseManagementEvent responseManagementEvent = getMinimalValidNewAddress();
     underTest.processNewAddress(responseManagementEvent, OffsetDateTime.now());
@@ -229,8 +233,9 @@ public class NewAddressReportedServiceTest {
     expectedCase.setFieldCoordinatorId(collectionCase.getFieldCoordinatorId());
     expectedCase.setFieldOfficerId(collectionCase.getFieldOfficerId());
     expectedCase.setCeExpectedCapacity(collectionCase.getCeExpectedCapacity());
-    expectedCase.setSurvey("CENSUS");
 
+    expectedCase.setActionPlanId(EXPECTED_ACTION_PLAN_ID);
+    expectedCase.setSurvey("CENSUS");
     expectedCase.setHandDelivery(false);
     expectedCase.setRefusalReceived(false);
     expectedCase.setReceiptReceived(false);


### PR DESCRIPTION
# Motivation and Context
Now have an explicit table to map from event to skeleton case: https://collaborate2.ons.gov.uk/confluence/display/CATD/Census+Case+Processor#CensusCaseProcessor-NewAddressReported

# What has changed
Changed to code to match new table

# How to test?
Everything else on master, mvn clean install and run ATs
Check some mandatory fields Region, id, addressType, addressLevel missing error msgs.  Had an error I can't reproduce with these (wrong error msg).  Was probably due to dirty local environment, but would appreciate further eyes on this.
{
   "event":{
      "type":"NEW_ADDRESS_REPORTED",
      "source":"FIELDWORK_GATEWAY",
      "channel":"sender",
      "dateTime":"2011-08-12T20:17:46.384Z",
      "transactionId":"d9126d67-2830-4aac-8e52-47fb8f84d3b9"
   },
   "payload":{
      "newAddress":{
         "collectionCase":{
            "id":"beeb3cb8-e24d-46b6-bcf1-6f5cff561b04",
            "caseType":"SPG",
            "survey":"CENSUS",
            "fieldCoordinatorId":"SO_23",
            "fieldOfficerId":"SO_23_123",
            "collectionExerciseId":"context.collection_exercise_id",
            "address":{
               "addressLine1":"123",
               "addressLine2":"Fake caravan park",
               "addressLine3":"The long road",
               "townName":"Trumpton",
               "postcode":"SO190PG",
               "region":"E",
               "addressLevel":"U",
               "latitude":"50.917428",
               "longitude":"-1.238193"
            }
         }
      }
   }
}

# Links
https://trello.com/c/cX1TphoP/791-am1-align-copied-event-fields-with-new-table

# Screenshots (if appropriate):