### PR TITLE
910 copy lat long from source case id overwrite with anything on event

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -215,9 +215,12 @@ public class NewAddressReportedService {
     // Set fields empty/null/blank unless they come from the event
     newCase.setOrganisationName(
         getEventValOverSource(null, newCollectionCase.getAddress().getOrganisationName()));
-    newCase.setLatitude(getEventValOverSource(null, newCollectionCase.getAddress().getLatitude()));
+    newCase.setLatitude(
+        getEventValOverSource(
+            sourceCase.getLatitude(), newCollectionCase.getAddress().getLatitude()));
     newCase.setLongitude(
-        getEventValOverSource(null, newCollectionCase.getAddress().getLongitude()));
+        getEventValOverSource(
+            sourceCase.getLongitude(), newCollectionCase.getAddress().getLongitude()));
     newCase.setUprn(getEventValOverSource(null, newCollectionCase.getAddress().getUprn()));
     newCase.setCeExpectedCapacity(
         getEventValOverSource(null, newCollectionCase.getCeExpectedCapacity()));

--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -212,11 +212,11 @@ public class NewAddressReportedService {
         getEventValOverSource(
             sourceCase.getFieldOfficerId(), newCollectionCase.getFieldOfficerId()));
     newCase.setLatitude(
-            getEventValOverSource(
-                    sourceCase.getLatitude(), newCollectionCase.getAddress().getLatitude()));
+        getEventValOverSource(
+            sourceCase.getLatitude(), newCollectionCase.getAddress().getLatitude()));
     newCase.setLongitude(
-            getEventValOverSource(
-                    sourceCase.getLongitude(), newCollectionCase.getAddress().getLongitude()));
+        getEventValOverSource(
+            sourceCase.getLongitude(), newCollectionCase.getAddress().getLongitude()));
 
     // Set fields empty/null/blank unless they come from the event
     newCase.setOrganisationName(

--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -211,16 +211,16 @@ public class NewAddressReportedService {
     newCase.setFieldOfficerId(
         getEventValOverSource(
             sourceCase.getFieldOfficerId(), newCollectionCase.getFieldOfficerId()));
+    newCase.setLatitude(
+            getEventValOverSource(
+                    sourceCase.getLatitude(), newCollectionCase.getAddress().getLatitude()));
+    newCase.setLongitude(
+            getEventValOverSource(
+                    sourceCase.getLongitude(), newCollectionCase.getAddress().getLongitude()));
 
     // Set fields empty/null/blank unless they come from the event
     newCase.setOrganisationName(
         getEventValOverSource(null, newCollectionCase.getAddress().getOrganisationName()));
-    newCase.setLatitude(
-        getEventValOverSource(
-            sourceCase.getLatitude(), newCollectionCase.getAddress().getLatitude()));
-    newCase.setLongitude(
-        getEventValOverSource(
-            sourceCase.getLongitude(), newCollectionCase.getAddress().getLongitude()));
     newCase.setUprn(getEventValOverSource(null, newCollectionCase.getAddress().getUprn()));
     newCase.setCeExpectedCapacity(
         getEventValOverSource(null, newCollectionCase.getCeExpectedCapacity()));

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
@@ -310,8 +310,8 @@ public class AddressReceiverIT {
     assertThat(actualCase.getFieldOfficerId()).isEqualTo(sourceCase.getFieldOfficerId());
 
     assertThat(actualCase.getOrganisationName()).isNull();
-    assertThat(actualCase.getLatitude()).isNull();
-    assertThat(actualCase.getLongitude()).isNull();
+    assertThat(actualCase.getLatitude()).isEqualTo(sourceCase.getLatitude());
+    assertThat(actualCase.getLongitude()).isEqualTo(sourceCase.getLongitude());
     assertThat(actualCase.getUprn()).isNull();
     assertThat(actualCase.getTreatmentCode()).isNull();
 

--- a/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
@@ -221,10 +221,11 @@ public class NewAddressReportedServiceTest {
     assertThat(newCase.getAddressType())
         .isEqualTo(newAddressCollectionCase.getAddress().getAddressType());
 
-    assertThat(newCase.getLatitude()).isNull();
-
     assertThat(newCase.getEstabUprn()).isEqualTo(sourceCase.getEstabUprn());
     assertThat(newCase.getMetadata().getSecureEstablishment()).isTrue();
+
+    assertThat(newCase.getLongitude()).isEqualTo(sourceCase.getLongitude());
+    assertThat(newCase.getLatitude()).isEqualTo(sourceCase.getLatitude());
   }
 
   @Test
@@ -246,6 +247,13 @@ public class NewAddressReportedServiceTest {
         .getCollectionCase()
         .getAddress()
         .setLatitude("51.47");
+    newAddressEvent
+        .getPayload()
+        .getNewAddress()
+        .getCollectionCase()
+        .getAddress()
+        .setLongitude("1.34");
+
     OffsetDateTime timeNow = OffsetDateTime.now();
 
     newAddressEvent.getEvent().setChannel("NOT FIELD");
@@ -270,6 +278,8 @@ public class NewAddressReportedServiceTest {
         .isEqualTo(newAddressCollectionCase.getAddress().getAddressType());
     assertThat(newCase.getLatitude())
         .isEqualTo(newAddressCollectionCase.getAddress().getLatitude());
+    assertThat(newCase.getLongitude())
+        .isEqualTo(newAddressCollectionCase.getAddress().getLongitude());
     assertThat(newCase.getEstabUprn()).isEqualTo(sourceCase.getEstabUprn());
     assertThat(newCase.getMetadata().getSecureEstablishment()).isFalse();
 


### PR DESCRIPTION
# Motivation and Context
When a newAddress reported has no Long/Lat on the event, if it has a source case copy them from that

# What has changed
Copies source rather than null for lat/long

# How to test?
mvn clean install
& with ATs on card

# Links
https://trello.com/c/nPtXCwKt/910-copy-lat-long-from-source-case-id-overwrite-with-anything-on-event-3