### PR TITLE
AM1 7.1 new address HI telephone capture

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
@@ -254,6 +254,7 @@ public class CaseService {
     individualResponseCase.setMsoa(parentCase.getMsoa());
     individualResponseCase.setLad(parentCase.getLad());
     individualResponseCase.setRegion(parentCase.getRegion());
+    individualResponseCase.setSkeleton(parentCase.isSkeleton());
     individualResponseCase.setSurvey(
         parentCase.getSurvey()); // Should only ever be "CENSUS" from the parent case
 

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
@@ -401,6 +401,27 @@ public class CaseServiceTest {
         underTest.prepareIndividualResponseCaseFromParentCase(parentCase, childCaseId);
 
     // Then
+    assertChildCaseIsCorrect(parentCase, childCaseId, actualChildCase);
+  }
+
+  @Test
+  public void checkIndividualCaseCreatedCorrectlyFromSkeleton() {
+    // Given
+    EasyRandom easyRandom = new EasyRandom();
+    Case parentCase = easyRandom.nextObject(Case.class);
+    UUID childCaseId = UUID.randomUUID();
+
+    parentCase.setSkeleton(true);
+
+    // When
+    Case actualChildCase =
+        underTest.prepareIndividualResponseCaseFromParentCase(parentCase, childCaseId);
+
+    // Then
+    assertChildCaseIsCorrect(parentCase, childCaseId, actualChildCase);
+  }
+
+  private void assertChildCaseIsCorrect(Case parentCase, UUID childCaseId, Case actualChildCase) {
     assertThat(actualChildCase.getCaseRef()).isNotEqualTo(parentCase.getCaseRef());
     assertThat(UUID.fromString(actualChildCase.getCaseId().toString()))
         .isNotEqualTo(parentCase.getCaseId());
@@ -439,6 +460,7 @@ public class CaseServiceTest {
     assertThat(actualChildCase.getTreatmentCode()).isNull();
     assertThat(actualChildCase.getCeExpectedCapacity()).isNull();
     assertThat(actualChildCase.getAddressLevel()).isEqualTo(parentCase.getAddressLevel());
+    assertThat(actualChildCase.isSkeleton()).isEqualTo(parentCase.isSkeleton());
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
Child cases from skeleton cases should be marked as such

# What has changed
* Copy over skeleton marker when creating a child individual case

# How to test?
Run the new AT for individual telephone capture on newly reported address, check the skeleton flag is set in the DB on the HI case created

# Links
https://trello.com/c/zwSsVjsD/713-am1-part-71-new-address-create-hi-case-for-telephone-capture-3
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/249