### PR TITLE
Send update to field for CE cases when UAA

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiver.java
@@ -82,6 +82,6 @@ public class UndeliveredMailReceiver {
     return !caze.isRefusalReceived()
         && !caze.isAddressInvalid()
         && !caze.isReceiptReceived()
-        && (!caze.getRegion().startsWith("N") && !caze.getAddressType().equals("CE"));
+        && !(caze.getRegion().startsWith("N") && caze.getCaseType().equals("CE"));
   }
 }


### PR DESCRIPTION
# Motivation and Context
There was a defect which was stopping English and Welsh CE cases being sent to field when we receive an Undelivered As Addressed message.

# What has changed
Fixed the bug. Improved the tests.

# How to test?
Run the tests.

# Links
Trello: https://trello.com/c/tUUaxWm6