### PR TITLE
Standardising Wording to camelCase

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/SampleUnitDTO.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/SampleUnitDTO.java
@@ -1,6 +1,5 @@
 package uk.gov.ons.census.casesvc.model.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data

--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/SampleUnitDTO.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/SampleUnitDTO.java
@@ -17,9 +17,9 @@ public class SampleUnitDTO {
   private String latitude;
   private String longitude;
 
-  @JsonProperty("fieldcoordinatorId")
+  @JsonProperty("fieldCoordinatorId")
   private String fieldCoordinatorId;
 
-  @JsonProperty("fieldofficerId")
+  @JsonProperty("fieldOfficerId")
   private String fieldOfficerId;
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/SampleUnitDTO.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/SampleUnitDTO.java
@@ -16,10 +16,6 @@ public class SampleUnitDTO {
   private String postcode;
   private String latitude;
   private String longitude;
-
-  @JsonProperty("fieldCoordinatorId")
   private String fieldCoordinatorId;
-
-  @JsonProperty("fieldOfficerId")
   private String fieldOfficerId;
 }


### PR DESCRIPTION
# Motivation and Context
Some places in the event dictionary used fieldofficerId & fieldcoordinatorId (note lowercase letters) when RM uses fieldOfficerId & fieldCoordinatorId
Need to have it changed to camelCase

# What has changed
Typo changes in JSON in SampleUnitDTO

# How to test?
Build and view output after tests are run

# Links
https://trello.com/c/hdCMxP1S/883-fieldcoordinatorid-fieldofficerid-need-to-use-standardised-camel-case-across-census-3