### PR TITLE
Changing criteria for when an UPDATE message is sent to field

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiver.java
@@ -52,10 +52,7 @@ public class UndeliveredMailReceiver {
               Long.parseLong(event.getPayload().getFulfilmentInformation().getCaseRef()));
     }
 
-    if (!caze.isRefusalReceived()
-        && !caze.isAddressInvalid()
-        && !caze.isReceiptReceived()
-        && (!caze.getRegion().startsWith("N") && !caze.getAddressType().equals("CE"))) {
+    if (isMarkingCaseAsUpdated(caze)) {
       caseService.saveCaseAndEmitCaseUpdatedEvent(
           caze, buildMetadata(event.getEvent().getType(), ActionInstructionType.UPDATE));
     }
@@ -79,5 +76,12 @@ public class UndeliveredMailReceiver {
           convertObjectToJson(event.getPayload().getFulfilmentInformation()),
           messageTimestamp);
     }
+  }
+
+  private boolean isMarkingCaseAsUpdated(Case caze) {
+    return !caze.isRefusalReceived()
+        && !caze.isAddressInvalid()
+        && !caze.isReceiptReceived()
+        && (!caze.getRegion().startsWith("N") && !caze.getAddressType().equals("CE"));
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiver.java
@@ -52,7 +52,7 @@ public class UndeliveredMailReceiver {
               Long.parseLong(event.getPayload().getFulfilmentInformation().getCaseRef()));
     }
 
-    if (isMarkingCaseAsUpdated(caze)) {
+    if (shouldEmitCaseUpdated(caze)) {
       caseService.saveCaseAndEmitCaseUpdatedEvent(
           caze, buildMetadata(event.getEvent().getType(), ActionInstructionType.UPDATE));
     }
@@ -78,7 +78,7 @@ public class UndeliveredMailReceiver {
     }
   }
 
-  private boolean isMarkingCaseAsUpdated(Case caze) {
+  private boolean shouldEmitCaseUpdated(Case caze) {
     return !caze.isRefusalReceived()
         && !caze.isAddressInvalid()
         && !caze.isReceiptReceived()

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiver.java
@@ -53,9 +53,9 @@ public class UndeliveredMailReceiver {
     }
 
     if (!caze.isRefusalReceived()
-        && !caze.isAddressInvalid()
-        && !caze.isReceiptReceived()
-        && (!caze.getRegion().startsWith("N") && !caze.getAddressType().equals("CE"))) {
+        || !caze.isAddressInvalid()
+        || !caze.isReceiptReceived()
+        || (!caze.getRegion().startsWith("N") && !caze.getAddressType().equals("CE"))) {
       caseService.saveCaseAndEmitCaseUpdatedEvent(
           caze, buildMetadata(event.getEvent().getType(), ActionInstructionType.UPDATE));
     }

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiver.java
@@ -53,9 +53,9 @@ public class UndeliveredMailReceiver {
     }
 
     if (!caze.isRefusalReceived()
-        || !caze.isAddressInvalid()
-        || !caze.isReceiptReceived()
-        || (!caze.getRegion().startsWith("N") && !caze.getAddressType().equals("CE"))) {
+        && !caze.isAddressInvalid()
+        && !caze.isReceiptReceived()
+        && (!caze.getRegion().startsWith("N") && !caze.getAddressType().equals("CE"))) {
       caseService.saveCaseAndEmitCaseUpdatedEvent(
           caze, buildMetadata(event.getEvent().getType(), ActionInstructionType.UPDATE));
     }

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiver.java
@@ -52,8 +52,13 @@ public class UndeliveredMailReceiver {
               Long.parseLong(event.getPayload().getFulfilmentInformation().getCaseRef()));
     }
 
-    caseService.saveCaseAndEmitCaseUpdatedEvent(
-        caze, buildMetadata(event.getEvent().getType(), ActionInstructionType.UPDATE));
+    if (!caze.isRefusalReceived()
+        || !caze.isAddressInvalid()
+        || !caze.isReceiptReceived()
+        || (!caze.getRegion().startsWith("N") && !caze.getAddressType().equals("CE"))) {
+      caseService.saveCaseAndEmitCaseUpdatedEvent(
+          caze, buildMetadata(event.getEvent().getType(), ActionInstructionType.UPDATE));
+    }
 
     if (uacQidLink != null) {
       eventLogger.logUacQidEvent(

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SurveyLaunchedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SurveyLaunchedReceiverIT.java
@@ -71,6 +71,9 @@ public class SurveyLaunchedReceiverIT {
     caze.setCaseId(TEST_CASE_ID);
     caze.setUacQidLinks(null);
     caze.setEvents(null);
+    caze.setAddressInvalid(false);
+    caze.setRefusalReceived(false);
+    caze.setReceiptReceived(false);
     caze = caseRepository.saveAndFlush(caze);
 
     UacQidLink uacQidLink = new UacQidLink();

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiverIT.java
@@ -82,6 +82,9 @@ public class UndeliveredMailReceiverIT {
     caze.setUacQidLinks(null);
     caze.setEvents(null);
     caze.setSurvey("CENSUS");
+    caze.setAddressInvalid(false);
+    caze.setRefusalReceived(false);
+    caze.setReceiptReceived(false);
     caze = caseRepository.saveAndFlush(caze);
 
     UacQidLink uacQidLink = new UacQidLink();
@@ -142,6 +145,9 @@ public class UndeliveredMailReceiverIT {
     caze.setUacQidLinks(null);
     caze.setEvents(null);
     caze.setSurvey("CENSUS");
+    caze.setAddressInvalid(false);
+    caze.setRefusalReceived(false);
+    caze.setReceiptReceived(false);
     caseRepository.saveAndFlush(caze);
 
     ResponseManagementEvent event = new ResponseManagementEvent();

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiverTest.java
@@ -173,6 +173,6 @@ public class UndeliveredMailReceiverTest {
     underTest.receiveMessage(message);
 
     // Then
-    verify(caseService, never()).saveCaseAndEmitCaseUpdatedEvent(any());
+    verify(caseService, never()).saveCaseAndEmitCaseUpdatedEvent(any(), any());
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiverTest.java
@@ -12,6 +12,7 @@ import static uk.gov.ons.census.casesvc.testutil.MessageConstructor.constructMes
 import static uk.gov.ons.census.casesvc.utility.MetadataHelper.buildMetadata;
 
 import java.time.OffsetDateTime;
+import org.jeasy.random.EasyRandom;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.messaging.Message;
@@ -32,6 +33,7 @@ import uk.gov.ons.census.casesvc.utility.MsgDateHelper;
 
 public class UndeliveredMailReceiverTest {
   private static final long TEST_CASE_REF = 1234567890L;
+  private EasyRandom easyRandom = new EasyRandom();
 
   @Test
   public void testReceiveMessageWithCaseRef() {
@@ -43,7 +45,10 @@ public class UndeliveredMailReceiverTest {
     event.getPayload().setFulfilmentInformation(new FulfilmentInformation());
     event.getPayload().getFulfilmentInformation().setCaseRef(Long.toString(TEST_CASE_REF));
 
-    Case caze = new Case();
+    Case caze = easyRandom.nextObject(Case.class);
+    caze.setAddressInvalid(false);
+    caze.setRefusalReceived(false);
+    caze.setReceiptReceived(false);
 
     UacService uacService = mock(UacService.class);
     CaseService caseService = mock(CaseService.class);
@@ -93,7 +98,10 @@ public class UndeliveredMailReceiverTest {
     event.getPayload().setFulfilmentInformation(new FulfilmentInformation());
     event.getPayload().getFulfilmentInformation().setQuestionnaireId("76543");
 
-    Case caze = new Case();
+    Case caze = easyRandom.nextObject(Case.class);
+    caze.setAddressInvalid(false);
+    caze.setRefusalReceived(false);
+    caze.setReceiptReceived(false);
     UacQidLink uacQidLink = new UacQidLink();
     uacQidLink.setCaze(caze);
 
@@ -145,7 +153,6 @@ public class UndeliveredMailReceiverTest {
     event.getPayload().getFulfilmentInformation().setCaseRef(Long.toString(TEST_CASE_REF));
 
     Case caze = new Case();
-    caze.setReceiptReceived(true);
     UacQidLink uacQidLink = new UacQidLink();
     uacQidLink.setCaze(caze);
 
@@ -160,6 +167,7 @@ public class UndeliveredMailReceiverTest {
     when(caseService.getCaseByCaseRef(eq(TEST_CASE_REF))).thenReturn(caze);
 
     // When
+    caze.setReceiptReceived(true);
     underTest.receiveMessage(message);
     caze.setReceiptReceived(false);
     caze.setRefusalReceived(true);


### PR DESCRIPTION
# Motivation and Context
An UPDATE message is still being emitted to field when an undelivered_mail_reported event is ingested
This should not happen if the case is marked as either receipted, refused, invalid or NI CE

# What has changed
New criteria added for when an UPDATE message is not sent
Creation of unit test to cover all scenarios where an UPDATE message is not sent
Had to couple other integration tests to set receipt/refusal/invalid to false

# How to test?
Run and tests locally and check image builds

# Links
https://trello.com/c/hkArUv0E/807-dont-update-field-on-undeliveredmailreported-event-when-case-has-been-receipted-refused-etc-5