### PR TITLE
Changes to add individual case id for PQ link event for HIs

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/UacDTO.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/UacDTO.java
@@ -16,4 +16,5 @@ public class UacDTO {
   private String caseId;
   private String collectionExerciseId;
   private String formType;
+  private String individualCaseId;
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverIT.java
@@ -144,7 +144,7 @@ public class QuestionnaireLinkedReceiverIT {
     assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
     assertThat(actualUacQidLink.isActive()).isTrue();
 
-    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 2, true);
+    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 2, false);
   }
 
   @Test
@@ -205,7 +205,7 @@ public class QuestionnaireLinkedReceiverIT {
     UacQidLink actualUacQidLink = uacQidLinks.get(0);
     assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
 
-    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 2, true);
+    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 2, false);
   }
 
   @Test
@@ -275,7 +275,7 @@ public class QuestionnaireLinkedReceiverIT {
     UacQidLink actualUacQidLink = uacQidLinks.get(0);
     assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
 
-    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 2, true);
+    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 2, false);
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverIT.java
@@ -323,8 +323,6 @@ public class QuestionnaireLinkedReceiverIT {
     CollectionCase actualCollectionCase = responseManagementEvent.getPayload().getCollectionCase();
     assertThat(actualCollectionCase.getCaseType()).isEqualTo("HI");
 
-    //    String expectedHICaseId = actualCollectionCase.getId();
-
     // Check Uac updated message sent and contains expected data
     responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(outboundUacQueue);
     assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.UAC_UPDATED);

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverIT.java
@@ -144,7 +144,7 @@ public class QuestionnaireLinkedReceiverIT {
     assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
     assertThat(actualUacQidLink.isActive()).isTrue();
 
-    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 2, 2);
+    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 2, true);
   }
 
   @Test
@@ -205,7 +205,7 @@ public class QuestionnaireLinkedReceiverIT {
     UacQidLink actualUacQidLink = uacQidLinks.get(0);
     assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
 
-    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 2, 2);
+    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 2, true);
   }
 
   @Test
@@ -275,7 +275,7 @@ public class QuestionnaireLinkedReceiverIT {
     UacQidLink actualUacQidLink = uacQidLinks.get(0);
     assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
 
-    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 2, 2);
+    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 2, true);
   }
 
   @Test
@@ -347,7 +347,7 @@ public class QuestionnaireLinkedReceiverIT {
 
     List<Event> events = eventRepository.findAll(new Sort(ASC, "rmEventProcessed"));
 
-    validateEvents(events, expectedQuestionnaireId, 2, 3);
+    validateEvents(events, expectedQuestionnaireId, 2, true);
   }
 
   @Test
@@ -398,7 +398,7 @@ public class QuestionnaireLinkedReceiverIT {
 
     List<Event> events = eventRepository.findAll(new Sort(ASC, "rmEventProcessed"));
 
-    validateEvents(events, expectedQuestionnaireId, 2, 2);
+    validateEvents(events, expectedQuestionnaireId, 2, false);
   }
 
   @Test
@@ -449,7 +449,7 @@ public class QuestionnaireLinkedReceiverIT {
 
     List<Event> events = eventRepository.findAll(new Sort(ASC, "rmEventProcessed"));
 
-    validateEvents(events, expectedQuestionnaireId, 2, 2);
+    validateEvents(events, expectedQuestionnaireId, 2, false);
   }
 
   @Test
@@ -508,7 +508,7 @@ public class QuestionnaireLinkedReceiverIT {
     assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
     assertThat(actualUacQidLink.isActive()).isFalse();
 
-    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 1, 2);
+    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 1, false);
   }
 
   @Test
@@ -566,11 +566,14 @@ public class QuestionnaireLinkedReceiverIT {
     assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
     assertThat(actualUacQidLink.isActive()).isFalse();
 
-    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 1, 2);
+    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 1, false);
   }
 
   private void validateEvents(
-      List<Event> events, String expectedQuestionnaireId, int execptedEventCount, int payloadLength)
+      List<Event> events,
+      String expectedQuestionnaireId,
+      int execptedEventCount,
+      boolean individualCaseIdExpected)
       throws JSONException {
     assertThat(events.size()).as("Event Count").isEqualTo(execptedEventCount);
 
@@ -587,10 +590,9 @@ public class QuestionnaireLinkedReceiverIT {
     assertThat(event.getEventDescription()).isEqualTo("Questionnaire Linked");
 
     JSONObject payload = new JSONObject(event.getEventPayload());
-    assertThat(payload.length()).isEqualTo(payloadLength);
     assertThat(payload.getString("caseId")).isEqualTo(TEST_CASE_ID.toString());
     assertThat(payload.getString("questionnaireId")).isEqualTo(expectedQuestionnaireId);
-    if (payloadLength == 3) {
+    if (individualCaseIdExpected) {
       assertThat(payload.getString("individualCaseId"))
           .isEqualTo(TEST_INDIVIDUAL_CASE_ID.toString());
     }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverIT.java
@@ -48,7 +48,9 @@ import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class QuestionnaireLinkedReceiverIT {
+
   private static final UUID TEST_CASE_ID = UUID.randomUUID();
+  private static final UUID TEST_INDIVIDUAL_CASE_ID = UUID.randomUUID();
   private static final EasyRandom easyRandom = new EasyRandom();
   private static final String QUESTIONNAIRE_LINKED_CHANNEL = "FIELD";
   private static final String QUESTIONNAIRE_LINKED_SOURCE = "FIELDWORK_GATEWAY";
@@ -142,7 +144,7 @@ public class QuestionnaireLinkedReceiverIT {
     assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
     assertThat(actualUacQidLink.isActive()).isTrue();
 
-    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 2);
+    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 2, 2);
   }
 
   @Test
@@ -203,7 +205,7 @@ public class QuestionnaireLinkedReceiverIT {
     UacQidLink actualUacQidLink = uacQidLinks.get(0);
     assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
 
-    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 2);
+    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 2, 2);
   }
 
   @Test
@@ -273,7 +275,7 @@ public class QuestionnaireLinkedReceiverIT {
     UacQidLink actualUacQidLink = uacQidLinks.get(0);
     assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
 
-    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 2);
+    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 2, 2);
   }
 
   @Test
@@ -305,6 +307,7 @@ public class QuestionnaireLinkedReceiverIT {
     UacDTO uac = new UacDTO();
     uac.setCaseId(TEST_CASE_ID.toString());
     uac.setQuestionnaireId(expectedQuestionnaireId);
+    uac.setIndividualCaseId(TEST_INDIVIDUAL_CASE_ID.toString());
     managementEvent.getPayload().setUac(uac);
 
     // WHEN
@@ -320,19 +323,19 @@ public class QuestionnaireLinkedReceiverIT {
     CollectionCase actualCollectionCase = responseManagementEvent.getPayload().getCollectionCase();
     assertThat(actualCollectionCase.getCaseType()).isEqualTo("HI");
 
-    String expectedHICaseId = actualCollectionCase.getId();
+    //    String expectedHICaseId = actualCollectionCase.getId();
 
     // Check Uac updated message sent and contains expected data
     responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(outboundUacQueue);
     assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.UAC_UPDATED);
     UacDTO actualUac = responseManagementEvent.getPayload().getUac();
     assertThat(actualUac.getQuestionnaireId()).isEqualTo(expectedQuestionnaireId);
-    assertThat(actualUac.getCaseId()).isEqualTo(expectedHICaseId);
+    assertThat(actualUac.getCaseId()).isEqualTo(TEST_INDIVIDUAL_CASE_ID.toString());
     assertThat(actualUac.getActive()).isTrue();
 
     // Check database HI Case created as expected
     Case actualHHCase = caseRepository.findById(TEST_CASE_ID).get();
-    Case actualHICase = caseRepository.findById(UUID.fromString(expectedHICaseId)).get();
+    Case actualHICase = caseRepository.findById(TEST_INDIVIDUAL_CASE_ID).get();
     assertThat(actualHICase.getCaseType()).isEqualTo("HI");
     assertThat(actualHICase.getUprn()).isEqualTo(actualHHCase.getUprn());
     assertThat(actualHICase.getEstabUprn()).isEqualTo(actualHHCase.getEstabUprn());
@@ -346,7 +349,7 @@ public class QuestionnaireLinkedReceiverIT {
 
     List<Event> events = eventRepository.findAll(new Sort(ASC, "rmEventProcessed"));
 
-    validateEvents(events, expectedQuestionnaireId, 2);
+    validateEvents(events, expectedQuestionnaireId, 2, 3);
   }
 
   @Test
@@ -397,7 +400,7 @@ public class QuestionnaireLinkedReceiverIT {
 
     List<Event> events = eventRepository.findAll(new Sort(ASC, "rmEventProcessed"));
 
-    validateEvents(events, expectedQuestionnaireId, 2);
+    validateEvents(events, expectedQuestionnaireId, 2, 2);
   }
 
   @Test
@@ -448,7 +451,7 @@ public class QuestionnaireLinkedReceiverIT {
 
     List<Event> events = eventRepository.findAll(new Sort(ASC, "rmEventProcessed"));
 
-    validateEvents(events, expectedQuestionnaireId, 2);
+    validateEvents(events, expectedQuestionnaireId, 2, 2);
   }
 
   @Test
@@ -507,7 +510,7 @@ public class QuestionnaireLinkedReceiverIT {
     assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
     assertThat(actualUacQidLink.isActive()).isFalse();
 
-    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 1);
+    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 1, 2);
   }
 
   @Test
@@ -565,11 +568,11 @@ public class QuestionnaireLinkedReceiverIT {
     assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
     assertThat(actualUacQidLink.isActive()).isFalse();
 
-    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 1);
+    validateEvents(eventRepository.findAll(), expectedQuestionnaireId, 1, 2);
   }
 
   private void validateEvents(
-      List<Event> events, String expectedQuestionnaireId, int execptedEventCount)
+      List<Event> events, String expectedQuestionnaireId, int execptedEventCount, int payloadLength)
       throws JSONException {
     assertThat(events.size()).as("Event Count").isEqualTo(execptedEventCount);
 
@@ -586,9 +589,13 @@ public class QuestionnaireLinkedReceiverIT {
     assertThat(event.getEventDescription()).isEqualTo("Questionnaire Linked");
 
     JSONObject payload = new JSONObject(event.getEventPayload());
-    assertThat(payload.length()).isEqualTo(2);
+    assertThat(payload.length()).isEqualTo(payloadLength);
     assertThat(payload.getString("caseId")).isEqualTo(TEST_CASE_ID.toString());
     assertThat(payload.getString("questionnaireId")).isEqualTo(expectedQuestionnaireId);
+    if (payloadLength == 3) {
+      assertThat(payload.getString("individualCaseId"))
+          .isEqualTo(TEST_INDIVIDUAL_CASE_ID.toString());
+    }
   }
 
   private ResponseManagementEvent sendMessageAndExpectInboundMessage(

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
@@ -391,6 +391,7 @@ public class ReceiptReceiverIT {
       UacDTO uac = new UacDTO();
       uac.setCaseId(caseId);
       uac.setQuestionnaireId(expectedQuestionnaireId);
+      uac.setIndividualCaseId(null);
       managementEvent.getPayload().setUac(uac);
 
       qidLinkingMsgs[i] =


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When a PQ link event comes in with an individual QID, and the parent case is a HH, the event carries an individualCaseId to set the created HIs cases case_id.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Logic added to check what is required to create a HI case, and error where things are missing. Tests updated and added.
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build branch and run with acceptance tests on [branch of the same name](https://github.com/ONSdigital/census-rm-acceptance-tests/pull/247).
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/pquWVfXV/835-create-hi-case-for-individual-pq-link-event-8
# Screenshots (if appropriate):