### PR TITLE
Don't unreceipt cases which were receipted by EQ

### DIFF
--- a/src/test/java/uk/gov/ons/census/casesvc/service/QidReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/QidReceiptServiceTest.java
@@ -200,6 +200,7 @@ public class QidReceiptServiceTest {
     underTest.processUnreceipt(managementEvent, OffsetDateTime.now(), uacQidLink);
 
     // Then
+    verifyZeroInteractions(uacService);
     verifyZeroInteractions(caseReceiptService);
     verifyZeroInteractions(blankQuestionnaireService);
     verifyZeroInteractions(eventLogger);


### PR DESCRIPTION
# Motivation and Context
We want to stop the unreceipting of the tiny handful of cases which have been receipted via EQ, but the respondent also posted back the blank questionnaire.

# What has changed
Check to see if an EQ receipt has been received on the same QID and ignore the unreceipt if it has.

# How to test?
Load a sample. Receipt the case via EQ. Then, receipt it again via the paper receipting process, but mark it as blank. The blank should be ignored.

# Links
Trello: https://trello.com/c/yAgPc1W1