### PR TITLE
Capture callId on refusals

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/RefusalDTO.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/RefusalDTO.java
@@ -12,5 +12,6 @@ public class RefusalDTO {
   private RefusalType type;
   private String report;
   private String agentId;
+  private String callId;
   private CollectionCase collectionCase;
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverIT.java
@@ -128,6 +128,7 @@ public class RefusalReceiverIT {
     assertThat(actualRefusal.getType()).isEqualTo(expectedRefusal.getType());
     assertThat(actualRefusal.getReport()).isEqualTo(expectedRefusal.getReport());
     assertThat(actualRefusal.getAgentId()).isEqualTo(expectedRefusal.getAgentId());
+    assertThat(actualRefusal.getCallId()).isEqualTo(expectedRefusal.getCallId());
     assertThat(actualRefusal.getCollectionCase().getId())
         .isEqualTo(expectedRefusal.getCollectionCase().getId());
   }
@@ -188,6 +189,7 @@ public class RefusalReceiverIT {
     assertThat(actualRefusal.getType()).isEqualTo(RefusalType.HARD_REFUSAL);
     assertThat(actualRefusal.getReport()).isEqualTo(refusalDTO.getReport());
     assertThat(actualRefusal.getAgentId()).isEqualTo(refusalDTO.getAgentId());
+    assertThat(actualRefusal.getCallId()).isEqualTo(refusalDTO.getCallId());
     assertThat(actualRefusal.getCollectionCase().getId())
         .isEqualTo(refusalDTO.getCollectionCase().getId());
   }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverTest.java
@@ -1,15 +1,12 @@
 package uk.gov.ons.census.casesvc.messaging;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static uk.gov.ons.census.casesvc.testutil.DataUtils.getTestResponseManagementEvent;
 import static uk.gov.ons.census.casesvc.testutil.MessageConstructor.constructMessageWithValidTimeStamp;
 
 import java.time.OffsetDateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -28,9 +25,7 @@ public class RefusalReceiverTest {
   @Test
   public void shouldProcessARefusalReceivedMessageSuccessfully() {
     // GIVEN
-    ResponseManagementEvent managementEvent = getTestResponseManagementEvent();
-    String expectedCaseId = managementEvent.getPayload().getCollectionCase().getId();
-
+    ResponseManagementEvent managementEvent = new ResponseManagementEvent();
     Message<ResponseManagementEvent> message = constructMessageWithValidTimeStamp(managementEvent);
     OffsetDateTime expectedDate = MsgDateHelper.getMsgTimeStamp(message);
 
@@ -38,13 +33,6 @@ public class RefusalReceiverTest {
     underTest.receiveMessage(message);
 
     // THEN
-    ArgumentCaptor<ResponseManagementEvent> managementEventArgumentCaptor =
-        ArgumentCaptor.forClass(ResponseManagementEvent.class);
-    verify(refusalService)
-        .processRefusal(managementEventArgumentCaptor.capture(), eq(expectedDate));
-
-    String actualCaseId =
-        managementEventArgumentCaptor.getValue().getPayload().getCollectionCase().getId();
-    assertThat(actualCaseId).isEqualTo(expectedCaseId);
+    verify(refusalService).processRefusal(eq(managementEvent), eq(expectedDate));
   }
 }


### PR DESCRIPTION
# Motivation and Context
We want to be able to capture a callId sent from CC/Field on refusals because reasons.

# What has changed
Added the callId to the DTO.

# How to test?
Send in a refusal including a callId. Check the event table to make sure it got persisted.

# Links
Trello: https://trello.com/c/ZwNBjX2s