### PR TITLE
set new case to skeleton and copy metadata over

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -14,11 +14,13 @@ import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
 import uk.gov.ons.census.casesvc.model.dto.Metadata;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.casesvc.model.entity.Case;
+import uk.gov.ons.census.casesvc.model.entity.CaseMetadata;
 import uk.gov.ons.census.casesvc.model.entity.EventType;
 import uk.gov.ons.census.casesvc.utility.JsonHelper;
 
 @Component
 public class NewAddressReportedService {
+
   private final CaseService caseService;
   private final EventLogger eventLogger;
 
@@ -83,15 +85,23 @@ public class NewAddressReportedService {
   private Metadata getMetaDataToCreateFieldCaseIfConditionsMet(
       Case caze, ResponseManagementEvent newAddressEvent) {
 
-    if (!caze.getCaseType().equals("SPG") && !caze.getCaseType().equals("CE")) return null;
+    if (!caze.getCaseType().equals("SPG") && !caze.getCaseType().equals("CE")) {
+      return null;
+    }
 
-    if (!newAddressEvent.getEvent().getChannel().equals("FIELD")) return null;
+    if (!newAddressEvent.getEvent().getChannel().equals("FIELD")) {
+      return null;
+    }
 
     if (newAddressEvent.getPayload().getNewAddress().getCollectionCase().getFieldCoordinatorId()
-        == null) return null;
+        == null) {
+      return null;
+    }
 
     if (newAddressEvent.getPayload().getNewAddress().getCollectionCase().getFieldOfficerId()
-        == null) return null;
+        == null) {
+      return null;
+    }
 
     return buildMetadata(EventTypeDTO.NEW_ADDRESS_REPORTED, ActionInstructionType.CREATE);
   }
@@ -227,9 +237,11 @@ public class NewAddressReportedService {
     newCase.setOa(sourceCase.getOa());
     newCase.setPrintBatch(sourceCase.getPrintBatch());
     newCase.setSurvey(sourceCase.getSurvey());
+    newCase.setMetadata(metadataFromSourceCase(sourceCase.getMetadata()));
 
     // Fields that need to be set
     newCase.setActionPlanId(censusActionPlanId);
+    newCase.setSkeleton(true);
     newCase.setHandDelivery(false);
     newCase.setRefusalReceived(false);
     newCase.setReceiptReceived(false);
@@ -245,5 +257,11 @@ public class NewAddressReportedService {
     } else {
       return baseValue;
     }
+  }
+
+  private CaseMetadata metadataFromSourceCase(CaseMetadata sourceMetadata) {
+    CaseMetadata newCaseMetadata = new CaseMetadata();
+    newCaseMetadata.setSecureEstablishment(sourceMetadata.getSecureEstablishment());
+    return newCaseMetadata;
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
@@ -252,6 +252,7 @@ public class AddressReceiverIT {
     sourceCase.setCaseType("HH");
     sourceCase.setAddressLevel("U");
     sourceCase.setCollectionExerciseId(censuscollectionExerciseId);
+    sourceCase.getMetadata().setSecureEstablishment(true);
     sourceCase = caseRepository.saveAndFlush(sourceCase);
 
     Address address = new Address();
@@ -295,7 +296,7 @@ public class AddressReceiverIT {
     assertThat(actualCase.getCollectionExerciseId()).isEqualTo(censuscollectionExerciseId);
     assertThat(actualCase.getActionPlanId()).isEqualTo(censusActionPlanId);
     assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
-    assertThat(actualCase.isSkeleton()).isFalse();
+    assertThat(actualCase.isSkeleton()).isTrue();
     assertThat(actualCase.getCaseType()).isEqualTo(collectionCase.getAddress().getAddressType());
     assertThat(actualCase.getAddressLine1()).isEqualTo(sourceCase.getAddressLine1());
     assertThat(actualCase.getAddressLine2()).isEqualTo(sourceCase.getAddressLine2());
@@ -315,6 +316,7 @@ public class AddressReceiverIT {
     assertThat(actualCase.getTreatmentCode()).isNull();
 
     assertThat(actualCase.getEstabUprn()).isEqualTo(sourceCase.getEstabUprn());
+    assertThat(actualCase.getMetadata().getSecureEstablishment()).isTrue();
 
     assertThat(actualCase.isReceiptReceived()).isFalse();
     assertThat(actualCase.isRefusalReceived()).isFalse();
@@ -344,6 +346,7 @@ public class AddressReceiverIT {
     sourceCase.setCaseType("HH");
     sourceCase.setAddressLevel("U");
     sourceCase.setCollectionExerciseId(censuscollectionExerciseId);
+    sourceCase.getMetadata().setSecureEstablishment(false);
     sourceCase = caseRepository.saveAndFlush(sourceCase);
 
     Address address = new Address();
@@ -405,7 +408,7 @@ public class AddressReceiverIT {
     assertThat(actualCase.getActionPlanId()).isEqualTo(censusActionPlanId);
     assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
     assertThat(actualCase.getCaseType()).isEqualTo(collectionCase.getCaseType());
-    assertThat(actualCase.isSkeleton()).isFalse();
+    assertThat(actualCase.isSkeleton()).isTrue();
 
     assertThat(actualCase.getAddressLine1())
         .isEqualTo(collectionCase.getAddress().getAddressLine1());
@@ -431,6 +434,7 @@ public class AddressReceiverIT {
     assertThat(actualCase.getTreatmentCode()).isEqualTo(collectionCase.getTreatmentCode());
 
     assertThat(actualCase.getEstabUprn()).isEqualTo(sourceCase.getEstabUprn());
+    assertThat(actualCase.getMetadata().getSecureEstablishment()).isFalse();
 
     assertThat(actualCase.isReceiptReceived()).isFalse();
     assertThat(actualCase.isRefusalReceived()).isFalse();

--- a/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
@@ -195,6 +195,7 @@ public class NewAddressReportedServiceTest {
     EasyRandom easyRandom = new EasyRandom();
     Case sourceCase = easyRandom.nextObject(Case.class);
     sourceCase.setCaseId(UUID.randomUUID());
+    sourceCase.getMetadata().setSecureEstablishment(true);
     ResponseManagementEvent newAddressEvent = getMinimalValidNewAddress();
     OffsetDateTime timeNow = OffsetDateTime.now();
     newAddressEvent.getEvent().setChannel("NOT FIELD");
@@ -211,6 +212,7 @@ public class NewAddressReportedServiceTest {
     CollectionCase newAddressCollectionCase =
         newAddressEvent.getPayload().getNewAddress().getCollectionCase();
 
+    assertThat(newCase.isSkeleton()).isTrue();
     assertThat(newCase.getAddressLine1()).isEqualTo(sourceCase.getAddressLine1());
     assertThat(newCase.getAddressLine2()).isEqualTo(sourceCase.getAddressLine2());
     assertThat(newCase.getAddressLine3()).isEqualTo(sourceCase.getAddressLine3());
@@ -222,6 +224,7 @@ public class NewAddressReportedServiceTest {
     assertThat(newCase.getLatitude()).isNull();
 
     assertThat(newCase.getEstabUprn()).isEqualTo(sourceCase.getEstabUprn());
+    assertThat(newCase.getMetadata().getSecureEstablishment()).isTrue();
   }
 
   @Test
@@ -229,6 +232,7 @@ public class NewAddressReportedServiceTest {
     EasyRandom easyRandom = new EasyRandom();
     Case sourceCase = easyRandom.nextObject(Case.class);
     sourceCase.setCaseId(UUID.randomUUID());
+    sourceCase.getMetadata().setSecureEstablishment(false);
     ResponseManagementEvent newAddressEvent = getMinimalValidNewAddress();
     newAddressEvent
         .getPayload()
@@ -258,6 +262,7 @@ public class NewAddressReportedServiceTest {
     CollectionCase newAddressCollectionCase =
         newAddressEvent.getPayload().getNewAddress().getCollectionCase();
 
+    assertThat(newCase.isSkeleton()).isTrue();
     assertThat(newCase.getAddressLine1())
         .isEqualTo(newAddressCollectionCase.getAddress().getAddressLine1());
     assertThat(newCase.getCaseId().toString()).isEqualTo(newAddressCollectionCase.getId());
@@ -266,6 +271,7 @@ public class NewAddressReportedServiceTest {
     assertThat(newCase.getLatitude())
         .isEqualTo(newAddressCollectionCase.getAddress().getLatitude());
     assertThat(newCase.getEstabUprn()).isEqualTo(sourceCase.getEstabUprn());
+    assertThat(newCase.getMetadata().getSecureEstablishment()).isFalse();
 
     verify(caseService).saveCaseAndEmitCaseCreatedEvent(newCase, null);
   }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If a new address event came in with a source case Id, the new case wasn't being set as a skeleton case. Also, the case metadata needed copying over (at the moment, only secure establishment).

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
New case has its skeleton flag ticked.
Method added to set the case metadata (might be useful for future if more properties are added to the case metadata. If there is something in the case metadata we don't want being copied into the new case, we can set here).
Tests updated.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
maven clean install, run alongside acceptance tests on branch of [the same name](https://github.com/ONSdigital/census-rm-acceptance-tests/pull/239).

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/2pT2lf1x/874-add-more-fields-from-source-case-id-upon-receiving-newaddressreported-3
# Screenshots (if appropriate):