### PR TITLE
Am1 part2 new address using source case

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/AddressReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/AddressReceiver.java
@@ -71,13 +71,25 @@ public class AddressReceiver {
         break;
 
       case NEW_ADDRESS_REPORTED:
-        newAddressReportedService.processNewAddress(responseManagementEvent, messageTimestamp);
+        newAddressReported(responseManagementEvent, messageTimestamp);
         break;
 
       default:
         // Should never get here
         throw new RuntimeException(
             String.format("Event Type '%s' is invalid on this topic", event.getType()));
+    }
+  }
+
+  private void newAddressReported(
+      ResponseManagementEvent responseManagementEvent, OffsetDateTime messageTimestamp) {
+    if (responseManagementEvent.getPayload().getNewAddress().getSourceCaseId() != null) {
+      newAddressReportedService.processNewAddressFromSourceId(
+          responseManagementEvent,
+          messageTimestamp,
+          responseManagementEvent.getPayload().getNewAddress().getSourceCaseId());
+    } else {
+      newAddressReportedService.processNewAddress(responseManagementEvent, messageTimestamp);
     }
   }
 

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/AddressReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/AddressReceiver.java
@@ -87,7 +87,7 @@ public class AddressReceiver {
       newAddressReportedService.processNewAddressFromSourceId(
           responseManagementEvent,
           messageTimestamp,
-          responseManagementEvent.getPayload().getNewAddress().getSourceCaseId());
+          UUID.fromString(responseManagementEvent.getPayload().getNewAddress().getSourceCaseId()));
     } else {
       newAddressReportedService.processNewAddress(responseManagementEvent, messageTimestamp);
     }

--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/NewAddress.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/NewAddress.java
@@ -1,10 +1,9 @@
 package uk.gov.ons.census.casesvc.model.dto;
 
-import java.util.UUID;
 import lombok.Data;
 
 @Data
 public class NewAddress {
-  UUID sourceCaseId;
+  String sourceCaseId;
   CollectionCase collectionCase;
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -200,7 +200,6 @@ public class NewAddressReportedService {
     newCase.setMsoa(sourceCase.getMsoa());
     newCase.setOa(sourceCase.getOa());
     newCase.setPrintBatch(sourceCase.getPrintBatch());
-    newCase.setSecretSequenceNumber(sourceCase.getSecretSequenceNumber());
     newCase.setSurvey(sourceCase.getSurvey());
 
     // Fields that need to be set

--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -56,13 +56,13 @@ public class NewAddressReportedService {
     checkManadatoryFieldsPresent(newCollectionCase);
 
     Case sourceCase = caseService.getCaseByCaseId(sourceCaseId);
-    Case newAddressFromSourceCase = buildCaseFromSourceCaseAndEvent(newCollectionCase, sourceCase);
+    Case newCaseFromSourceCase = buildCaseFromSourceCaseAndEvent(newCollectionCase, sourceCase);
 
-    newAddressFromSourceCase = caseService.saveNewCaseAndStampCaseRef(newAddressFromSourceCase);
-    caseService.emitCaseCreatedEvent(newAddressFromSourceCase);
+    newCaseFromSourceCase = caseService.saveNewCaseAndStampCaseRef(newCaseFromSourceCase);
+    caseService.emitCaseCreatedEvent(newCaseFromSourceCase);
 
     eventLogger.logCaseEvent(
-        newAddressFromSourceCase,
+        newCaseFromSourceCase,
         newAddressEvent.getEvent().getDateTime(),
         "New Address reported",
         EventType.NEW_ADDRESS_REPORTED,
@@ -113,6 +113,7 @@ public class NewAddressReportedService {
     skeletonCase.setReceiptReceived(false);
     skeletonCase.setAddressInvalid(false);
     skeletonCase.setCeActualResponses(0);
+    skeletonCase.setCreatedDateTime(OffsetDateTime.now());
 
     return skeletonCase;
   }
@@ -209,6 +210,7 @@ public class NewAddressReportedService {
     newCase.setReceiptReceived(false);
     newCase.setAddressInvalid(false);
     newCase.setCeActualResponses(0);
+    newCase.setCreatedDateTime(OffsetDateTime.now());
 
     return newCase;
   }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
@@ -265,7 +265,7 @@ public class AddressReceiverIT {
 
     NewAddress newAddress = new NewAddress();
     newAddress.setCollectionCase(collectionCase);
-    newAddress.setSourceCaseId(sourceCase.getCaseId());
+    newAddress.setSourceCaseId(sourceCase.getCaseId().toString());
 
     EventDTO eventDTO = new EventDTO();
     eventDTO.setType(NEW_ADDRESS_REPORTED);
@@ -375,7 +375,7 @@ public class AddressReceiverIT {
 
     NewAddress newAddress = new NewAddress();
     newAddress.setCollectionCase(collectionCase);
-    newAddress.setSourceCaseId(sourceCase.getCaseId());
+    newAddress.setSourceCaseId(sourceCase.getCaseId().toString());
 
     EventDTO eventDTO = new EventDTO();
     eventDTO.setType(NEW_ADDRESS_REPORTED);

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
@@ -237,6 +237,215 @@ public class AddressReceiverIT {
     assertThat(event.getEventType()).isEqualTo(EventType.NEW_ADDRESS_REPORTED);
   }
 
+  @Test
+  public void testNewAddressCreatedFromBasicEventAndSourceCase()
+      throws InterruptedException, IOException {
+    // GIVEN
+    BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(rhCaseQueue);
+
+    EasyRandom easyRandom = new EasyRandom();
+    Case sourceCase = easyRandom.nextObject(Case.class);
+    sourceCase.setReceiptReceived(false);
+    sourceCase.setSurvey("CENSUS");
+    sourceCase.setUacQidLinks(null);
+    sourceCase.setEvents(null);
+    sourceCase.setCaseType("HH");
+    sourceCase.setAddressLevel("U");
+    sourceCase.setCollectionExerciseId(censuscollectionExerciseId);
+    sourceCase = caseRepository.saveAndFlush(sourceCase);
+
+    Address address = new Address();
+    address.setAddressLevel("E");
+    address.setAddressType("HH");
+    address.setRegion("W");
+
+    CollectionCase collectionCase = new CollectionCase();
+    collectionCase.setId(UUID.randomUUID().toString());
+    collectionCase.setAddress(address);
+
+    NewAddress newAddress = new NewAddress();
+    newAddress.setCollectionCase(collectionCase);
+    newAddress.setSourceCaseId(sourceCase.getCaseId());
+
+    EventDTO eventDTO = new EventDTO();
+    eventDTO.setType(NEW_ADDRESS_REPORTED);
+    eventDTO.setDateTime(OffsetDateTime.now());
+
+    ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
+    responseManagementEvent.setEvent(eventDTO);
+
+    PayloadDTO payloadDTO = new PayloadDTO();
+    payloadDTO.setNewAddress(newAddress);
+    responseManagementEvent.setPayload(payloadDTO);
+
+    // WHEN
+    rabbitQueueHelper.sendMessage(addressReceiver, responseManagementEvent);
+
+    // THEN
+    ResponseManagementEvent actualResponseManagementEvent =
+        rabbitQueueHelper.checkExpectedMessageReceived(outboundQueue);
+
+    assertThat(actualResponseManagementEvent.getEvent().getType())
+        .isEqualTo(EventTypeDTO.CASE_CREATED);
+    CollectionCase actualPayloadCase =
+        actualResponseManagementEvent.getPayload().getCollectionCase();
+    assertThat(actualPayloadCase.getId()).isEqualTo(collectionCase.getId());
+
+    Case actualCase = caseRepository.findById(UUID.fromString(collectionCase.getId())).get();
+    assertThat(actualCase.getCollectionExerciseId()).isEqualTo(censuscollectionExerciseId);
+    assertThat(actualCase.getActionPlanId()).isEqualTo(censusActionPlanId);
+    assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
+    assertThat(actualCase.getCaseType()).isNull();
+    assertThat(actualCase.isSkeleton()).isFalse();
+
+    assertThat(actualCase.getAddressLine1()).isEqualTo(sourceCase.getAddressLine1());
+    assertThat(actualCase.getAddressLine2()).isEqualTo(sourceCase.getAddressLine2());
+    assertThat(actualCase.getAddressLine3()).isEqualTo(sourceCase.getAddressLine3());
+    assertThat(actualCase.getPostcode()).isEqualTo(sourceCase.getPostcode());
+    assertThat(actualCase.getTownName()).isEqualTo(sourceCase.getTownName());
+    assertThat(actualCase.getCollectionExerciseId())
+        .isEqualTo(sourceCase.getCollectionExerciseId());
+    assertThat(actualCase.getEstabType()).isEqualTo(sourceCase.getEstabType());
+    assertThat(actualCase.getFieldCoordinatorId()).isEqualTo(sourceCase.getFieldCoordinatorId());
+    assertThat(actualCase.getFieldOfficerId()).isEqualTo(sourceCase.getFieldOfficerId());
+
+    assertThat(actualCase.getOrganisationName()).isNull();
+    assertThat(actualCase.getLatitude()).isNull();
+    assertThat(actualCase.getLongitude()).isNull();
+    assertThat(actualCase.getUprn()).isNull();
+    assertThat(actualCase.getCaseType()).isNull();
+    assertThat(actualCase.getTreatmentCode()).isNull();
+
+    assertThat(actualCase.getEstabUprn()).isEqualTo(sourceCase.getEstabUprn());
+
+    assertThat(actualCase.isReceiptReceived()).isFalse();
+    assertThat(actualCase.isRefusalReceived()).isFalse();
+    assertThat(actualCase.isAddressInvalid()).isFalse();
+    assertThat(actualCase.isHandDelivery()).isFalse();
+
+    // check database for log eventDTO
+    List<Event> events = eventRepository.findAll();
+    assertThat(events.size()).isEqualTo(1);
+    Event event = events.get(0);
+    assertThat(event.getEventDescription()).isEqualTo("New Address reported");
+    assertThat(event.getEventType()).isEqualTo(EventType.NEW_ADDRESS_REPORTED);
+  }
+
+  @Test
+  public void testNewAddressCreatedFromEventWithDetailsAndSourceCase()
+      throws InterruptedException, IOException {
+    // GIVEN
+    BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(rhCaseQueue);
+
+    EasyRandom easyRandom = new EasyRandom();
+    Case sourceCase = easyRandom.nextObject(Case.class);
+    sourceCase.setReceiptReceived(false);
+    sourceCase.setSurvey("CENSUS");
+    sourceCase.setUacQidLinks(null);
+    sourceCase.setEvents(null);
+    sourceCase.setCaseType("HH");
+    sourceCase.setAddressLevel("U");
+    sourceCase.setCollectionExerciseId(censuscollectionExerciseId);
+    sourceCase = caseRepository.saveAndFlush(sourceCase);
+
+    Address address = new Address();
+    address.setAddressLevel("E");
+    address.setAddressType("HH");
+    address.setRegion("W");
+
+    address.setAddressLine1("123");
+    address.setAddressLine2("Fake Street");
+    address.setAddressLine3("Made up district");
+    address.setTownName("Nowheresville");
+    address.setPostcode("AB12 3CD");
+    address.setEstabType("HH");
+    address.setOrganisationName("Super Org");
+    address.setLatitude("12.34");
+    address.setLongitude("56.78");
+    address.setUprn("uprn01");
+
+    CollectionCase collectionCase = new CollectionCase();
+    collectionCase.setId(UUID.randomUUID().toString());
+    collectionCase.setAddress(address);
+    collectionCase.setFieldCoordinatorId("1234");
+    collectionCase.setFieldOfficerId("5678");
+    collectionCase.setCeExpectedCapacity(1);
+    collectionCase.setCaseType("SPG");
+    collectionCase.setTreatmentCode("TREAT");
+
+    NewAddress newAddress = new NewAddress();
+    newAddress.setCollectionCase(collectionCase);
+    newAddress.setSourceCaseId(sourceCase.getCaseId());
+
+    EventDTO eventDTO = new EventDTO();
+    eventDTO.setType(NEW_ADDRESS_REPORTED);
+    eventDTO.setDateTime(OffsetDateTime.now());
+
+    ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
+    responseManagementEvent.setEvent(eventDTO);
+
+    PayloadDTO payloadDTO = new PayloadDTO();
+    payloadDTO.setNewAddress(newAddress);
+    responseManagementEvent.setPayload(payloadDTO);
+
+    // WHEN
+    rabbitQueueHelper.sendMessage(addressReceiver, responseManagementEvent);
+
+    // THEN
+    ResponseManagementEvent actualResponseManagementEvent =
+        rabbitQueueHelper.checkExpectedMessageReceived(outboundQueue);
+
+    assertThat(actualResponseManagementEvent.getEvent().getType())
+        .isEqualTo(EventTypeDTO.CASE_CREATED);
+    CollectionCase actualPayloadCase =
+        actualResponseManagementEvent.getPayload().getCollectionCase();
+    assertThat(actualPayloadCase.getId()).isEqualTo(collectionCase.getId());
+
+    Case actualCase = caseRepository.findById(UUID.fromString(collectionCase.getId())).get();
+    assertThat(actualCase.getCollectionExerciseId()).isEqualTo(censuscollectionExerciseId);
+    assertThat(actualCase.getActionPlanId()).isEqualTo(censusActionPlanId);
+    assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
+    assertThat(actualCase.getCaseType()).isEqualTo(collectionCase.getCaseType());
+    assertThat(actualCase.isSkeleton()).isFalse();
+
+    assertThat(actualCase.getAddressLine1())
+        .isEqualTo(collectionCase.getAddress().getAddressLine1());
+    assertThat(actualCase.getAddressLine2())
+        .isEqualTo(collectionCase.getAddress().getAddressLine2());
+    assertThat(actualCase.getAddressLine3())
+        .isEqualTo(collectionCase.getAddress().getAddressLine3());
+    assertThat(actualCase.getPostcode()).isEqualTo(collectionCase.getAddress().getPostcode());
+    assertThat(actualCase.getTownName()).isEqualTo(collectionCase.getAddress().getTownName());
+    assertThat(actualCase.getCollectionExerciseId())
+        .isEqualTo(sourceCase.getCollectionExerciseId());
+    assertThat(actualCase.getEstabType()).isEqualTo(collectionCase.getAddress().getEstabType());
+    assertThat(actualCase.getFieldCoordinatorId())
+        .isEqualTo(collectionCase.getFieldCoordinatorId());
+    assertThat(actualCase.getFieldOfficerId()).isEqualTo(collectionCase.getFieldOfficerId());
+
+    assertThat(actualCase.getOrganisationName())
+        .isEqualTo(collectionCase.getAddress().getOrganisationName());
+    assertThat(actualCase.getLatitude()).isEqualTo(collectionCase.getAddress().getLatitude());
+    assertThat(actualCase.getLongitude()).isEqualTo(collectionCase.getAddress().getLongitude());
+    assertThat(actualCase.getUprn()).isEqualTo(collectionCase.getAddress().getUprn());
+    assertThat(actualCase.getCaseType()).isEqualTo(collectionCase.getCaseType());
+    assertThat(actualCase.getTreatmentCode()).isEqualTo(collectionCase.getTreatmentCode());
+
+    assertThat(actualCase.getEstabUprn()).isEqualTo(sourceCase.getEstabUprn());
+
+    assertThat(actualCase.isReceiptReceived()).isFalse();
+    assertThat(actualCase.isRefusalReceived()).isFalse();
+    assertThat(actualCase.isAddressInvalid()).isFalse();
+    assertThat(actualCase.isHandDelivery()).isFalse();
+
+    // check database for log eventDTO
+    List<Event> events = eventRepository.findAll();
+    assertThat(events.size()).isEqualTo(1);
+    Event event = events.get(0);
+    assertThat(event.getEventDescription()).isEqualTo("New Address reported");
+    assertThat(event.getEventType()).isEqualTo(EventType.NEW_ADDRESS_REPORTED);
+  }
+
   public void testEventTypeLoggedOnly(
       PayloadDTO payload,
       String expectedEventPayloadJson,

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverTest.java
@@ -87,7 +87,7 @@ public class AddressReceiverTest {
     EventDTO event = new EventDTO();
     event.setType(NEW_ADDRESS_REPORTED);
     NewAddress newAddress = new NewAddress();
-    newAddress.setSourceCaseId(UUID.randomUUID());
+    newAddress.setSourceCaseId(UUID.randomUUID().toString());
     PayloadDTO payload = new PayloadDTO();
     payload.setNewAddress(newAddress);
     responseManagementEvent.setEvent(event);
@@ -100,7 +100,9 @@ public class AddressReceiverTest {
 
     verify(newAddressReportedService)
         .processNewAddressFromSourceId(
-            eq(responseManagementEvent), eq(expectedDateTime), eq(newAddress.getSourceCaseId()));
+            eq(responseManagementEvent),
+            eq(expectedDateTime),
+            eq(UUID.fromString(newAddress.getSourceCaseId())));
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverTest.java
@@ -19,6 +19,7 @@ import org.springframework.messaging.Message;
 import uk.gov.ons.census.casesvc.logging.EventLogger;
 import uk.gov.ons.census.casesvc.model.dto.EventDTO;
 import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
+import uk.gov.ons.census.casesvc.model.dto.NewAddress;
 import uk.gov.ons.census.casesvc.model.dto.PayloadDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.casesvc.model.entity.Case;
@@ -64,7 +65,12 @@ public class AddressReceiverTest {
     ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
     EventDTO event = new EventDTO();
     event.setType(NEW_ADDRESS_REPORTED);
+    NewAddress newAddress = new NewAddress();
+    newAddress.setSourceCaseId(null);
+    PayloadDTO payload = new PayloadDTO();
+    payload.setNewAddress(newAddress);
     responseManagementEvent.setEvent(event);
+    responseManagementEvent.setPayload(payload);
     Message<ResponseManagementEvent> message =
         constructMessageWithValidTimeStamp(responseManagementEvent);
     OffsetDateTime expectedDateTime = MsgDateHelper.getMsgTimeStamp(message);
@@ -73,6 +79,28 @@ public class AddressReceiverTest {
 
     verify(newAddressReportedService)
         .processNewAddress(eq(responseManagementEvent), eq(expectedDateTime));
+  }
+
+  @Test
+  public void testNewAddressReportedServiceCalledWithSourceCaseId() {
+    ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
+    EventDTO event = new EventDTO();
+    event.setType(NEW_ADDRESS_REPORTED);
+    NewAddress newAddress = new NewAddress();
+    newAddress.setSourceCaseId(UUID.randomUUID());
+    PayloadDTO payload = new PayloadDTO();
+    payload.setNewAddress(newAddress);
+    responseManagementEvent.setEvent(event);
+    responseManagementEvent.setPayload(payload);
+    Message<ResponseManagementEvent> message =
+        constructMessageWithValidTimeStamp(responseManagementEvent);
+    OffsetDateTime expectedDateTime = MsgDateHelper.getMsgTimeStamp(message);
+
+    underTest.receiveMessage(message);
+
+    verify(newAddressReportedService)
+        .processNewAddressFromSourceId(
+            eq(responseManagementEvent), eq(expectedDateTime), eq(newAddress.getSourceCaseId()));
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
@@ -187,6 +187,79 @@ public class NewAddressReportedServiceTest {
     }
   }
 
+  @Test
+  public void testNewAddressFromSourceCaseWithMinimalEventFields() {
+    EasyRandom easyRandom = new EasyRandom();
+    Case sourceCase = easyRandom.nextObject(Case.class);
+    sourceCase.setCaseId(UUID.randomUUID());
+    ResponseManagementEvent newAddressEvent = getMinimalValidNewAddress();
+    OffsetDateTime timeNow = OffsetDateTime.now();
+
+    when(caseService.getCaseByCaseId(any())).thenReturn(sourceCase);
+
+    underTest.processNewAddressFromSourceId(newAddressEvent, timeNow, sourceCase.getCaseId());
+
+    ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
+    verify(caseService).saveNewCaseAndStampCaseRef(caseArgumentCaptor.capture());
+    Case newCase = caseArgumentCaptor.getAllValues().get(0);
+
+    CollectionCase newAddressCollectionCase =
+        newAddressEvent.getPayload().getNewAddress().getCollectionCase();
+
+    assertThat(newCase.getAddressLine1()).isEqualTo(sourceCase.getAddressLine1());
+    assertThat(newCase.getAddressLine2()).isEqualTo(sourceCase.getAddressLine2());
+    assertThat(newCase.getAddressLine3()).isEqualTo(sourceCase.getAddressLine3());
+
+    assertThat(newCase.getCaseId().toString()).isEqualTo(newAddressCollectionCase.getId());
+    assertThat(newCase.getAddressType())
+        .isEqualTo(newAddressCollectionCase.getAddress().getAddressType());
+
+    assertThat(newCase.getLatitude()).isNull();
+
+    assertThat(newCase.getEstabUprn()).isEqualTo(sourceCase.getEstabUprn());
+  }
+
+  @Test
+  public void testNewAddressFromSourceCaseWithProvidedEventFields() {
+    EasyRandom easyRandom = new EasyRandom();
+    Case sourceCase = easyRandom.nextObject(Case.class);
+    sourceCase.setCaseId(UUID.randomUUID());
+    ResponseManagementEvent newAddressEvent = getMinimalValidNewAddress();
+    newAddressEvent
+        .getPayload()
+        .getNewAddress()
+        .getCollectionCase()
+        .getAddress()
+        .setAddressLine1("666");
+    newAddressEvent
+        .getPayload()
+        .getNewAddress()
+        .getCollectionCase()
+        .getAddress()
+        .setLatitude("51.47");
+    OffsetDateTime timeNow = OffsetDateTime.now();
+
+    when(caseService.getCaseByCaseId(any())).thenReturn(sourceCase);
+
+    underTest.processNewAddressFromSourceId(newAddressEvent, timeNow, sourceCase.getCaseId());
+
+    ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
+    verify(caseService).saveNewCaseAndStampCaseRef(caseArgumentCaptor.capture());
+    Case newCase = caseArgumentCaptor.getAllValues().get(0);
+
+    CollectionCase newAddressCollectionCase =
+        newAddressEvent.getPayload().getNewAddress().getCollectionCase();
+
+    assertThat(newCase.getAddressLine1())
+        .isEqualTo(newAddressCollectionCase.getAddress().getAddressLine1());
+    assertThat(newCase.getCaseId().toString()).isEqualTo(newAddressCollectionCase.getId());
+    assertThat(newCase.getAddressType())
+        .isEqualTo(newAddressCollectionCase.getAddress().getAddressType());
+    assertThat(newCase.getLatitude())
+        .isEqualTo(newAddressCollectionCase.getAddress().getLatitude());
+    assertThat(newCase.getEstabUprn()).isEqualTo(sourceCase.getEstabUprn());
+  }
+
   private ResponseManagementEvent getMinimalValidNewAddress() {
     Address address = new Address();
     address.setAddressLevel("U");

--- a/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
@@ -78,6 +78,7 @@ public class NewAddressReportedServiceTest {
     ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
     verify(caseService).saveNewCaseAndStampCaseRef(caseArgumentCaptor.capture());
     Case actualCase = caseArgumentCaptor.getValue();
+    actualCase.setCreatedDateTime(expectedCase.getCreatedDateTime());
     assertThat(actualCase).isEqualToComparingFieldByFieldRecursively(expectedCase);
 
     verify(caseService).emitCaseCreatedEvent(casetoEmit);


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
New address events can be submitted that include a case id from an existing case. A number of fields can be copied from either the event or source case, depending whether they are present in the event. There are also a number of fields that do not come on the event, but can either be copied from the source case or not.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
New method to build a case from a new address event and source case, taking the fields from the appropriate source depending on presence.
Tests updated and some added.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build branch, and [test with acceptance tests on the same branch name](https://github.com/ONSdigital/census-rm-acceptance-tests/pull/235). Check the tables in the confluence document linked from Trello, and the confluence doc linked from that doc. Check that these tables match up with how the new case is built.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/3EyvVwQF/708-am1-part-2-new-address-create-using-source-case-8
# Screenshots (if appropriate):