### PR TITLE
Fix flakey slow integration tests

### DIFF
--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/ActionSchedulerEventReceieverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/ActionSchedulerEventReceieverIT.java
@@ -14,7 +14,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -34,7 +33,6 @@ import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class ActionSchedulerEventReceieverIT {
   private static final UUID TEST_CASE_ID = UUID.randomUUID();

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
@@ -8,14 +8,11 @@ import static uk.gov.ons.census.casesvc.testutil.DataUtils.createTestAddressModi
 import static uk.gov.ons.census.casesvc.testutil.DataUtils.createTestAddressTypeChangeJson;
 import static uk.gov.ons.census.casesvc.utility.JsonHelper.convertObjectToJson;
 
-import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.BlockingQueue;
 import org.jeasy.random.EasyRandom;
-import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,7 +24,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Sort;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -48,13 +44,13 @@ import uk.gov.ons.census.casesvc.model.entity.EventType;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 import uk.gov.ons.census.casesvc.model.repository.EventRepository;
 import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
+import uk.gov.ons.census.casesvc.testutil.QueueSpy;
 import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 import uk.gov.ons.census.casesvc.utility.JsonHelper;
 
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class AddressReceiverIT {
   private static final UUID TEST_CASE_ID = UUID.randomUUID();
@@ -87,74 +83,77 @@ public class AddressReceiverIT {
   }
 
   @Test
-  public void testInvalidAddress() throws InterruptedException, IOException {
-    // GIVEN
-    BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(rhCaseQueue);
+  public void testInvalidAddress() throws Exception {
+    try (QueueSpy rhCaseQueueSpy = rabbitQueueHelper.listen(rhCaseQueue)) {
+      // GIVEN
+      EasyRandom easyRandom = new EasyRandom();
+      Case caze = easyRandom.nextObject(Case.class);
+      caze.setCaseId(TEST_CASE_ID);
+      caze.setSurvey("CENSUS");
+      caze.setUacQidLinks(null);
+      caze.setEvents(null);
+      caze.setAddressInvalid(false);
+      caze = caseRepository.saveAndFlush(caze);
 
-    EasyRandom easyRandom = new EasyRandom();
-    Case caze = easyRandom.nextObject(Case.class);
-    caze.setCaseId(TEST_CASE_ID);
-    caze.setSurvey("CENSUS");
-    caze.setUacQidLinks(null);
-    caze.setEvents(null);
-    caze.setAddressInvalid(false);
-    caze = caseRepository.saveAndFlush(caze);
+      ResponseManagementEvent managementEvent = new ResponseManagementEvent();
+      managementEvent.setEvent(new EventDTO());
+      managementEvent.getEvent().setDateTime(OffsetDateTime.now());
+      managementEvent.getEvent().setChannel("Test channel");
+      managementEvent.getEvent().setSource("Test source");
+      managementEvent.getEvent().setType(EventTypeDTO.ADDRESS_NOT_VALID);
+      managementEvent.setPayload(new PayloadDTO());
+      managementEvent.getPayload().setInvalidAddress(new InvalidAddress());
+      managementEvent
+          .getPayload()
+          .getInvalidAddress()
+          .setCollectionCase(new CollectionCaseCaseId());
+      managementEvent
+          .getPayload()
+          .getInvalidAddress()
+          .getCollectionCase()
+          .setId(caze.getCaseId().toString());
 
-    ResponseManagementEvent managementEvent = new ResponseManagementEvent();
-    managementEvent.setEvent(new EventDTO());
-    managementEvent.getEvent().setDateTime(OffsetDateTime.now());
-    managementEvent.getEvent().setChannel("Test channel");
-    managementEvent.getEvent().setSource("Test source");
-    managementEvent.getEvent().setType(EventTypeDTO.ADDRESS_NOT_VALID);
-    managementEvent.setPayload(new PayloadDTO());
-    managementEvent.getPayload().setInvalidAddress(new InvalidAddress());
-    managementEvent.getPayload().getInvalidAddress().setCollectionCase(new CollectionCaseCaseId());
-    managementEvent
-        .getPayload()
-        .getInvalidAddress()
-        .getCollectionCase()
-        .setId(caze.getCaseId().toString());
+      String json = convertObjectToJson(managementEvent);
+      Message message =
+          MessageBuilder.withBody(json.getBytes())
+              .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+              .build();
 
-    String json = convertObjectToJson(managementEvent);
-    Message message =
-        MessageBuilder.withBody(json.getBytes())
-            .setContentType(MessageProperties.CONTENT_TYPE_JSON)
-            .build();
+      // WHEN
+      rabbitQueueHelper.sendMessage(addressReceiver, message);
 
-    // WHEN
-    rabbitQueueHelper.sendMessage(addressReceiver, message);
+      // THEN
 
-    // THEN
+      // check the emitted eventDTO
+      ResponseManagementEvent responseManagementEvent =
+          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
 
-    // check the emitted eventDTO
-    ResponseManagementEvent responseManagementEvent =
-        rabbitQueueHelper.checkExpectedMessageReceived(outboundQueue);
+      assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_UPDATED);
+      CollectionCase actualPayloadCase = responseManagementEvent.getPayload().getCollectionCase();
+      assertThat(actualPayloadCase.getId()).isEqualTo(caze.getCaseId().toString());
+      assertThat(actualPayloadCase.getAddressInvalid()).isTrue();
 
-    assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_UPDATED);
-    CollectionCase actualPayloadCase = responseManagementEvent.getPayload().getCollectionCase();
-    assertThat(actualPayloadCase.getId()).isEqualTo(caze.getCaseId().toString());
-    assertThat(actualPayloadCase.getAddressInvalid()).isTrue();
+      Case actualCase = caseRepository.findById(TEST_CASE_ID).get();
+      assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
+      assertThat(actualCase.isAddressInvalid()).isTrue();
 
-    Case actualCase = caseRepository.findById(TEST_CASE_ID).get();
-    assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
-    assertThat(actualCase.isAddressInvalid()).isTrue();
+      // check the metadata is included with field CANCEL decision
+      assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
+          .isEqualTo(ActionInstructionType.CANCEL);
+      assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
+          .isEqualTo(EventTypeDTO.ADDRESS_NOT_VALID);
 
-    // check the metadata is included with field CANCEL decision
-    assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
-        .isEqualTo(ActionInstructionType.CANCEL);
-    assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
-        .isEqualTo(EventTypeDTO.ADDRESS_NOT_VALID);
-
-    // check database for log eventDTO
-    List<Event> events = eventRepository.findAll();
-    assertThat(events.size()).isEqualTo(1);
-    Event event = events.get(0);
-    assertThat(event.getEventDescription()).isEqualTo("Invalid address");
-    assertThat(event.getEventType()).isEqualTo(EventType.ADDRESS_NOT_VALID);
+      // check database for log eventDTO
+      List<Event> events = eventRepository.findAll();
+      assertThat(events.size()).isEqualTo(1);
+      Event event = events.get(0);
+      assertThat(event.getEventDescription()).isEqualTo("Invalid address");
+      assertThat(event.getEventType()).isEqualTo(EventType.ADDRESS_NOT_VALID);
+    }
   }
 
   @Test
-  public void testAddressModifiedEventTypeLoggedOnly() throws InterruptedException, JSONException {
+  public void testAddressModifiedEventTypeLoggedOnly() throws Exception {
     PayloadDTO payload = new PayloadDTO();
     payload.setAddressModification(createTestAddressModifiedJson(TEST_CASE_ID));
 
@@ -167,8 +166,7 @@ public class AddressReceiverIT {
   }
 
   @Test
-  public void testAddressTypeChangeEventTypeLoggedOnly()
-      throws InterruptedException, JSONException {
+  public void testAddressTypeChangeEventTypeLoggedOnly() throws Exception {
     PayloadDTO payload = new PayloadDTO();
     payload.setAddressTypeChange(createTestAddressTypeChangeJson(TEST_CASE_ID));
 
@@ -181,274 +179,272 @@ public class AddressReceiverIT {
   }
 
   @Test
-  public void testNewAddressCreatesSkeletonCase() throws InterruptedException, IOException {
-    // GIVEN
-    BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(rhCaseQueue);
+  public void testNewAddressCreatesSkeletonCase() throws Exception {
+    try (QueueSpy rhCaseQueueSpy = rabbitQueueHelper.listen(rhCaseQueue)) {
+      // GIVEN
+      Address address = new Address();
+      address.setAddressLevel("E");
+      address.setAddressType("HH");
+      address.setRegion("W");
 
-    Address address = new Address();
-    address.setAddressLevel("E");
-    address.setAddressType("HH");
-    address.setRegion("W");
+      CollectionCase collectionCase = new CollectionCase();
+      collectionCase.setId(UUID.randomUUID().toString());
+      collectionCase.setAddress(address);
 
-    CollectionCase collectionCase = new CollectionCase();
-    collectionCase.setId(UUID.randomUUID().toString());
-    collectionCase.setAddress(address);
+      NewAddress newAddress = new NewAddress();
+      newAddress.setCollectionCase(collectionCase);
 
-    NewAddress newAddress = new NewAddress();
-    newAddress.setCollectionCase(collectionCase);
+      EventDTO eventDTO = new EventDTO();
+      eventDTO.setType(NEW_ADDRESS_REPORTED);
+      eventDTO.setDateTime(OffsetDateTime.now());
 
-    EventDTO eventDTO = new EventDTO();
-    eventDTO.setType(NEW_ADDRESS_REPORTED);
-    eventDTO.setDateTime(OffsetDateTime.now());
+      ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
+      responseManagementEvent.setEvent(eventDTO);
 
-    ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
-    responseManagementEvent.setEvent(eventDTO);
+      PayloadDTO payloadDTO = new PayloadDTO();
+      payloadDTO.setNewAddress(newAddress);
+      responseManagementEvent.setPayload(payloadDTO);
 
-    PayloadDTO payloadDTO = new PayloadDTO();
-    payloadDTO.setNewAddress(newAddress);
-    responseManagementEvent.setPayload(payloadDTO);
+      // WHEN
+      rabbitQueueHelper.sendMessage(addressReceiver, responseManagementEvent);
 
-    // WHEN
-    rabbitQueueHelper.sendMessage(addressReceiver, responseManagementEvent);
+      // THEN
+      ResponseManagementEvent actualResponseManagementEvent =
+          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
 
-    // THEN
-    ResponseManagementEvent actualResponseManagementEvent =
-        rabbitQueueHelper.checkExpectedMessageReceived(outboundQueue);
+      assertThat(actualResponseManagementEvent.getEvent().getType())
+          .isEqualTo(EventTypeDTO.CASE_CREATED);
+      CollectionCase actualPayloadCase =
+          actualResponseManagementEvent.getPayload().getCollectionCase();
+      assertThat(actualPayloadCase.getId()).isEqualTo(collectionCase.getId());
+      assertThat(actualPayloadCase.isSkeleton()).isTrue().as("Is Skeleton Case");
 
-    assertThat(actualResponseManagementEvent.getEvent().getType())
-        .isEqualTo(EventTypeDTO.CASE_CREATED);
-    CollectionCase actualPayloadCase =
-        actualResponseManagementEvent.getPayload().getCollectionCase();
-    assertThat(actualPayloadCase.getId()).isEqualTo(collectionCase.getId());
-    assertThat(actualPayloadCase.isSkeleton()).isTrue().as("Is Skeleton Case");
+      Case actualCase = caseRepository.findById(UUID.fromString(collectionCase.getId())).get();
+      assertThat(actualCase.getCollectionExerciseId()).isEqualTo(censuscollectionExerciseId);
+      assertThat(actualCase.getActionPlanId()).isEqualTo(censusActionPlanId);
+      assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
+      assertThat(actualCase.getCaseType()).isEqualTo("HH");
+      assertThat(actualCase.isSkeleton()).isTrue().as("Is Skeleton Case In DB");
 
-    Case actualCase = caseRepository.findById(UUID.fromString(collectionCase.getId())).get();
-    assertThat(actualCase.getCollectionExerciseId()).isEqualTo(censuscollectionExerciseId);
-    assertThat(actualCase.getActionPlanId()).isEqualTo(censusActionPlanId);
-    assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
-    assertThat(actualCase.getCaseType()).isEqualTo("HH");
-    assertThat(actualCase.isSkeleton()).isTrue().as("Is Skeleton Case In DB");
-
-    // check database for log eventDTO
-    List<Event> events = eventRepository.findAll();
-    assertThat(events.size()).isEqualTo(1);
-    Event event = events.get(0);
-    assertThat(event.getEventDescription()).isEqualTo("New Address reported");
-    assertThat(event.getEventType()).isEqualTo(EventType.NEW_ADDRESS_REPORTED);
+      // check database for log eventDTO
+      List<Event> events = eventRepository.findAll();
+      assertThat(events.size()).isEqualTo(1);
+      Event event = events.get(0);
+      assertThat(event.getEventDescription()).isEqualTo("New Address reported");
+      assertThat(event.getEventType()).isEqualTo(EventType.NEW_ADDRESS_REPORTED);
+    }
   }
 
   @Test
-  public void testNewAddressCreatedFromBasicEventAndSourceCase()
-      throws InterruptedException, IOException {
-    // GIVEN
-    BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(rhCaseQueue);
+  public void testNewAddressCreatedFromBasicEventAndSourceCase() throws Exception {
+    try (QueueSpy rhCaseQueueSpy = rabbitQueueHelper.listen(rhCaseQueue)) {
+      // GIVEN
+      EasyRandom easyRandom = new EasyRandom();
+      Case sourceCase = easyRandom.nextObject(Case.class);
+      sourceCase.setReceiptReceived(false);
+      sourceCase.setSurvey("CENSUS");
+      sourceCase.setUacQidLinks(null);
+      sourceCase.setEvents(null);
+      sourceCase.setCaseType("HH");
+      sourceCase.setAddressLevel("U");
+      sourceCase.setRefusalReceived(null);
+      sourceCase.setCollectionExerciseId(censuscollectionExerciseId);
+      sourceCase.getMetadata().setSecureEstablishment(true);
+      sourceCase = caseRepository.saveAndFlush(sourceCase);
 
-    EasyRandom easyRandom = new EasyRandom();
-    Case sourceCase = easyRandom.nextObject(Case.class);
-    sourceCase.setReceiptReceived(false);
-    sourceCase.setSurvey("CENSUS");
-    sourceCase.setUacQidLinks(null);
-    sourceCase.setEvents(null);
-    sourceCase.setCaseType("HH");
-    sourceCase.setAddressLevel("U");
-    sourceCase.setRefusalReceived(null);
-    sourceCase.setCollectionExerciseId(censuscollectionExerciseId);
-    sourceCase.getMetadata().setSecureEstablishment(true);
-    sourceCase = caseRepository.saveAndFlush(sourceCase);
+      Address address = new Address();
+      address.setAddressLevel("E");
+      address.setAddressType("HH");
+      address.setRegion("W");
 
-    Address address = new Address();
-    address.setAddressLevel("E");
-    address.setAddressType("HH");
-    address.setRegion("W");
+      CollectionCase collectionCase = new CollectionCase();
+      collectionCase.setId(UUID.randomUUID().toString());
+      collectionCase.setAddress(address);
 
-    CollectionCase collectionCase = new CollectionCase();
-    collectionCase.setId(UUID.randomUUID().toString());
-    collectionCase.setAddress(address);
+      NewAddress newAddress = new NewAddress();
+      newAddress.setCollectionCase(collectionCase);
+      newAddress.setSourceCaseId(sourceCase.getCaseId().toString());
 
-    NewAddress newAddress = new NewAddress();
-    newAddress.setCollectionCase(collectionCase);
-    newAddress.setSourceCaseId(sourceCase.getCaseId().toString());
+      EventDTO eventDTO = new EventDTO();
+      eventDTO.setType(NEW_ADDRESS_REPORTED);
+      eventDTO.setDateTime(OffsetDateTime.now());
 
-    EventDTO eventDTO = new EventDTO();
-    eventDTO.setType(NEW_ADDRESS_REPORTED);
-    eventDTO.setDateTime(OffsetDateTime.now());
+      ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
+      responseManagementEvent.setEvent(eventDTO);
 
-    ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
-    responseManagementEvent.setEvent(eventDTO);
+      PayloadDTO payloadDTO = new PayloadDTO();
+      payloadDTO.setNewAddress(newAddress);
+      responseManagementEvent.setPayload(payloadDTO);
 
-    PayloadDTO payloadDTO = new PayloadDTO();
-    payloadDTO.setNewAddress(newAddress);
-    responseManagementEvent.setPayload(payloadDTO);
+      // WHEN
+      rabbitQueueHelper.sendMessage(addressReceiver, responseManagementEvent);
 
-    // WHEN
-    rabbitQueueHelper.sendMessage(addressReceiver, responseManagementEvent);
+      // THEN
+      ResponseManagementEvent actualResponseManagementEvent =
+          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
 
-    // THEN
-    ResponseManagementEvent actualResponseManagementEvent =
-        rabbitQueueHelper.checkExpectedMessageReceived(outboundQueue);
+      assertThat(actualResponseManagementEvent.getEvent().getType())
+          .isEqualTo(EventTypeDTO.CASE_CREATED);
+      CollectionCase actualPayloadCase =
+          actualResponseManagementEvent.getPayload().getCollectionCase();
+      assertThat(actualPayloadCase.getId()).isEqualTo(collectionCase.getId());
 
-    assertThat(actualResponseManagementEvent.getEvent().getType())
-        .isEqualTo(EventTypeDTO.CASE_CREATED);
-    CollectionCase actualPayloadCase =
-        actualResponseManagementEvent.getPayload().getCollectionCase();
-    assertThat(actualPayloadCase.getId()).isEqualTo(collectionCase.getId());
+      Case actualCase = caseRepository.findById(UUID.fromString(collectionCase.getId())).get();
+      assertThat(actualCase.getCollectionExerciseId()).isEqualTo(censuscollectionExerciseId);
+      assertThat(actualCase.getActionPlanId()).isEqualTo(censusActionPlanId);
+      assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
+      assertThat(actualCase.isSkeleton()).isTrue();
+      assertThat(actualCase.getCaseType()).isEqualTo(collectionCase.getAddress().getAddressType());
+      assertThat(actualCase.getAddressLine1()).isEqualTo(sourceCase.getAddressLine1());
+      assertThat(actualCase.getAddressLine2()).isEqualTo(sourceCase.getAddressLine2());
+      assertThat(actualCase.getAddressLine3()).isEqualTo(sourceCase.getAddressLine3());
+      assertThat(actualCase.getPostcode()).isEqualTo(sourceCase.getPostcode());
+      assertThat(actualCase.getTownName()).isEqualTo(sourceCase.getTownName());
+      assertThat(actualCase.getCollectionExerciseId())
+          .isEqualTo(sourceCase.getCollectionExerciseId());
+      assertThat(actualCase.getEstabType()).isEqualTo(sourceCase.getEstabType());
+      assertThat(actualCase.getFieldCoordinatorId()).isEqualTo(sourceCase.getFieldCoordinatorId());
+      assertThat(actualCase.getFieldOfficerId()).isEqualTo(sourceCase.getFieldOfficerId());
 
-    Case actualCase = caseRepository.findById(UUID.fromString(collectionCase.getId())).get();
-    assertThat(actualCase.getCollectionExerciseId()).isEqualTo(censuscollectionExerciseId);
-    assertThat(actualCase.getActionPlanId()).isEqualTo(censusActionPlanId);
-    assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
-    assertThat(actualCase.isSkeleton()).isTrue();
-    assertThat(actualCase.getCaseType()).isEqualTo(collectionCase.getAddress().getAddressType());
-    assertThat(actualCase.getAddressLine1()).isEqualTo(sourceCase.getAddressLine1());
-    assertThat(actualCase.getAddressLine2()).isEqualTo(sourceCase.getAddressLine2());
-    assertThat(actualCase.getAddressLine3()).isEqualTo(sourceCase.getAddressLine3());
-    assertThat(actualCase.getPostcode()).isEqualTo(sourceCase.getPostcode());
-    assertThat(actualCase.getTownName()).isEqualTo(sourceCase.getTownName());
-    assertThat(actualCase.getCollectionExerciseId())
-        .isEqualTo(sourceCase.getCollectionExerciseId());
-    assertThat(actualCase.getEstabType()).isEqualTo(sourceCase.getEstabType());
-    assertThat(actualCase.getFieldCoordinatorId()).isEqualTo(sourceCase.getFieldCoordinatorId());
-    assertThat(actualCase.getFieldOfficerId()).isEqualTo(sourceCase.getFieldOfficerId());
+      assertThat(actualCase.getOrganisationName()).isNull();
+      assertThat(actualCase.getLatitude()).isEqualTo(sourceCase.getLatitude());
+      assertThat(actualCase.getLongitude()).isEqualTo(sourceCase.getLongitude());
+      assertThat(actualCase.getUprn()).isNull();
+      assertThat(actualCase.getTreatmentCode()).isNull();
 
-    assertThat(actualCase.getOrganisationName()).isNull();
-    assertThat(actualCase.getLatitude()).isEqualTo(sourceCase.getLatitude());
-    assertThat(actualCase.getLongitude()).isEqualTo(sourceCase.getLongitude());
-    assertThat(actualCase.getUprn()).isNull();
-    assertThat(actualCase.getTreatmentCode()).isNull();
+      assertThat(actualCase.getEstabUprn()).isEqualTo(sourceCase.getEstabUprn());
+      assertThat(actualCase.getMetadata().getSecureEstablishment()).isTrue();
 
-    assertThat(actualCase.getEstabUprn()).isEqualTo(sourceCase.getEstabUprn());
-    assertThat(actualCase.getMetadata().getSecureEstablishment()).isTrue();
+      assertThat(actualCase.isReceiptReceived()).isFalse();
+      assertThat(actualCase.getRefusalReceived()).isNull();
+      assertThat(actualCase.isAddressInvalid()).isFalse();
+      assertThat(actualCase.isHandDelivery()).isFalse();
 
-    assertThat(actualCase.isReceiptReceived()).isFalse();
-    assertThat(actualCase.getRefusalReceived()).isNull();
-    assertThat(actualCase.isAddressInvalid()).isFalse();
-    assertThat(actualCase.isHandDelivery()).isFalse();
-
-    // check database for log eventDTO
-    List<Event> events = eventRepository.findAll();
-    assertThat(events.size()).isEqualTo(1);
-    Event event = events.get(0);
-    assertThat(event.getEventDescription()).isEqualTo("New Address reported");
-    assertThat(event.getEventType()).isEqualTo(EventType.NEW_ADDRESS_REPORTED);
+      // check database for log eventDTO
+      List<Event> events = eventRepository.findAll();
+      assertThat(events.size()).isEqualTo(1);
+      Event event = events.get(0);
+      assertThat(event.getEventDescription()).isEqualTo("New Address reported");
+      assertThat(event.getEventType()).isEqualTo(EventType.NEW_ADDRESS_REPORTED);
+    }
   }
 
   @Test
-  public void testNewAddressCreatedFromEventWithDetailsAndSourceCase()
-      throws InterruptedException, IOException {
-    // GIVEN
-    BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(rhCaseQueue);
+  public void testNewAddressCreatedFromEventWithDetailsAndSourceCase() throws Exception {
+    try (QueueSpy rhCaseQueueSpy = rabbitQueueHelper.listen(rhCaseQueue)) {
+      // GIVEN
+      EasyRandom easyRandom = new EasyRandom();
+      Case sourceCase = easyRandom.nextObject(Case.class);
+      sourceCase.setReceiptReceived(false);
+      sourceCase.setSurvey("CENSUS");
+      sourceCase.setUacQidLinks(null);
+      sourceCase.setEvents(null);
+      sourceCase.setCaseType("HH");
+      sourceCase.setAddressLevel("U");
+      sourceCase.setCollectionExerciseId(censuscollectionExerciseId);
+      sourceCase.getMetadata().setSecureEstablishment(false);
+      sourceCase.setRefusalReceived(null);
+      sourceCase = caseRepository.saveAndFlush(sourceCase);
 
-    EasyRandom easyRandom = new EasyRandom();
-    Case sourceCase = easyRandom.nextObject(Case.class);
-    sourceCase.setReceiptReceived(false);
-    sourceCase.setSurvey("CENSUS");
-    sourceCase.setUacQidLinks(null);
-    sourceCase.setEvents(null);
-    sourceCase.setCaseType("HH");
-    sourceCase.setAddressLevel("U");
-    sourceCase.setCollectionExerciseId(censuscollectionExerciseId);
-    sourceCase.getMetadata().setSecureEstablishment(false);
-    sourceCase.setRefusalReceived(null);
-    sourceCase = caseRepository.saveAndFlush(sourceCase);
+      Address address = new Address();
+      address.setAddressLevel("E");
+      address.setAddressType("HH");
+      address.setRegion("W");
 
-    Address address = new Address();
-    address.setAddressLevel("E");
-    address.setAddressType("HH");
-    address.setRegion("W");
+      address.setAddressLine1("123");
+      address.setAddressLine2("Fake Street");
+      address.setAddressLine3("Made up district");
+      address.setTownName("Nowheresville");
+      address.setPostcode("AB12 3CD");
+      address.setEstabType("HH");
+      address.setOrganisationName("Super Org");
+      address.setLatitude("12.34");
+      address.setLongitude("56.78");
+      address.setUprn("uprn01");
 
-    address.setAddressLine1("123");
-    address.setAddressLine2("Fake Street");
-    address.setAddressLine3("Made up district");
-    address.setTownName("Nowheresville");
-    address.setPostcode("AB12 3CD");
-    address.setEstabType("HH");
-    address.setOrganisationName("Super Org");
-    address.setLatitude("12.34");
-    address.setLongitude("56.78");
-    address.setUprn("uprn01");
+      CollectionCase collectionCase = new CollectionCase();
+      collectionCase.setId(UUID.randomUUID().toString());
+      collectionCase.setAddress(address);
+      collectionCase.setFieldCoordinatorId("1234");
+      collectionCase.setFieldOfficerId("5678");
+      collectionCase.setCeExpectedCapacity(1);
+      collectionCase.setCaseType("SPG");
+      collectionCase.setTreatmentCode("TREAT");
 
-    CollectionCase collectionCase = new CollectionCase();
-    collectionCase.setId(UUID.randomUUID().toString());
-    collectionCase.setAddress(address);
-    collectionCase.setFieldCoordinatorId("1234");
-    collectionCase.setFieldOfficerId("5678");
-    collectionCase.setCeExpectedCapacity(1);
-    collectionCase.setCaseType("SPG");
-    collectionCase.setTreatmentCode("TREAT");
+      NewAddress newAddress = new NewAddress();
+      newAddress.setCollectionCase(collectionCase);
+      newAddress.setSourceCaseId(sourceCase.getCaseId().toString());
 
-    NewAddress newAddress = new NewAddress();
-    newAddress.setCollectionCase(collectionCase);
-    newAddress.setSourceCaseId(sourceCase.getCaseId().toString());
+      EventDTO eventDTO = new EventDTO();
+      eventDTO.setType(NEW_ADDRESS_REPORTED);
+      eventDTO.setDateTime(OffsetDateTime.now());
+      eventDTO.setChannel("FIELD");
 
-    EventDTO eventDTO = new EventDTO();
-    eventDTO.setType(NEW_ADDRESS_REPORTED);
-    eventDTO.setDateTime(OffsetDateTime.now());
-    eventDTO.setChannel("FIELD");
+      ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
+      responseManagementEvent.setEvent(eventDTO);
 
-    ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
-    responseManagementEvent.setEvent(eventDTO);
+      PayloadDTO payloadDTO = new PayloadDTO();
+      payloadDTO.setNewAddress(newAddress);
+      responseManagementEvent.setPayload(payloadDTO);
 
-    PayloadDTO payloadDTO = new PayloadDTO();
-    payloadDTO.setNewAddress(newAddress);
-    responseManagementEvent.setPayload(payloadDTO);
+      // WHEN
+      rabbitQueueHelper.sendMessage(addressReceiver, responseManagementEvent);
 
-    // WHEN
-    rabbitQueueHelper.sendMessage(addressReceiver, responseManagementEvent);
+      // THEN
+      ResponseManagementEvent actualResponseManagementEvent =
+          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
 
-    // THEN
-    ResponseManagementEvent actualResponseManagementEvent =
-        rabbitQueueHelper.checkExpectedMessageReceived(outboundQueue);
+      assertThat(actualResponseManagementEvent.getEvent().getType())
+          .isEqualTo(EventTypeDTO.CASE_CREATED);
+      CollectionCase actualPayloadCase =
+          actualResponseManagementEvent.getPayload().getCollectionCase();
+      assertThat(actualPayloadCase.getId()).isEqualTo(collectionCase.getId());
 
-    assertThat(actualResponseManagementEvent.getEvent().getType())
-        .isEqualTo(EventTypeDTO.CASE_CREATED);
-    CollectionCase actualPayloadCase =
-        actualResponseManagementEvent.getPayload().getCollectionCase();
-    assertThat(actualPayloadCase.getId()).isEqualTo(collectionCase.getId());
+      Case actualCase = caseRepository.findById(UUID.fromString(collectionCase.getId())).get();
+      assertThat(actualCase.getCollectionExerciseId()).isEqualTo(censuscollectionExerciseId);
+      assertThat(actualCase.getActionPlanId()).isEqualTo(censusActionPlanId);
+      assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
+      assertThat(actualCase.getCaseType()).isEqualTo(collectionCase.getCaseType());
+      assertThat(actualCase.isSkeleton()).isTrue();
 
-    Case actualCase = caseRepository.findById(UUID.fromString(collectionCase.getId())).get();
-    assertThat(actualCase.getCollectionExerciseId()).isEqualTo(censuscollectionExerciseId);
-    assertThat(actualCase.getActionPlanId()).isEqualTo(censusActionPlanId);
-    assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
-    assertThat(actualCase.getCaseType()).isEqualTo(collectionCase.getCaseType());
-    assertThat(actualCase.isSkeleton()).isTrue();
+      assertThat(actualCase.getAddressLine1())
+          .isEqualTo(collectionCase.getAddress().getAddressLine1());
+      assertThat(actualCase.getAddressLine2())
+          .isEqualTo(collectionCase.getAddress().getAddressLine2());
+      assertThat(actualCase.getAddressLine3())
+          .isEqualTo(collectionCase.getAddress().getAddressLine3());
+      assertThat(actualCase.getPostcode()).isEqualTo(collectionCase.getAddress().getPostcode());
+      assertThat(actualCase.getTownName()).isEqualTo(collectionCase.getAddress().getTownName());
+      assertThat(actualCase.getCollectionExerciseId())
+          .isEqualTo(sourceCase.getCollectionExerciseId());
+      assertThat(actualCase.getEstabType()).isEqualTo(collectionCase.getAddress().getEstabType());
+      assertThat(actualCase.getFieldCoordinatorId())
+          .isEqualTo(collectionCase.getFieldCoordinatorId());
+      assertThat(actualCase.getFieldOfficerId()).isEqualTo(collectionCase.getFieldOfficerId());
 
-    assertThat(actualCase.getAddressLine1())
-        .isEqualTo(collectionCase.getAddress().getAddressLine1());
-    assertThat(actualCase.getAddressLine2())
-        .isEqualTo(collectionCase.getAddress().getAddressLine2());
-    assertThat(actualCase.getAddressLine3())
-        .isEqualTo(collectionCase.getAddress().getAddressLine3());
-    assertThat(actualCase.getPostcode()).isEqualTo(collectionCase.getAddress().getPostcode());
-    assertThat(actualCase.getTownName()).isEqualTo(collectionCase.getAddress().getTownName());
-    assertThat(actualCase.getCollectionExerciseId())
-        .isEqualTo(sourceCase.getCollectionExerciseId());
-    assertThat(actualCase.getEstabType()).isEqualTo(collectionCase.getAddress().getEstabType());
-    assertThat(actualCase.getFieldCoordinatorId())
-        .isEqualTo(collectionCase.getFieldCoordinatorId());
-    assertThat(actualCase.getFieldOfficerId()).isEqualTo(collectionCase.getFieldOfficerId());
+      assertThat(actualCase.getOrganisationName())
+          .isEqualTo(collectionCase.getAddress().getOrganisationName());
+      assertThat(actualCase.getLatitude()).isEqualTo(collectionCase.getAddress().getLatitude());
+      assertThat(actualCase.getLongitude()).isEqualTo(collectionCase.getAddress().getLongitude());
+      assertThat(actualCase.getUprn()).isEqualTo(collectionCase.getAddress().getUprn());
+      assertThat(actualCase.getCaseType()).isEqualTo(collectionCase.getCaseType());
+      assertThat(actualCase.getTreatmentCode()).isEqualTo(collectionCase.getTreatmentCode());
 
-    assertThat(actualCase.getOrganisationName())
-        .isEqualTo(collectionCase.getAddress().getOrganisationName());
-    assertThat(actualCase.getLatitude()).isEqualTo(collectionCase.getAddress().getLatitude());
-    assertThat(actualCase.getLongitude()).isEqualTo(collectionCase.getAddress().getLongitude());
-    assertThat(actualCase.getUprn()).isEqualTo(collectionCase.getAddress().getUprn());
-    assertThat(actualCase.getCaseType()).isEqualTo(collectionCase.getCaseType());
-    assertThat(actualCase.getTreatmentCode()).isEqualTo(collectionCase.getTreatmentCode());
+      assertThat(actualCase.getEstabUprn()).isEqualTo(sourceCase.getEstabUprn());
+      assertThat(actualCase.getMetadata().getSecureEstablishment()).isFalse();
 
-    assertThat(actualCase.getEstabUprn()).isEqualTo(sourceCase.getEstabUprn());
-    assertThat(actualCase.getMetadata().getSecureEstablishment()).isFalse();
+      assertThat(actualCase.isReceiptReceived()).isFalse();
+      assertThat(actualCase.getRefusalReceived()).isNull();
+      assertThat(actualCase.isAddressInvalid()).isFalse();
+      assertThat(actualCase.isHandDelivery()).isFalse();
 
-    assertThat(actualCase.isReceiptReceived()).isFalse();
-    assertThat(actualCase.getRefusalReceived()).isNull();
-    assertThat(actualCase.isAddressInvalid()).isFalse();
-    assertThat(actualCase.isHandDelivery()).isFalse();
-
-    // check database for log eventDTO
-    List<Event> events = eventRepository.findAll();
-    assertThat(events.size()).isEqualTo(1);
-    Event event = events.get(0);
-    assertThat(event.getEventDescription()).isEqualTo("New Address reported");
-    assertThat(event.getEventType()).isEqualTo(EventType.NEW_ADDRESS_REPORTED);
+      // check database for log eventDTO
+      List<Event> events = eventRepository.findAll();
+      assertThat(events.size()).isEqualTo(1);
+      Event event = events.get(0);
+      assertThat(event.getEventDescription()).isEqualTo("New Address reported");
+      assertThat(event.getEventType()).isEqualTo(EventType.NEW_ADDRESS_REPORTED);
+    }
   }
 
   public void testEventTypeLoggedOnly(
@@ -457,51 +453,51 @@ public class AddressReceiverIT {
       EventTypeDTO eventTypeDTO,
       EventType eventType,
       String eventDescription)
-      throws InterruptedException, JSONException {
-    // GIVEN
-    BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(rhCaseQueue);
+      throws Exception {
+    try (QueueSpy rhCaseQueueSpy = rabbitQueueHelper.listen(rhCaseQueue)) {
+      // GIVEN
+      EasyRandom easyRandom = new EasyRandom();
+      Case caze = easyRandom.nextObject(Case.class);
+      caze.setCaseId(TEST_CASE_ID);
+      caze.setUacQidLinks(null);
+      caze.setEvents(null);
+      caze.setAddressInvalid(false);
+      caze = caseRepository.saveAndFlush(caze);
 
-    EasyRandom easyRandom = new EasyRandom();
-    Case caze = easyRandom.nextObject(Case.class);
-    caze.setCaseId(TEST_CASE_ID);
-    caze.setUacQidLinks(null);
-    caze.setEvents(null);
-    caze.setAddressInvalid(false);
-    caze = caseRepository.saveAndFlush(caze);
+      ResponseManagementEvent managementEvent = new ResponseManagementEvent();
+      managementEvent.setEvent(new EventDTO());
+      managementEvent.getEvent().setDateTime(OffsetDateTime.now());
+      managementEvent.getEvent().setChannel("Test channel");
+      managementEvent.getEvent().setSource("Test source");
+      managementEvent.getEvent().setType(eventTypeDTO);
+      managementEvent.setPayload(payload);
 
-    ResponseManagementEvent managementEvent = new ResponseManagementEvent();
-    managementEvent.setEvent(new EventDTO());
-    managementEvent.getEvent().setDateTime(OffsetDateTime.now());
-    managementEvent.getEvent().setChannel("Test channel");
-    managementEvent.getEvent().setSource("Test source");
-    managementEvent.getEvent().setType(eventTypeDTO);
-    managementEvent.setPayload(payload);
+      String json = convertObjectToJson(managementEvent);
+      Message message =
+          MessageBuilder.withBody(json.getBytes())
+              .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+              .build();
+      rabbitQueueHelper.sendMessage(addressReceiver, message);
 
-    String json = convertObjectToJson(managementEvent);
-    Message message =
-        MessageBuilder.withBody(json.getBytes())
-            .setContentType(MessageProperties.CONTENT_TYPE_JSON)
-            .build();
-    rabbitQueueHelper.sendMessage(addressReceiver, message);
+      // Check no message emitted
+      rabbitQueueHelper.checkMessageIsNotReceived(rhCaseQueueSpy, 3);
 
-    // Check no message emitted
-    rabbitQueueHelper.checkMessageIsNotReceived(outboundQueue, 3);
+      // Check case not changed
+      Optional<Case> actualCaseOpt = caseRepository.findById(caze.getCaseId());
+      Case actualCase = actualCaseOpt.get();
+      assertThat(actualCase.isAddressInvalid()).isFalse();
 
-    // Check case not changed
-    Optional<Case> actualCaseOpt = caseRepository.findById(caze.getCaseId());
-    Case actualCase = actualCaseOpt.get();
-    assertThat(actualCase.isAddressInvalid()).isFalse();
+      // Event logged is as expected
+      List<Event> events = eventRepository.findAll(Sort.by(ASC, "rmEventProcessed"));
+      assertThat(events.size()).isEqualTo(1);
+      Event event = events.get(0);
+      assertThat(event.getEventChannel()).isEqualTo("Test channel");
+      assertThat(event.getEventSource()).isEqualTo("Test source");
+      assertThat(event.getEventDescription()).isEqualTo(eventDescription);
+      assertThat(event.getEventType()).isEqualTo(eventType);
 
-    // Event logged is as expected
-    List<Event> events = eventRepository.findAll(Sort.by(ASC, "rmEventProcessed"));
-    assertThat(events.size()).isEqualTo(1);
-    Event event = events.get(0);
-    assertThat(event.getEventChannel()).isEqualTo("Test channel");
-    assertThat(event.getEventSource()).isEqualTo("Test source");
-    assertThat(event.getEventDescription()).isEqualTo(eventDescription);
-    assertThat(event.getEventType()).isEqualTo(eventType);
-
-    String actualEventPayloadJson = event.getEventPayload();
-    JSONAssert.assertEquals(actualEventPayloadJson, expectedEventPayloadJson, STRICT);
+      String actualEventPayloadJson = event.getEventPayload();
+      JSONAssert.assertEquals(actualEventPayloadJson, expectedEventPayloadJson, STRICT);
+    }
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
@@ -126,7 +126,7 @@ public class AddressReceiverIT {
 
       // check the emitted eventDTO
       ResponseManagementEvent responseManagementEvent =
-          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
+          rhCaseQueueSpy.checkExpectedMessageReceived();
 
       assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_UPDATED);
       CollectionCase actualPayloadCase = responseManagementEvent.getPayload().getCollectionCase();
@@ -210,7 +210,7 @@ public class AddressReceiverIT {
 
       // THEN
       ResponseManagementEvent actualResponseManagementEvent =
-          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
+          rhCaseQueueSpy.checkExpectedMessageReceived();
 
       assertThat(actualResponseManagementEvent.getEvent().getType())
           .isEqualTo(EventTypeDTO.CASE_CREATED);
@@ -281,7 +281,7 @@ public class AddressReceiverIT {
 
       // THEN
       ResponseManagementEvent actualResponseManagementEvent =
-          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
+          rhCaseQueueSpy.checkExpectedMessageReceived();
 
       assertThat(actualResponseManagementEvent.getEvent().getType())
           .isEqualTo(EventTypeDTO.CASE_CREATED);
@@ -392,7 +392,7 @@ public class AddressReceiverIT {
 
       // THEN
       ResponseManagementEvent actualResponseManagementEvent =
-          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
+          rhCaseQueueSpy.checkExpectedMessageReceived();
 
       assertThat(actualResponseManagementEvent.getEvent().getType())
           .isEqualTo(EventTypeDTO.CASE_CREATED);
@@ -480,7 +480,7 @@ public class AddressReceiverIT {
       rabbitQueueHelper.sendMessage(addressReceiver, message);
 
       // Check no message emitted
-      rabbitQueueHelper.checkMessageIsNotReceived(rhCaseQueueSpy, 3);
+      rhCaseQueueSpy.checkMessageIsNotReceived(3);
 
       // Check case not changed
       Optional<Case> actualCaseOpt = caseRepository.findById(caze.getCaseId());

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/CCSPropertyListedIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/CCSPropertyListedIT.java
@@ -88,7 +88,7 @@ public class CCSPropertyListedIT {
       rabbitQueueHelper.sendMessage(ccsPropertyListedQueue, responseManagementEvent);
 
       // Then
-      ResponseManagementEvent ccsToFwmt = rabbitQueueHelper.checkExpectedMessageReceived(queueSpy);
+      ResponseManagementEvent ccsToFwmt = queueSpy.checkExpectedMessageReceived();
       assertThat(ccsToFwmt.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_CREATED);
       assertThat(ccsToFwmt.getPayload().getCollectionCase().getId())
           .isEqualTo(TEST_CASE_ID.toString());
@@ -132,7 +132,7 @@ public class CCSPropertyListedIT {
       rabbitQueueHelper.sendMessage(ccsPropertyListedQueue, responseManagementEvent);
 
       // Then
-      rabbitQueueHelper.checkMessageIsNotReceived(queueSpy, 5);
+      queueSpy.checkMessageIsNotReceived(5);
 
       Case actualCase = caseRepository.findById(TEST_CASE_ID).get();
       assertThat(actualCase.getSurvey()).isEqualTo("CCS");
@@ -167,7 +167,7 @@ public class CCSPropertyListedIT {
       rabbitQueueHelper.sendMessage(ccsPropertyListedQueue, responseManagementEvent);
 
       // Then
-      rabbitQueueHelper.checkMessageIsNotReceived(queueSpy, 5);
+      queueSpy.checkMessageIsNotReceived(5);
 
       Case actualCase = caseRepository.findById(TEST_CASE_ID).get();
       assertThat(actualCase.getSurvey()).isEqualTo("CCS");
@@ -197,7 +197,7 @@ public class CCSPropertyListedIT {
       rabbitQueueHelper.sendMessage(ccsPropertyListedQueue, responseManagementEvent);
 
       // Then
-      rabbitQueueHelper.checkMessageIsNotReceived(queueSpy, 5);
+      queueSpy.checkMessageIsNotReceived(5);
 
       Case actualCase = caseRepository.findById(TEST_CASE_ID).get();
       assertThat(actualCase.getSurvey()).isEqualTo("CCS");

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/FulfilmentConfirmedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/FulfilmentConfirmedReceiverIT.java
@@ -16,7 +16,6 @@ import org.springframework.amqp.core.MessageProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -38,7 +37,6 @@ import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class FulfilmentConfirmedReceiverIT {
   private static final UUID TEST_CASE_ID = UUID.randomUUID();

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/FulfilmentRequestReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/FulfilmentRequestReceiverIT.java
@@ -199,7 +199,7 @@ public class FulfilmentRequestReceiverIT {
 
       // THEN
       ResponseManagementEvent responseManagementEvent =
-          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
+          rhCaseQueueSpy.checkExpectedMessageReceived();
       assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_CREATED);
       assertThat(
               responseManagementEvent.getPayload().getCollectionCase().getAddress().getEstabUprn())
@@ -281,7 +281,7 @@ public class FulfilmentRequestReceiverIT {
 
       // THEN
       ResponseManagementEvent responseManagementEvent =
-          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
+          rhCaseQueueSpy.checkExpectedMessageReceived();
       assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_CREATED);
       assertThat(
               responseManagementEvent.getPayload().getCollectionCase().getAddress().getEstabUprn())
@@ -375,7 +375,7 @@ public class FulfilmentRequestReceiverIT {
 
       // THEN
       ResponseManagementEvent responseManagementEvent =
-          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
+          rhCaseQueueSpy.checkExpectedMessageReceived();
       assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_CREATED);
       assertThat(
               responseManagementEvent.getPayload().getCollectionCase().getAddress().getEstabUprn())

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/FulfilmentRequestReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/FulfilmentRequestReceiverIT.java
@@ -6,10 +6,8 @@ import static uk.gov.ons.census.casesvc.testutil.DataUtils.convertJsonToObject;
 import static uk.gov.ons.census.casesvc.testutil.DataUtils.getTestResponseManagementFulfilmentRequestedEvent;
 import static uk.gov.ons.census.casesvc.utility.JsonHelper.convertObjectToJson;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.BlockingQueue;
 import org.jeasy.random.EasyRandom;
 import org.junit.Before;
 import org.junit.Test;
@@ -20,7 +18,6 @@ import org.springframework.amqp.core.MessageProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -32,12 +29,12 @@ import uk.gov.ons.census.casesvc.model.entity.EventType;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 import uk.gov.ons.census.casesvc.model.repository.EventRepository;
 import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
+import uk.gov.ons.census.casesvc.testutil.QueueSpy;
 import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class FulfilmentRequestReceiverIT {
   private static final UUID TEST_CASE_ID = UUID.randomUUID();
@@ -170,253 +167,251 @@ public class FulfilmentRequestReceiverIT {
   }
 
   @Test
-  public void testIndividualResponseFulfilmentRequestLogged()
-      throws InterruptedException, IOException {
-    // GIVEN
-    BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(rhCaseQueue);
+  public void testIndividualResponseFulfilmentRequestLogged() throws Exception {
+    try (QueueSpy rhCaseQueueSpy = rabbitQueueHelper.listen(rhCaseQueue)) {
+      // GIVEN
+      EasyRandom easyRandom = new EasyRandom();
+      Case caze = easyRandom.nextObject(Case.class);
+      caze.setCaseId(TEST_CASE_ID);
+      caze.setUacQidLinks(null);
+      caze.setEvents(null);
+      Case parentCase = caseRepository.saveAndFlush(caze);
 
-    EasyRandom easyRandom = new EasyRandom();
-    Case caze = easyRandom.nextObject(Case.class);
-    caze.setCaseId(TEST_CASE_ID);
-    caze.setUacQidLinks(null);
-    caze.setEvents(null);
-    Case parentCase = caseRepository.saveAndFlush(caze);
+      ResponseManagementEvent managementEvent = getTestResponseManagementFulfilmentRequestedEvent();
+      managementEvent.getPayload().getFulfilmentRequest().setCaseId(TEST_CASE_ID.toString());
+      managementEvent
+          .getPayload()
+          .getFulfilmentRequest()
+          .setIndividualCaseId(TEST_INDIVIDUAL_CASE_ID.toString());
+      managementEvent
+          .getPayload()
+          .getFulfilmentRequest()
+          .setFulfilmentCode(TEST_INDIVIDUAL_RESPONSE_FULFILMENT_CODE);
+      managementEvent.getEvent().setTransactionId(UUID.randomUUID());
 
-    ResponseManagementEvent managementEvent = getTestResponseManagementFulfilmentRequestedEvent();
-    managementEvent.getPayload().getFulfilmentRequest().setCaseId(TEST_CASE_ID.toString());
-    managementEvent
-        .getPayload()
-        .getFulfilmentRequest()
-        .setIndividualCaseId(TEST_INDIVIDUAL_CASE_ID.toString());
-    managementEvent
-        .getPayload()
-        .getFulfilmentRequest()
-        .setFulfilmentCode(TEST_INDIVIDUAL_RESPONSE_FULFILMENT_CODE);
-    managementEvent.getEvent().setTransactionId(UUID.randomUUID());
+      // WHEN
+      String json = convertObjectToJson(managementEvent);
+      Message message =
+          MessageBuilder.withBody(json.getBytes())
+              .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+              .build();
+      rabbitQueueHelper.sendMessage(inboundQueue, message);
 
-    // WHEN
-    String json = convertObjectToJson(managementEvent);
-    Message message =
-        MessageBuilder.withBody(json.getBytes())
-            .setContentType(MessageProperties.CONTENT_TYPE_JSON)
-            .build();
-    rabbitQueueHelper.sendMessage(inboundQueue, message);
+      // THEN
+      ResponseManagementEvent responseManagementEvent =
+          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
+      assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_CREATED);
+      assertThat(
+              responseManagementEvent.getPayload().getCollectionCase().getAddress().getEstabUprn())
+          .isEqualTo(parentCase.getEstabUprn());
+      assertThat(responseManagementEvent.getPayload().getFulfilmentRequest())
+          .isEqualTo(managementEvent.getPayload().getFulfilmentRequest());
 
-    // THEN
-    ResponseManagementEvent responseManagementEvent =
-        rabbitQueueHelper.checkExpectedMessageReceived(outboundQueue);
-    assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_CREATED);
-    assertThat(responseManagementEvent.getPayload().getCollectionCase().getAddress().getEstabUprn())
-        .isEqualTo(parentCase.getEstabUprn());
-    assertThat(responseManagementEvent.getPayload().getFulfilmentRequest())
-        .isEqualTo(managementEvent.getPayload().getFulfilmentRequest());
+      List<Event> events = eventRepository.findAll();
+      assertThat(events.size()).isEqualTo(1);
+      Event event = events.get(0);
+      FulfilmentRequestDTO actualFulfilmentRequest =
+          convertJsonToObject(event.getEventPayload(), FulfilmentRequestDTO.class);
+      assertThat(actualFulfilmentRequest.getCaseId()).isEqualTo(TEST_CASE_ID.toString());
+      assertThat(actualFulfilmentRequest.getFulfilmentCode())
+          .isEqualTo(TEST_INDIVIDUAL_RESPONSE_FULFILMENT_CODE);
 
-    List<Event> events = eventRepository.findAll();
-    assertThat(events.size()).isEqualTo(1);
-    Event event = events.get(0);
-    FulfilmentRequestDTO actualFulfilmentRequest =
-        convertJsonToObject(event.getEventPayload(), FulfilmentRequestDTO.class);
-    assertThat(actualFulfilmentRequest.getCaseId()).isEqualTo(TEST_CASE_ID.toString());
-    assertThat(actualFulfilmentRequest.getFulfilmentCode())
-        .isEqualTo(TEST_INDIVIDUAL_RESPONSE_FULFILMENT_CODE);
+      assertThat(actualFulfilmentRequest.getContact()).isNull();
 
-    assertThat(actualFulfilmentRequest.getContact()).isNull();
+      List<Case> cases = caseRepository.findAll();
+      assertThat(cases.size()).isEqualTo(2);
 
-    List<Case> cases = caseRepository.findAll();
-    assertThat(cases.size()).isEqualTo(2);
+      Case actualParentCase = caseRepository.findById(parentCase.getCaseId()).get();
+      Case actualChildCase = caseRepository.findById(TEST_INDIVIDUAL_CASE_ID).get();
 
-    Case actualParentCase = caseRepository.findById(parentCase.getCaseId()).get();
-    Case actualChildCase = caseRepository.findById(TEST_INDIVIDUAL_CASE_ID).get();
+      // Ensure emitted RM message matches new case
+      assertThat(UUID.fromString(responseManagementEvent.getPayload().getCollectionCase().getId()))
+          .isEqualTo(actualChildCase.getCaseId());
 
-    // Ensure emitted RM message matches new case
-    assertThat(UUID.fromString(responseManagementEvent.getPayload().getCollectionCase().getId()))
-        .isEqualTo(actualChildCase.getCaseId());
+      assertThat(actualParentCase.getEstabUprn()).isEqualTo(actualChildCase.getEstabUprn());
+      assertThat(actualParentCase.getAddressLine1()).isEqualTo(actualChildCase.getAddressLine1());
+      assertThat(actualParentCase.getCaseRef()).isNotEqualTo(actualChildCase.getCaseRef());
 
-    assertThat(actualParentCase.getEstabUprn()).isEqualTo(actualChildCase.getEstabUprn());
-    assertThat(actualParentCase.getAddressLine1()).isEqualTo(actualChildCase.getAddressLine1());
-    assertThat(actualParentCase.getCaseRef()).isNotEqualTo(actualChildCase.getCaseRef());
+      assertThat(actualChildCase.getAddressType()).isEqualTo(actualParentCase.getAddressType());
+      assertThat(actualChildCase.getCaseType()).isEqualTo("HI");
+      assertThat(actualChildCase.isReceiptReceived()).isEqualTo(false);
+      assertThat(actualChildCase.getRefusalReceived()).isNull();
 
-    assertThat(actualChildCase.getAddressType()).isEqualTo(actualParentCase.getAddressType());
-    assertThat(actualChildCase.getCaseType()).isEqualTo("HI");
-    assertThat(actualChildCase.isReceiptReceived()).isEqualTo(false);
-    assertThat(actualChildCase.getRefusalReceived()).isNull();
-
-    assertThat(actualChildCase.getHtcWillingness()).isNull();
-    assertThat(actualChildCase.getTreatmentCode()).isNull();
-  }
-
-  @Test
-  public void testIndividualResponseFulfilmentRequestWithUacLogged()
-      throws InterruptedException, IOException {
-    // GIVEN
-    BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(rhCaseQueue);
-
-    EasyRandom easyRandom = new EasyRandom();
-    Case caze = easyRandom.nextObject(Case.class);
-    caze.setCaseId(TEST_CASE_ID);
-    caze.setUacQidLinks(null);
-    caze.setEvents(null);
-    Case parentCase = caseRepository.saveAndFlush(caze);
-
-    ResponseManagementEvent managementEvent = getTestResponseManagementFulfilmentRequestedEvent();
-    managementEvent.getPayload().getFulfilmentRequest().setCaseId(TEST_CASE_ID.toString());
-    managementEvent
-        .getPayload()
-        .getFulfilmentRequest()
-        .setIndividualCaseId(TEST_INDIVIDUAL_CASE_ID.toString());
-    managementEvent
-        .getPayload()
-        .getFulfilmentRequest()
-        .setFulfilmentCode(TEST_INDIVIDUAL_RESPONSE_FULFILMENT_CODE);
-    managementEvent.getEvent().setTransactionId(UUID.randomUUID());
-
-    UacCreatedDTO uacQidCreated = new UacCreatedDTO();
-    uacQidCreated.setCaseId(TEST_INDIVIDUAL_CASE_ID);
-    uacQidCreated.setQid("123");
-    uacQidCreated.setUac(UUID.randomUUID().toString());
-    managementEvent.getPayload().getFulfilmentRequest().setUacQidCreated(uacQidCreated);
-
-    // WHEN
-    String json = convertObjectToJson(managementEvent);
-    Message message =
-        MessageBuilder.withBody(json.getBytes())
-            .setContentType(MessageProperties.CONTENT_TYPE_JSON)
-            .build();
-    rabbitQueueHelper.sendMessage(inboundQueue, message);
-
-    // THEN
-    ResponseManagementEvent responseManagementEvent =
-        rabbitQueueHelper.checkExpectedMessageReceived(outboundQueue);
-    assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_CREATED);
-    assertThat(responseManagementEvent.getPayload().getCollectionCase().getAddress().getEstabUprn())
-        .isEqualTo(parentCase.getEstabUprn());
-    assertThat(responseManagementEvent.getPayload().getFulfilmentRequest())
-        .isEqualTo(managementEvent.getPayload().getFulfilmentRequest());
-
-    List<Event> events = eventRepository.findAll();
-    assertThat(events.size()).isEqualTo(2);
-
-    int remainingMatches = 2;
-
-    for (Event event : events) {
-      if (event.getEventType() == EventType.FULFILMENT_REQUESTED) {
-        FulfilmentRequestDTO actualFulfilmentRequest =
-            convertJsonToObject(event.getEventPayload(), FulfilmentRequestDTO.class);
-        assertThat(actualFulfilmentRequest.getCaseId()).isEqualTo(TEST_CASE_ID.toString());
-        assertThat(actualFulfilmentRequest.getFulfilmentCode())
-            .isEqualTo(TEST_INDIVIDUAL_RESPONSE_FULFILMENT_CODE);
-
-        assertThat(actualFulfilmentRequest.getContact()).isNull();
-        remainingMatches--;
-      } else if (event.getEventType() == EventType.RM_UAC_CREATED) {
-        PayloadDTO payload = convertJsonToObject(event.getEventPayload(), PayloadDTO.class);
-        UacCreatedDTO actualUacCreated = payload.getFulfilmentRequest().getUacQidCreated();
-        assertThat(actualUacCreated.getCaseId()).isEqualTo(TEST_INDIVIDUAL_CASE_ID);
-        assertThat(actualUacCreated.getQid()).isEqualTo("123");
-        assertThat(actualUacCreated.getUac()).isEqualTo(uacQidCreated.getUac());
-        remainingMatches--;
-      } else {
-        fail("Unexpected event loggeed");
-      }
+      assertThat(actualChildCase.getHtcWillingness()).isNull();
+      assertThat(actualChildCase.getTreatmentCode()).isNull();
     }
-
-    assertThat(remainingMatches).isZero();
-
-    Event event = events.get(0);
-
-    List<Case> cases = caseRepository.findAll();
-    assertThat(cases.size()).isEqualTo(2);
-
-    Case actualParentCase = caseRepository.findById(parentCase.getCaseId()).get();
-    Case actualChildCase = caseRepository.findById(TEST_INDIVIDUAL_CASE_ID).get();
-
-    // Ensure emitted RM message matches new case
-    assertThat(UUID.fromString(responseManagementEvent.getPayload().getCollectionCase().getId()))
-        .isEqualTo(actualChildCase.getCaseId());
-
-    assertThat(actualParentCase.getEstabUprn()).isEqualTo(actualChildCase.getEstabUprn());
-    assertThat(actualParentCase.getAddressLine1()).isEqualTo(actualChildCase.getAddressLine1());
-    assertThat(actualParentCase.getCaseRef()).isNotEqualTo(actualChildCase.getCaseRef());
-
-    assertThat(actualChildCase.getAddressType()).isEqualTo(actualParentCase.getAddressType());
-    assertThat(actualChildCase.getCaseType()).isEqualTo("HI");
-    assertThat(actualChildCase.isReceiptReceived()).isEqualTo(false);
-    assertThat(actualChildCase.getRefusalReceived()).isNull();
-
-    assertThat(actualChildCase.getHtcWillingness()).isNull();
-    assertThat(actualChildCase.getTreatmentCode()).isNull();
   }
 
   @Test
-  public void testIndividualResponseFulfilmentRequestSMS()
-      throws InterruptedException, IOException {
-    // GIVEN
-    BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(rhCaseQueue);
+  public void testIndividualResponseFulfilmentRequestWithUacLogged() throws Exception {
+    try (QueueSpy rhCaseQueueSpy = rabbitQueueHelper.listen(rhCaseQueue)) {
+      // GIVEN
+      EasyRandom easyRandom = new EasyRandom();
+      Case caze = easyRandom.nextObject(Case.class);
+      caze.setCaseId(TEST_CASE_ID);
+      caze.setUacQidLinks(null);
+      caze.setEvents(null);
+      Case parentCase = caseRepository.saveAndFlush(caze);
 
-    EasyRandom easyRandom = new EasyRandom();
-    Case caze = easyRandom.nextObject(Case.class);
-    caze.setCaseId(TEST_CASE_ID);
-    caze.setUacQidLinks(null);
-    caze.setEvents(null);
-    Case parentCase = caseRepository.saveAndFlush(caze);
+      ResponseManagementEvent managementEvent = getTestResponseManagementFulfilmentRequestedEvent();
+      managementEvent.getPayload().getFulfilmentRequest().setCaseId(TEST_CASE_ID.toString());
+      managementEvent
+          .getPayload()
+          .getFulfilmentRequest()
+          .setIndividualCaseId(TEST_INDIVIDUAL_CASE_ID.toString());
+      managementEvent
+          .getPayload()
+          .getFulfilmentRequest()
+          .setFulfilmentCode(TEST_INDIVIDUAL_RESPONSE_FULFILMENT_CODE);
+      managementEvent.getEvent().setTransactionId(UUID.randomUUID());
 
-    ResponseManagementEvent managementEvent = getTestResponseManagementFulfilmentRequestedEvent();
-    managementEvent.getPayload().getFulfilmentRequest().setCaseId(TEST_CASE_ID.toString());
-    managementEvent
-        .getPayload()
-        .getFulfilmentRequest()
-        .setIndividualCaseId(TEST_INDIVIDUAL_CASE_ID.toString());
-    managementEvent
-        .getPayload()
-        .getFulfilmentRequest()
-        .setFulfilmentCode(TEST_INDIVIDUAL_RESPONSE_FULFILMENT_CODE_SMS);
-    managementEvent.getEvent().setTransactionId(UUID.randomUUID());
+      UacCreatedDTO uacQidCreated = new UacCreatedDTO();
+      uacQidCreated.setCaseId(TEST_INDIVIDUAL_CASE_ID);
+      uacQidCreated.setQid("123");
+      uacQidCreated.setUac(UUID.randomUUID().toString());
+      managementEvent.getPayload().getFulfilmentRequest().setUacQidCreated(uacQidCreated);
 
-    // WHEN
-    String json = convertObjectToJson(managementEvent);
-    Message message =
-        MessageBuilder.withBody(json.getBytes())
-            .setContentType(MessageProperties.CONTENT_TYPE_JSON)
-            .build();
-    rabbitQueueHelper.sendMessage(inboundQueue, message);
+      // WHEN
+      String json = convertObjectToJson(managementEvent);
+      Message message =
+          MessageBuilder.withBody(json.getBytes())
+              .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+              .build();
+      rabbitQueueHelper.sendMessage(inboundQueue, message);
 
-    // THEN
-    ResponseManagementEvent responseManagementEvent =
-        rabbitQueueHelper.checkExpectedMessageReceived(outboundQueue);
-    assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_CREATED);
-    assertThat(responseManagementEvent.getPayload().getCollectionCase().getAddress().getEstabUprn())
-        .isEqualTo(parentCase.getEstabUprn());
-    assertThat(responseManagementEvent.getPayload().getFulfilmentRequest()).isNull();
+      // THEN
+      ResponseManagementEvent responseManagementEvent =
+          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
+      assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_CREATED);
+      assertThat(
+              responseManagementEvent.getPayload().getCollectionCase().getAddress().getEstabUprn())
+          .isEqualTo(parentCase.getEstabUprn());
+      assertThat(responseManagementEvent.getPayload().getFulfilmentRequest())
+          .isEqualTo(managementEvent.getPayload().getFulfilmentRequest());
 
-    List<Event> events = eventRepository.findAll();
-    assertThat(events.size()).isEqualTo(1);
-    Event event = events.get(0);
-    FulfilmentRequestDTO actualFulfilmentRequest =
-        convertJsonToObject(event.getEventPayload(), FulfilmentRequestDTO.class);
-    assertThat(actualFulfilmentRequest.getCaseId()).isEqualTo(TEST_CASE_ID.toString());
-    assertThat(actualFulfilmentRequest.getFulfilmentCode())
-        .isEqualTo(TEST_INDIVIDUAL_RESPONSE_FULFILMENT_CODE_SMS);
+      List<Event> events = eventRepository.findAll();
+      assertThat(events.size()).isEqualTo(2);
 
-    List<Case> cases = caseRepository.findAll();
-    assertThat(cases.size()).isEqualTo(2);
+      int remainingMatches = 2;
 
-    Case actualParentCase = caseRepository.findById(parentCase.getCaseId()).get();
-    Case actualChildCase = caseRepository.findById(TEST_INDIVIDUAL_CASE_ID).get();
+      for (Event event : events) {
+        if (event.getEventType() == EventType.FULFILMENT_REQUESTED) {
+          FulfilmentRequestDTO actualFulfilmentRequest =
+              convertJsonToObject(event.getEventPayload(), FulfilmentRequestDTO.class);
+          assertThat(actualFulfilmentRequest.getCaseId()).isEqualTo(TEST_CASE_ID.toString());
+          assertThat(actualFulfilmentRequest.getFulfilmentCode())
+              .isEqualTo(TEST_INDIVIDUAL_RESPONSE_FULFILMENT_CODE);
 
-    // Ensure emitted RM message matches new case
-    assertThat(UUID.fromString(responseManagementEvent.getPayload().getCollectionCase().getId()))
-        .isEqualTo(actualChildCase.getCaseId());
+          assertThat(actualFulfilmentRequest.getContact()).isNull();
+          remainingMatches--;
+        } else if (event.getEventType() == EventType.RM_UAC_CREATED) {
+          PayloadDTO payload = convertJsonToObject(event.getEventPayload(), PayloadDTO.class);
+          UacCreatedDTO actualUacCreated = payload.getFulfilmentRequest().getUacQidCreated();
+          assertThat(actualUacCreated.getCaseId()).isEqualTo(TEST_INDIVIDUAL_CASE_ID);
+          assertThat(actualUacCreated.getQid()).isEqualTo("123");
+          assertThat(actualUacCreated.getUac()).isEqualTo(uacQidCreated.getUac());
+          remainingMatches--;
+        } else {
+          fail("Unexpected event loggeed");
+        }
+      }
 
-    assertThat(actualParentCase.getEstabUprn()).isEqualTo(actualChildCase.getEstabUprn());
-    assertThat(actualParentCase.getAddressLine1()).isEqualTo(actualChildCase.getAddressLine1());
-    assertThat(actualParentCase.getCaseRef()).isNotEqualTo(actualChildCase.getCaseRef());
+      assertThat(remainingMatches).isZero();
 
-    assertThat(actualChildCase.getAddressType()).isEqualTo(actualParentCase.getAddressType());
-    assertThat(actualChildCase.getCaseType()).isEqualTo("HI");
-    assertThat(actualChildCase.isReceiptReceived()).isEqualTo(false);
-    assertThat(actualChildCase.getRefusalReceived()).isNull();
+      List<Case> cases = caseRepository.findAll();
+      assertThat(cases.size()).isEqualTo(2);
 
-    assertThat(actualChildCase.getHtcWillingness()).isNull();
-    assertThat(actualChildCase.getTreatmentCode()).isNull();
+      Case actualParentCase = caseRepository.findById(parentCase.getCaseId()).get();
+      Case actualChildCase = caseRepository.findById(TEST_INDIVIDUAL_CASE_ID).get();
+
+      // Ensure emitted RM message matches new case
+      assertThat(UUID.fromString(responseManagementEvent.getPayload().getCollectionCase().getId()))
+          .isEqualTo(actualChildCase.getCaseId());
+
+      assertThat(actualParentCase.getEstabUprn()).isEqualTo(actualChildCase.getEstabUprn());
+      assertThat(actualParentCase.getAddressLine1()).isEqualTo(actualChildCase.getAddressLine1());
+      assertThat(actualParentCase.getCaseRef()).isNotEqualTo(actualChildCase.getCaseRef());
+
+      assertThat(actualChildCase.getAddressType()).isEqualTo(actualParentCase.getAddressType());
+      assertThat(actualChildCase.getCaseType()).isEqualTo("HI");
+      assertThat(actualChildCase.isReceiptReceived()).isEqualTo(false);
+      assertThat(actualChildCase.getRefusalReceived()).isNull();
+
+      assertThat(actualChildCase.getHtcWillingness()).isNull();
+      assertThat(actualChildCase.getTreatmentCode()).isNull();
+    }
+  }
+
+  @Test
+  public void testIndividualResponseFulfilmentRequestSMS() throws Exception {
+    try (QueueSpy rhCaseQueueSpy = rabbitQueueHelper.listen(rhCaseQueue)) {
+      // GIVEN
+      EasyRandom easyRandom = new EasyRandom();
+      Case caze = easyRandom.nextObject(Case.class);
+      caze.setCaseId(TEST_CASE_ID);
+      caze.setUacQidLinks(null);
+      caze.setEvents(null);
+      Case parentCase = caseRepository.saveAndFlush(caze);
+
+      ResponseManagementEvent managementEvent = getTestResponseManagementFulfilmentRequestedEvent();
+      managementEvent.getPayload().getFulfilmentRequest().setCaseId(TEST_CASE_ID.toString());
+      managementEvent
+          .getPayload()
+          .getFulfilmentRequest()
+          .setIndividualCaseId(TEST_INDIVIDUAL_CASE_ID.toString());
+      managementEvent
+          .getPayload()
+          .getFulfilmentRequest()
+          .setFulfilmentCode(TEST_INDIVIDUAL_RESPONSE_FULFILMENT_CODE_SMS);
+      managementEvent.getEvent().setTransactionId(UUID.randomUUID());
+
+      // WHEN
+      String json = convertObjectToJson(managementEvent);
+      Message message =
+          MessageBuilder.withBody(json.getBytes())
+              .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+              .build();
+      rabbitQueueHelper.sendMessage(inboundQueue, message);
+
+      // THEN
+      ResponseManagementEvent responseManagementEvent =
+          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
+      assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_CREATED);
+      assertThat(
+              responseManagementEvent.getPayload().getCollectionCase().getAddress().getEstabUprn())
+          .isEqualTo(parentCase.getEstabUprn());
+      assertThat(responseManagementEvent.getPayload().getFulfilmentRequest()).isNull();
+
+      List<Event> events = eventRepository.findAll();
+      assertThat(events.size()).isEqualTo(1);
+      Event event = events.get(0);
+      FulfilmentRequestDTO actualFulfilmentRequest =
+          convertJsonToObject(event.getEventPayload(), FulfilmentRequestDTO.class);
+      assertThat(actualFulfilmentRequest.getCaseId()).isEqualTo(TEST_CASE_ID.toString());
+      assertThat(actualFulfilmentRequest.getFulfilmentCode())
+          .isEqualTo(TEST_INDIVIDUAL_RESPONSE_FULFILMENT_CODE_SMS);
+
+      List<Case> cases = caseRepository.findAll();
+      assertThat(cases.size()).isEqualTo(2);
+
+      Case actualParentCase = caseRepository.findById(parentCase.getCaseId()).get();
+      Case actualChildCase = caseRepository.findById(TEST_INDIVIDUAL_CASE_ID).get();
+
+      // Ensure emitted RM message matches new case
+      assertThat(UUID.fromString(responseManagementEvent.getPayload().getCollectionCase().getId()))
+          .isEqualTo(actualChildCase.getCaseId());
+
+      assertThat(actualParentCase.getEstabUprn()).isEqualTo(actualChildCase.getEstabUprn());
+      assertThat(actualParentCase.getAddressLine1()).isEqualTo(actualChildCase.getAddressLine1());
+      assertThat(actualParentCase.getCaseRef()).isNotEqualTo(actualChildCase.getCaseRef());
+
+      assertThat(actualChildCase.getAddressType()).isEqualTo(actualParentCase.getAddressType());
+      assertThat(actualChildCase.getCaseType()).isEqualTo("HI");
+      assertThat(actualChildCase.isReceiptReceived()).isEqualTo(false);
+      assertThat(actualChildCase.getRefusalReceived()).isNull();
+
+      assertThat(actualChildCase.getHtcWillingness()).isNull();
+      assertThat(actualChildCase.getTreatmentCode()).isNull();
+    }
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverIT.java
@@ -190,7 +190,7 @@ public class QuestionnaireLinkedReceiverIT {
       assertThat(actualUac.getCaseId()).isEqualTo(TEST_CASE_ID.toString());
 
       // Check Case updated message not sent
-      rabbitQueueHelper.checkMessageIsNotReceived(rhCaseQueueSpy, 5);
+      rhCaseQueueSpy.checkMessageIsNotReceived(5);
 
       // Check database that Case is still receipted and has response received set
       Case actualCase = caseRepository.findById(TEST_CASE_ID).get();
@@ -257,7 +257,7 @@ public class QuestionnaireLinkedReceiverIT {
       assertThat(actualUac.getCaseId()).isEqualTo(TEST_CASE_ID.toString());
 
       // Check Case updated message sent and contains expected data
-      responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
+      responseManagementEvent = rhCaseQueueSpy.checkExpectedMessageReceived();
       assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_UPDATED);
       CollectionCase actualCollectionCase =
           responseManagementEvent.getPayload().getCollectionCase();
@@ -324,7 +324,7 @@ public class QuestionnaireLinkedReceiverIT {
       assertThat(actualCollectionCase.getCaseType()).isEqualTo("HI");
 
       // Check Uac updated message sent and contains expected data
-      responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(rhUacQueueSpy);
+      responseManagementEvent = rhUacQueueSpy.checkExpectedMessageReceived();
       assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.UAC_UPDATED);
       UacDTO actualUac = responseManagementEvent.getPayload().getUac();
       assertThat(actualUac.getQuestionnaireId()).isEqualTo(expectedQuestionnaireId);
@@ -604,14 +604,14 @@ public class QuestionnaireLinkedReceiverIT {
       throws IOException, InterruptedException {
     sendMessage(sendQueue, createUacQid);
 
-    return rabbitQueueHelper.checkExpectedMessageReceived(queueSpy);
+    return queueSpy.checkExpectedMessageReceived();
   }
 
   private void sendMessageAndDoNotExpectInboundMessage(
       String sendQueue, Object createUacQid, QueueSpy queueSpy) throws InterruptedException {
     sendMessage(sendQueue, createUacQid);
 
-    rabbitQueueHelper.checkMessageIsNotReceived(queueSpy, 5);
+    queueSpy.checkMessageIsNotReceived(5);
   }
 
   private void sendMessage(String sendQueue, Object createUacQid) {

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
@@ -12,11 +12,9 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.IntStream;
 import org.jeasy.random.EasyRandom;
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,7 +25,6 @@ import org.springframework.amqp.core.MessageProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -44,12 +41,12 @@ import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 import uk.gov.ons.census.casesvc.model.repository.EventRepository;
 import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
+import uk.gov.ons.census.casesvc.testutil.QueueSpy;
 import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class ReceiptReceiverIT {
   private static final UUID TEST_CASE_ID = UUID.randomUUID();
@@ -92,181 +89,181 @@ public class ReceiptReceiverIT {
   }
 
   @Test
-  public void testReceiptEmitsMessageAndEventIsLoggedForCase()
-      throws InterruptedException, IOException, JSONException {
-    // GIVEN
-    BlockingQueue<String> rhUacOutboundQueue = rabbitQueueHelper.listen(rhUacQueue);
-    BlockingQueue<String> rhCaseOutboundQueue = rabbitQueueHelper.listen(rhCaseQueue);
+  public void testReceiptEmitsMessageAndEventIsLoggedForCase() throws Exception {
+    try (QueueSpy rhUacQueueSpy = rabbitQueueHelper.listen(rhUacQueue);
+        QueueSpy rhCaseQueueSpy = rabbitQueueHelper.listen(rhCaseQueue)) {
+      // GIVEN
+      EasyRandom easyRandom = new EasyRandom();
+      Case caze = easyRandom.nextObject(Case.class);
+      caze.setCaseId(TEST_CASE_ID);
+      caze.setReceiptReceived(false);
+      caze.setSurvey("CENSUS");
+      caze.setUacQidLinks(null);
+      caze.setEvents(null);
+      caze.setCaseType("HH");
+      caze.setAddressLevel("U");
+      caze = caseRepository.saveAndFlush(caze);
 
-    EasyRandom easyRandom = new EasyRandom();
-    Case caze = easyRandom.nextObject(Case.class);
-    caze.setCaseId(TEST_CASE_ID);
-    caze.setReceiptReceived(false);
-    caze.setSurvey("CENSUS");
-    caze.setUacQidLinks(null);
-    caze.setEvents(null);
-    caze.setCaseType("HH");
-    caze.setAddressLevel("U");
-    caze = caseRepository.saveAndFlush(caze);
+      UacQidLink uacQidLink = new UacQidLink();
+      uacQidLink.setId(UUID.randomUUID());
+      uacQidLink.setCaze(caze);
+      uacQidLink.setCcsCase(false);
+      uacQidLink.setQid(ENGLAND_HOUSEHOLD);
+      uacQidLink.setUac(TEST_UAC);
+      uacQidLinkRepository.saveAndFlush(uacQidLink);
 
-    UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setId(UUID.randomUUID());
-    uacQidLink.setCaze(caze);
-    uacQidLink.setCcsCase(false);
-    uacQidLink.setQid(ENGLAND_HOUSEHOLD);
-    uacQidLink.setUac(TEST_UAC);
-    uacQidLinkRepository.saveAndFlush(uacQidLink);
+      ResponseManagementEvent managementEvent = getTestResponseManagementReceiptEvent();
+      managementEvent.getPayload().getResponse().setQuestionnaireId(uacQidLink.getQid());
+      managementEvent.getEvent().setTransactionId(UUID.randomUUID());
 
-    ResponseManagementEvent managementEvent = getTestResponseManagementReceiptEvent();
-    managementEvent.getPayload().getResponse().setQuestionnaireId(uacQidLink.getQid());
-    managementEvent.getEvent().setTransactionId(UUID.randomUUID());
+      String json = convertObjectToJson(managementEvent);
+      Message message =
+          MessageBuilder.withBody(json.getBytes())
+              .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+              .build();
 
-    String json = convertObjectToJson(managementEvent);
-    Message message =
-        MessageBuilder.withBody(json.getBytes())
-            .setContentType(MessageProperties.CONTENT_TYPE_JSON)
-            .build();
+      // WHEN
+      rabbitQueueHelper.sendMessage(inboundQueue, message);
 
-    // WHEN
-    rabbitQueueHelper.sendMessage(inboundQueue, message);
+      // THEN
 
-    // THEN
+      // check messages sent
+      ResponseManagementEvent responseManagementEvent =
+          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
+      CollectionCase actualCollectionCase =
+          responseManagementEvent.getPayload().getCollectionCase();
+      assertThat(actualCollectionCase.getId()).isEqualTo(TEST_CASE_ID.toString());
+      assertThat(actualCollectionCase.getReceiptReceived()).isTrue();
 
-    // check messages sent
-    ResponseManagementEvent responseManagementEvent =
-        rabbitQueueHelper.checkExpectedMessageReceived(rhCaseOutboundQueue);
-    CollectionCase actualCollectionCase = responseManagementEvent.getPayload().getCollectionCase();
-    assertThat(actualCollectionCase.getId()).isEqualTo(TEST_CASE_ID.toString());
-    assertThat(actualCollectionCase.getReceiptReceived()).isTrue();
+      // check the metadata is included with field CANCEL decision
+      assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
+          .isEqualTo(ActionInstructionType.CANCEL);
+      assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
+          .isEqualTo(EventTypeDTO.RESPONSE_RECEIVED);
 
-    // check the metadata is included with field CANCEL decision
-    assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
-        .isEqualTo(ActionInstructionType.CANCEL);
-    assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
-        .isEqualTo(EventTypeDTO.RESPONSE_RECEIVED);
+      Metadata metaData = responseManagementEvent.getPayload().getMetadata();
+      assertThat(metaData.getCauseEventType()).isEqualTo(RESPONSE_RECEIVED);
+      assertThat(metaData.getFieldDecision()).isEqualTo(ActionInstructionType.CANCEL);
 
-    Metadata metaData = responseManagementEvent.getPayload().getMetadata();
-    assertThat(metaData.getCauseEventType()).isEqualTo(RESPONSE_RECEIVED);
-    assertThat(metaData.getFieldDecision()).isEqualTo(ActionInstructionType.CANCEL);
+      responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(rhUacQueueSpy);
+      assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.UAC_UPDATED);
+      UacDTO actualUacDTOObject = responseManagementEvent.getPayload().getUac();
+      assertThat(actualUacDTOObject.getUac()).isEqualTo(TEST_UAC);
+      assertThat(actualUacDTOObject.getQuestionnaireId()).isEqualTo(ENGLAND_HOUSEHOLD);
+      assertThat(actualUacDTOObject.getCaseId()).isEqualTo(TEST_CASE_ID.toString());
 
-    responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(rhUacOutboundQueue);
-    assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.UAC_UPDATED);
-    UacDTO actualUacDTOObject = responseManagementEvent.getPayload().getUac();
-    assertThat(actualUacDTOObject.getUac()).isEqualTo(TEST_UAC);
-    assertThat(actualUacDTOObject.getQuestionnaireId()).isEqualTo(ENGLAND_HOUSEHOLD);
-    assertThat(actualUacDTOObject.getCaseId()).isEqualTo(TEST_CASE_ID.toString());
+      Case actualCase = caseRepository.findById(TEST_CASE_ID).get();
+      assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
+      assertThat(actualCase.isReceiptReceived()).isTrue();
 
-    Case actualCase = caseRepository.findById(TEST_CASE_ID).get();
-    assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
-    assertThat(actualCase.isReceiptReceived()).isTrue();
+      // check database for log eventDTO
+      List<Event> events = eventRepository.findAll();
+      assertThat(events.size()).isEqualTo(1);
+      Event event = events.get(0);
+      assertThat(event.getEventDescription()).isEqualTo(QID_RECEIPTED);
 
-    // check database for log eventDTO
-    List<Event> events = eventRepository.findAll();
-    assertThat(events.size()).isEqualTo(1);
-    Event event = events.get(0);
-    assertThat(event.getEventDescription()).isEqualTo(QID_RECEIPTED);
+      UacQidLink actualUacQidLink = event.getUacQidLink();
+      assertThat(actualUacQidLink.getQid()).isEqualTo(ENGLAND_HOUSEHOLD);
+      assertThat(actualUacQidLink.getUac()).isEqualTo(TEST_UAC);
+      assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
+      assertThat(actualUacQidLink.isActive()).isFalse();
+      assertThat(actualUacQidLink.isBlankQuestionnaire()).isFalse();
 
-    UacQidLink actualUacQidLink = event.getUacQidLink();
-    assertThat(actualUacQidLink.getQid()).isEqualTo(ENGLAND_HOUSEHOLD);
-    assertThat(actualUacQidLink.getUac()).isEqualTo(TEST_UAC);
-    assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
-    assertThat(actualUacQidLink.isActive()).isFalse();
-    assertThat(actualUacQidLink.isBlankQuestionnaire()).isFalse();
-
-    // Test date saved format here
-    String utcDateAsString = new JSONObject(event.getEventPayload()).getString("dateTime");
-    assertThat(isStringFormattedAsUTCDate(utcDateAsString)).isTrue();
+      // Test date saved format here
+      String utcDateAsString = new JSONObject(event.getEventPayload()).getString("dateTime");
+      assertThat(isStringFormattedAsUTCDate(utcDateAsString)).isTrue();
+    }
   }
 
   @Test
-  public void testBlankQuestionnaireReceiptEmitsMessageAndEventIsLoggedForCase()
-      throws InterruptedException, IOException, JSONException {
-    // GIVEN
-    BlockingQueue<String> rhUacOutboundQueue = rabbitQueueHelper.listen(rhUacQueue);
-    BlockingQueue<String> rhCaseOutboundQueue = rabbitQueueHelper.listen(rhCaseQueue);
+  public void testBlankQuestionnaireReceiptEmitsMessageAndEventIsLoggedForCase() throws Exception {
+    try (QueueSpy rhUacQueueSpy = rabbitQueueHelper.listen(rhUacQueue);
+        QueueSpy rhCaseQueueSpy = rabbitQueueHelper.listen(rhCaseQueue)) {
+      // GIVEN
+      EasyRandom easyRandom = new EasyRandom();
+      Case caze = easyRandom.nextObject(Case.class);
+      caze.setCaseId(TEST_CASE_ID);
+      caze.setReceiptReceived(false);
+      caze.setSurvey("CENSUS");
+      caze.setUacQidLinks(null);
+      caze.setEvents(null);
+      caze.setCaseType("HH");
+      caze.setAddressLevel("U");
+      caze.setRefusalReceived(null);
+      caze.setAddressInvalid(false);
+      caze = caseRepository.saveAndFlush(caze);
 
-    EasyRandom easyRandom = new EasyRandom();
-    Case caze = easyRandom.nextObject(Case.class);
-    caze.setCaseId(TEST_CASE_ID);
-    caze.setReceiptReceived(false);
-    caze.setSurvey("CENSUS");
-    caze.setUacQidLinks(null);
-    caze.setEvents(null);
-    caze.setCaseType("HH");
-    caze.setAddressLevel("U");
-    caze.setRefusalReceived(null);
-    caze.setAddressInvalid(false);
-    caze = caseRepository.saveAndFlush(caze);
+      UacQidLink uacQidLink = new UacQidLink();
+      uacQidLink.setId(UUID.randomUUID());
+      uacQidLink.setCaze(caze);
+      uacQidLink.setCcsCase(false);
+      uacQidLink.setQid(ENGLAND_HOUSEHOLD);
+      uacQidLink.setUac(TEST_UAC);
+      uacQidLink.setBlankQuestionnaire(false);
+      uacQidLink.setActive(true);
+      uacQidLinkRepository.saveAndFlush(uacQidLink);
 
-    UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setId(UUID.randomUUID());
-    uacQidLink.setCaze(caze);
-    uacQidLink.setCcsCase(false);
-    uacQidLink.setQid(ENGLAND_HOUSEHOLD);
-    uacQidLink.setUac(TEST_UAC);
-    uacQidLink.setBlankQuestionnaire(false);
-    uacQidLink.setActive(true);
-    uacQidLinkRepository.saveAndFlush(uacQidLink);
+      ResponseManagementEvent managementEvent = getTestResponseManagementReceiptEvent();
+      managementEvent.getPayload().getResponse().setQuestionnaireId(uacQidLink.getQid());
+      managementEvent.getEvent().setTransactionId(UUID.randomUUID());
+      managementEvent.getPayload().getResponse().setUnreceipt(true);
+      String json = convertObjectToJson(managementEvent);
+      Message message =
+          MessageBuilder.withBody(json.getBytes())
+              .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+              .build();
 
-    ResponseManagementEvent managementEvent = getTestResponseManagementReceiptEvent();
-    managementEvent.getPayload().getResponse().setQuestionnaireId(uacQidLink.getQid());
-    managementEvent.getEvent().setTransactionId(UUID.randomUUID());
-    managementEvent.getPayload().getResponse().setUnreceipt(true);
-    String json = convertObjectToJson(managementEvent);
-    Message message =
-        MessageBuilder.withBody(json.getBytes())
-            .setContentType(MessageProperties.CONTENT_TYPE_JSON)
-            .build();
+      // WHEN
+      rabbitQueueHelper.sendMessage(inboundQueue, message);
 
-    // WHEN
-    rabbitQueueHelper.sendMessage(inboundQueue, message);
+      // THEN
 
-    // THEN
+      // check messages sent
+      ResponseManagementEvent responseManagementEvent =
+          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
+      CollectionCase actualCollectionCase =
+          responseManagementEvent.getPayload().getCollectionCase();
+      assertThat(actualCollectionCase.getId()).isEqualTo(TEST_CASE_ID.toString());
+      assertThat(actualCollectionCase.getReceiptReceived()).isFalse();
 
-    // check messages sent
-    ResponseManagementEvent responseManagementEvent =
-        rabbitQueueHelper.checkExpectedMessageReceived(rhCaseOutboundQueue);
-    CollectionCase actualCollectionCase = responseManagementEvent.getPayload().getCollectionCase();
-    assertThat(actualCollectionCase.getId()).isEqualTo(TEST_CASE_ID.toString());
-    assertThat(actualCollectionCase.getReceiptReceived()).isFalse();
+      // check the metadata is included with field close decision
+      assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
+          .isEqualTo(ActionInstructionType.UPDATE);
+      assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
+          .isEqualTo(EventTypeDTO.RESPONSE_RECEIVED);
 
-    // check the metadata is included with field close decision
-    assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
-        .isEqualTo(ActionInstructionType.UPDATE);
-    assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
-        .isEqualTo(EventTypeDTO.RESPONSE_RECEIVED);
+      Metadata metaData = responseManagementEvent.getPayload().getMetadata();
+      assertThat(metaData.getCauseEventType()).isEqualTo(RESPONSE_RECEIVED);
+      assertThat(metaData.getFieldDecision()).isEqualTo(ActionInstructionType.UPDATE);
 
-    Metadata metaData = responseManagementEvent.getPayload().getMetadata();
-    assertThat(metaData.getCauseEventType()).isEqualTo(RESPONSE_RECEIVED);
-    assertThat(metaData.getFieldDecision()).isEqualTo(ActionInstructionType.UPDATE);
+      responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(rhUacQueueSpy);
+      assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.UAC_UPDATED);
+      UacDTO actualUacDTOObject = responseManagementEvent.getPayload().getUac();
+      assertThat(actualUacDTOObject.getUac()).isEqualTo(TEST_UAC);
+      assertThat(actualUacDTOObject.getQuestionnaireId()).isEqualTo(ENGLAND_HOUSEHOLD);
+      assertThat(actualUacDTOObject.getCaseId()).isEqualTo(TEST_CASE_ID.toString());
 
-    responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(rhUacOutboundQueue);
-    assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.UAC_UPDATED);
-    UacDTO actualUacDTOObject = responseManagementEvent.getPayload().getUac();
-    assertThat(actualUacDTOObject.getUac()).isEqualTo(TEST_UAC);
-    assertThat(actualUacDTOObject.getQuestionnaireId()).isEqualTo(ENGLAND_HOUSEHOLD);
-    assertThat(actualUacDTOObject.getCaseId()).isEqualTo(TEST_CASE_ID.toString());
+      Case actualCase = caseRepository.findById(TEST_CASE_ID).get();
+      assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
+      assertThat(actualCase.isReceiptReceived()).isFalse();
 
-    Case actualCase = caseRepository.findById(TEST_CASE_ID).get();
-    assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
-    assertThat(actualCase.isReceiptReceived()).isFalse();
+      // check database for log eventDTO
+      List<Event> events = eventRepository.findAll();
+      assertThat(events.size()).isEqualTo(1);
+      Event event = events.get(0);
+      assertThat(event.getEventDescription()).isEqualTo(BLANK_QUESTIONNAIRE_RECEIVED);
 
-    // check database for log eventDTO
-    List<Event> events = eventRepository.findAll();
-    assertThat(events.size()).isEqualTo(1);
-    Event event = events.get(0);
-    assertThat(event.getEventDescription()).isEqualTo(BLANK_QUESTIONNAIRE_RECEIVED);
+      UacQidLink actualUacQidLink = event.getUacQidLink();
+      assertThat(actualUacQidLink.getQid()).isEqualTo(ENGLAND_HOUSEHOLD);
+      assertThat(actualUacQidLink.getUac()).isEqualTo(TEST_UAC);
+      assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
+      assertThat(actualUacQidLink.isActive()).isFalse();
+      assertThat(actualUacQidLink.isBlankQuestionnaire()).isTrue();
 
-    UacQidLink actualUacQidLink = event.getUacQidLink();
-    assertThat(actualUacQidLink.getQid()).isEqualTo(ENGLAND_HOUSEHOLD);
-    assertThat(actualUacQidLink.getUac()).isEqualTo(TEST_UAC);
-    assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
-    assertThat(actualUacQidLink.isActive()).isFalse();
-    assertThat(actualUacQidLink.isBlankQuestionnaire()).isTrue();
-
-    // Test date saved format here
-    String utcDateAsString = new JSONObject(event.getEventPayload()).getString("dateTime");
-    assertThat(isStringFormattedAsUTCDate(utcDateAsString)).isTrue();
+      // Test date saved format here
+      String utcDateAsString = new JSONObject(event.getEventPayload()).getString("dateTime");
+      assertThat(isStringFormattedAsUTCDate(utcDateAsString)).isTrue();
+    }
   }
 
   @Test
@@ -275,79 +272,76 @@ public class ReceiptReceiverIT {
     int numberOfReceiptsAndLinkToSend = 3;
     int expectedResponseCount = numberOfReceiptsAndLinkToSend * 2;
 
-    // GIVEN
-    BlockingQueue<String> rhCaseOutboundQueue =
-        rabbitQueueHelper.listen(rhCaseQueue, expectedResponseCount + 10);
+    try (QueueSpy rhCaseQueueSpy =
+        rabbitQueueHelper.listen(rhCaseQueue, expectedResponseCount + 10)) {
+      // GIVEN
+      EasyRandom easyRandom = new EasyRandom();
+      Case caze = easyRandom.nextObject(Case.class);
+      caze.setReceiptReceived(false);
+      caze.setSurvey("CENSUS");
+      caze.setUacQidLinks(null);
+      caze.setEvents(null);
+      caze.setAddressLevel("U");
+      caze.setCaseType("CE");
+      caze.setCeActualResponses(0);
+      caze.setCeExpectedCapacity(expectedResponseCount);
+      caze = caseRepository.saveAndFlush(caze);
 
-    EasyRandom easyRandom = new EasyRandom();
-    Case caze = easyRandom.nextObject(Case.class);
-    caze.setReceiptReceived(false);
-    caze.setSurvey("CENSUS");
-    caze.setUacQidLinks(null);
-    caze.setEvents(null);
-    caze.setAddressLevel("U");
-    caze.setCaseType("CE");
-    caze.setCeActualResponses(0);
-    caze.setCeExpectedCapacity(expectedResponseCount);
-    caze = caseRepository.saveAndFlush(caze);
+      UacQidLink uacQidLink = new UacQidLink();
+      uacQidLink.setId(UUID.randomUUID());
+      uacQidLink.setCaze(caze);
+      uacQidLink.setCcsCase(false);
+      uacQidLink.setQid(HOUSEHOLD_INDIVIDUAL_QUESTIONNAIRE_REQUEST_ENGLAND);
+      uacQidLink.setUac(TEST_UAC);
+      uacQidLinkRepository.saveAndFlush(uacQidLink);
 
-    UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setId(UUID.randomUUID());
-    uacQidLink.setCaze(caze);
-    uacQidLink.setCcsCase(false);
-    uacQidLink.setQid(HOUSEHOLD_INDIVIDUAL_QUESTIONNAIRE_REQUEST_ENGLAND);
-    uacQidLink.setUac(TEST_UAC);
-    uacQidLinkRepository.saveAndFlush(uacQidLink);
+      ResponseManagementEvent managementEvent = getTestResponseManagementReceiptEvent();
+      managementEvent.getPayload().getResponse().setQuestionnaireId(uacQidLink.getQid());
+      managementEvent.getEvent().setTransactionId(UUID.randomUUID());
 
-    ResponseManagementEvent managementEvent = getTestResponseManagementReceiptEvent();
-    managementEvent.getPayload().getResponse().setQuestionnaireId(uacQidLink.getQid());
-    managementEvent.getEvent().setTransactionId(UUID.randomUUID());
+      String json = convertObjectToJson(managementEvent);
+      Message message =
+          MessageBuilder.withBody(json.getBytes())
+              .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+              .build();
 
-    String json = convertObjectToJson(managementEvent);
-    Message message =
-        MessageBuilder.withBody(json.getBytes())
-            .setContentType(MessageProperties.CONTENT_TYPE_JSON)
-            .build();
+      // WHEN
+      assertThat(caze.getCeActualResponses()).isEqualTo(0);
+      CopyOnWriteArrayList<Integer> expectedActualResponses = new CopyOnWriteArrayList<Integer>();
+      final UUID caseId = caze.getCaseId();
 
-    // WHEN
-    assertThat(caze.getCeActualResponses()).isEqualTo(0);
-    CopyOnWriteArrayList<Integer> expectedActualResponses = new CopyOnWriteArrayList<Integer>();
-    final UUID caseId = caze.getCaseId();
+      Message[] qidLinkingMessages =
+          buildLinkReceiptedQidToCaseMsgs(caseId.toString(), numberOfReceiptsAndLinkToSend);
 
-    Message[] qidLinkingMessages =
-        buildLinkReceiptedQidToCaseMsgs(caseId.toString(), numberOfReceiptsAndLinkToSend);
+      IntStream.range(0, numberOfReceiptsAndLinkToSend)
+          .parallel()
+          .forEach(
+              count -> {
+                rabbitQueueHelper.sendMessage(inboundQueue, message);
+                rabbitQueueHelper.sendMessage(questionnaireLinkedQueue, qidLinkingMessages[count]);
 
-    IntStream.range(0, numberOfReceiptsAndLinkToSend)
-        .parallel()
-        .forEach(
-            count -> {
-              rabbitQueueHelper.sendMessage(inboundQueue, message);
-              rabbitQueueHelper.sendMessage(questionnaireLinkedQueue, qidLinkingMessages[count]);
+                expectedActualResponses.add(count + 1);
+                expectedActualResponses.add(numberOfReceiptsAndLinkToSend + count + 1);
+              });
 
-              expectedActualResponses.add(count + 1);
-              expectedActualResponses.add(numberOfReceiptsAndLinkToSend + count + 1);
-            });
+      // THEN
+      Case actualCase =
+          pollDatabaseUntilCorrectActualResponseCount(caseId, expectedResponseCount, 100);
+      assertThat(actualCase.getCeActualResponses())
+          .as("ActualResponses Count")
+          .isEqualTo(expectedResponseCount);
+      assertThat(actualCase.isReceiptReceived()).as("Case Receipted").isTrue();
 
-    // THEN
-    Case actualCase =
-        pollDatabaseUntilCorrectActualResponseCount(caseId, expectedResponseCount, 100);
-    assertThat(actualCase.getCeActualResponses())
-        .as("ActualResponses Count")
-        .isEqualTo(expectedResponseCount);
-    assertThat(actualCase.isReceiptReceived()).as("Case Receipted").isTrue();
-
-    checkExpectedResponsesEmitted(
-        expectedActualResponses, rhCaseOutboundQueue, caze.getCaseId().toString());
+      checkExpectedResponsesEmitted(
+          expectedActualResponses, rhCaseQueueSpy, caze.getCaseId().toString());
+    }
   }
 
   private void checkExpectedResponsesEmitted(
-      List<Integer> expectedActualResponses,
-      BlockingQueue<String> rhCaseOutboundQueue,
-      String caseId)
-      throws IOException {
+      List<Integer> expectedActualResponses, QueueSpy queueSpy, String caseId) throws IOException {
 
     List<Integer> actualResponsesList =
-        rabbitQueueHelper.collectAllActualResponseCountsForCaseId(rhCaseOutboundQueue, caseId);
+        rabbitQueueHelper.collectAllActualResponseCountsForCaseId(queueSpy.getQueue(), caseId);
 
     assertThat(actualResponsesList).hasSameElementsAs(expectedActualResponses);
   }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
@@ -129,7 +129,7 @@ public class ReceiptReceiverIT {
 
       // check messages sent
       ResponseManagementEvent responseManagementEvent =
-          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
+          rhCaseQueueSpy.checkExpectedMessageReceived();
       CollectionCase actualCollectionCase =
           responseManagementEvent.getPayload().getCollectionCase();
       assertThat(actualCollectionCase.getId()).isEqualTo(TEST_CASE_ID.toString());
@@ -145,7 +145,7 @@ public class ReceiptReceiverIT {
       assertThat(metaData.getCauseEventType()).isEqualTo(RESPONSE_RECEIVED);
       assertThat(metaData.getFieldDecision()).isEqualTo(ActionInstructionType.CANCEL);
 
-      responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(rhUacQueueSpy);
+      responseManagementEvent = rhUacQueueSpy.checkExpectedMessageReceived();
       assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.UAC_UPDATED);
       UacDTO actualUacDTOObject = responseManagementEvent.getPayload().getUac();
       assertThat(actualUacDTOObject.getUac()).isEqualTo(TEST_UAC);
@@ -220,7 +220,7 @@ public class ReceiptReceiverIT {
 
       // check messages sent
       ResponseManagementEvent responseManagementEvent =
-          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
+          rhCaseQueueSpy.checkExpectedMessageReceived();
       CollectionCase actualCollectionCase =
           responseManagementEvent.getPayload().getCollectionCase();
       assertThat(actualCollectionCase.getId()).isEqualTo(TEST_CASE_ID.toString());
@@ -236,7 +236,7 @@ public class ReceiptReceiverIT {
       assertThat(metaData.getCauseEventType()).isEqualTo(RESPONSE_RECEIVED);
       assertThat(metaData.getFieldDecision()).isEqualTo(ActionInstructionType.UPDATE);
 
-      responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(rhUacQueueSpy);
+      responseManagementEvent = rhUacQueueSpy.checkExpectedMessageReceived();
       assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.UAC_UPDATED);
       UacDTO actualUacDTOObject = responseManagementEvent.getPayload().getUac();
       assertThat(actualUacDTOObject.getUac()).isEqualTo(TEST_UAC);
@@ -340,8 +340,7 @@ public class ReceiptReceiverIT {
   private void checkExpectedResponsesEmitted(
       List<Integer> expectedActualResponses, QueueSpy queueSpy, String caseId) throws IOException {
 
-    List<Integer> actualResponsesList =
-        rabbitQueueHelper.collectAllActualResponseCountsForCaseId(queueSpy.getQueue(), caseId);
+    List<Integer> actualResponsesList = queueSpy.collectAllActualResponseCountsForCaseId(caseId);
 
     assertThat(actualResponsesList).hasSameElementsAs(expectedActualResponses);
   }
@@ -357,8 +356,6 @@ public class ReceiptReceiverIT {
       if (actualCase.getCeActualResponses() >= expectedActualResponses) {
         return actualCase;
       }
-
-      System.out.println("Current Actual Count: " + actualCase.getCeActualResponses());
 
       Thread.sleep(1000);
     }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverIT.java
@@ -123,6 +123,7 @@ public class RefusalReceiverIT {
       assertThat(actualRefusal.getType()).isEqualTo(expectedRefusal.getType());
       assertThat(actualRefusal.getReport()).isEqualTo(expectedRefusal.getReport());
       assertThat(actualRefusal.getAgentId()).isEqualTo(expectedRefusal.getAgentId());
+      assertThat(actualRefusal.getCallId()).isEqualTo(expectedRefusal.getCallId());
       assertThat(actualRefusal.getCollectionCase().getId())
           .isEqualTo(expectedRefusal.getCollectionCase().getId());
     }
@@ -182,6 +183,7 @@ public class RefusalReceiverIT {
       assertThat(actualRefusal.getType()).isEqualTo(RefusalType.HARD_REFUSAL);
       assertThat(actualRefusal.getReport()).isEqualTo(refusalDTO.getReport());
       assertThat(actualRefusal.getAgentId()).isEqualTo(refusalDTO.getAgentId());
+      assertThat(actualRefusal.getCallId()).isEqualTo(refusalDTO.getCallId());
       assertThat(actualRefusal.getCollectionCase().getId())
           .isEqualTo(refusalDTO.getCollectionCase().getId());
     }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverIT.java
@@ -97,7 +97,7 @@ public class RefusalReceiverIT {
 
       // THEN
       ResponseManagementEvent responseManagementEvent =
-          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
+          rhCaseQueueSpy.checkExpectedMessageReceived();
 
       EventDTO eventDTO = responseManagementEvent.getEvent();
       assertThat(eventDTO.getType()).isEqualTo(EventTypeDTO.CASE_UPDATED);
@@ -168,7 +168,7 @@ public class RefusalReceiverIT {
       rabbitQueueHelper.sendMessage(inboundQueue, message);
 
       // THEN
-      rabbitQueueHelper.checkMessageIsNotReceived(rhCaseQueueSpy, 5);
+      rhCaseQueueSpy.checkMessageIsNotReceived(5);
 
       Case actualCase = caseRepository.findById(TEST_CASE_ID).get();
       assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/RefusalReceiverIT.java
@@ -6,11 +6,9 @@ import static uk.gov.ons.census.casesvc.testutil.DataUtils.getRandomCase;
 import static uk.gov.ons.census.casesvc.testutil.DataUtils.getTestResponseManagementRefusalEvent;
 import static uk.gov.ons.census.casesvc.utility.JsonHelper.convertObjectToJson;
 
-import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.BlockingQueue;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,7 +18,6 @@ import org.springframework.amqp.core.MessageProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -31,12 +28,12 @@ import uk.gov.ons.census.casesvc.model.entity.Event;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 import uk.gov.ons.census.casesvc.model.repository.EventRepository;
 import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
+import uk.gov.ons.census.casesvc.testutil.QueueSpy;
 import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class RefusalReceiverIT {
 
@@ -68,127 +65,125 @@ public class RefusalReceiverIT {
   }
 
   @Test
-  public void testHardRefusalEmitsMessageAndLogsEventForCase()
-      throws InterruptedException, IOException {
-    // GIVEN
-    BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(rhCaseQueue);
+  public void testHardRefusalEmitsMessageAndLogsEventForCase() throws Exception {
+    try (QueueSpy rhCaseQueueSpy = rabbitQueueHelper.listen(rhCaseQueue)) {
+      // GIVEN
+      Case caze = getRandomCase();
+      caze.setCaseId(TEST_CASE_ID);
+      caze.setRefusalReceived(null);
+      caze.setSurvey("CENSUS");
+      caze.setUacQidLinks(null);
+      caze.setEvents(null);
+      caze.setAddressLevel("U");
+      caseRepository.saveAndFlush(caze);
 
-    Case caze = getRandomCase();
-    caze.setCaseId(TEST_CASE_ID);
-    caze.setRefusalReceived(null);
-    caze.setSurvey("CENSUS");
-    caze.setUacQidLinks(null);
-    caze.setEvents(null);
-    caze.setAddressLevel("U");
-    caseRepository.saveAndFlush(caze);
+      OffsetDateTime cazeCreatedTime =
+          caseRepository.findById(TEST_CASE_ID).get().getCreatedDateTime();
 
-    OffsetDateTime cazeCreatedTime =
-        caseRepository.findById(TEST_CASE_ID).get().getCreatedDateTime();
+      ResponseManagementEvent managementEvent =
+          getTestResponseManagementRefusalEvent(RefusalType.HARD_REFUSAL);
+      managementEvent.getEvent().setTransactionId(UUID.randomUUID());
+      RefusalDTO expectedRefusal = managementEvent.getPayload().getRefusal();
+      expectedRefusal.getCollectionCase().setId(TEST_CASE_ID.toString());
 
-    ResponseManagementEvent managementEvent =
-        getTestResponseManagementRefusalEvent(RefusalType.HARD_REFUSAL);
-    managementEvent.getEvent().setTransactionId(UUID.randomUUID());
-    RefusalDTO expectedRefusal = managementEvent.getPayload().getRefusal();
-    expectedRefusal.getCollectionCase().setId(TEST_CASE_ID.toString());
+      String json = convertObjectToJson(managementEvent);
+      Message message =
+          MessageBuilder.withBody(json.getBytes())
+              .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+              .build();
 
-    String json = convertObjectToJson(managementEvent);
-    Message message =
-        MessageBuilder.withBody(json.getBytes())
-            .setContentType(MessageProperties.CONTENT_TYPE_JSON)
-            .build();
+      // WHEN
+      rabbitQueueHelper.sendMessage(inboundQueue, message);
 
-    // WHEN
-    rabbitQueueHelper.sendMessage(inboundQueue, message);
+      // THEN
+      ResponseManagementEvent responseManagementEvent =
+          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
 
-    // THEN
-    ResponseManagementEvent responseManagementEvent =
-        rabbitQueueHelper.checkExpectedMessageReceived(outboundQueue);
+      EventDTO eventDTO = responseManagementEvent.getEvent();
+      assertThat(eventDTO.getType()).isEqualTo(EventTypeDTO.CASE_UPDATED);
+      assertThat(eventDTO.getSource()).isEqualTo("CASE_SERVICE");
+      assertThat(eventDTO.getChannel()).isEqualTo("RM");
 
-    EventDTO eventDTO = responseManagementEvent.getEvent();
-    assertThat(eventDTO.getType()).isEqualTo(EventTypeDTO.CASE_UPDATED);
-    assertThat(eventDTO.getSource()).isEqualTo("CASE_SERVICE");
-    assertThat(eventDTO.getChannel()).isEqualTo("RM");
+      Case actualCase = caseRepository.findById(TEST_CASE_ID).get();
+      assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
+      assertThat(actualCase.getRefusalReceived()).isEqualTo(RefusalType.HARD_REFUSAL);
+      assertThat(actualCase.getLastUpdated()).isNotEqualTo(cazeCreatedTime);
 
-    Case actualCase = caseRepository.findById(TEST_CASE_ID).get();
-    assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
-    assertThat(actualCase.getRefusalReceived()).isEqualTo(RefusalType.HARD_REFUSAL);
-    assertThat(actualCase.getLastUpdated()).isNotEqualTo(cazeCreatedTime);
+      // check the metadata is included with field CANCEL decision
+      assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
+          .isEqualTo(ActionInstructionType.CANCEL);
+      assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
+          .isEqualTo(EventTypeDTO.REFUSAL_RECEIVED);
 
-    // check the metadata is included with field CANCEL decision
-    assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
-        .isEqualTo(ActionInstructionType.CANCEL);
-    assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
-        .isEqualTo(EventTypeDTO.REFUSAL_RECEIVED);
+      List<Event> events = eventRepository.findAll();
+      assertThat(events.size()).isEqualTo(1);
 
-    List<Event> events = eventRepository.findAll();
-    assertThat(events.size()).isEqualTo(1);
-
-    RefusalDTO actualRefusal =
-        convertJsonToObject(events.get(0).getEventPayload(), RefusalDTO.class);
-    assertThat(actualRefusal.getType()).isEqualTo(expectedRefusal.getType());
-    assertThat(actualRefusal.getReport()).isEqualTo(expectedRefusal.getReport());
-    assertThat(actualRefusal.getAgentId()).isEqualTo(expectedRefusal.getAgentId());
-    assertThat(actualRefusal.getCollectionCase().getId())
-        .isEqualTo(expectedRefusal.getCollectionCase().getId());
+      RefusalDTO actualRefusal =
+          convertJsonToObject(events.get(0).getEventPayload(), RefusalDTO.class);
+      assertThat(actualRefusal.getType()).isEqualTo(expectedRefusal.getType());
+      assertThat(actualRefusal.getReport()).isEqualTo(expectedRefusal.getReport());
+      assertThat(actualRefusal.getAgentId()).isEqualTo(expectedRefusal.getAgentId());
+      assertThat(actualRefusal.getCollectionCase().getId())
+          .isEqualTo(expectedRefusal.getCollectionCase().getId());
+    }
   }
 
   @Test
-  public void testCaseAlreadySetToExtraordinaryNotUpdatedByAHardRefusal()
-      throws InterruptedException, IOException {
+  public void testCaseAlreadySetToExtraordinaryNotUpdatedByAHardRefusal() throws Exception {
     // As per
     // https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=SDC&title=Refusal+status+changes+and+Non+Compliance
     // If a case has already been marked as Extraordinary Refusal and we receive a Hard Refusal for
     // it we will not update the case, or emit
     //  Just record the event.
 
-    // GIVEN
-    BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(rhCaseQueue);
+    try (QueueSpy rhCaseQueueSpy = rabbitQueueHelper.listen(rhCaseQueue)) {
+      // GIVEN
+      Case caze = getRandomCase();
+      caze.setCaseId(TEST_CASE_ID);
+      caze.setRefusalReceived(RefusalType.EXTRAORDINARY_REFUSAL);
+      caze.setSurvey("CENSUS");
+      caze.setUacQidLinks(null);
+      caze.setEvents(null);
+      caze.setAddressLevel("U");
+      caseRepository.saveAndFlush(caze);
 
-    Case caze = getRandomCase();
-    caze.setCaseId(TEST_CASE_ID);
-    caze.setRefusalReceived(RefusalType.EXTRAORDINARY_REFUSAL);
-    caze.setSurvey("CENSUS");
-    caze.setUacQidLinks(null);
-    caze.setEvents(null);
-    caze.setAddressLevel("U");
-    caseRepository.saveAndFlush(caze);
+      OffsetDateTime cazeCreatedTime =
+          caseRepository.findById(TEST_CASE_ID).get().getCreatedDateTime();
 
-    OffsetDateTime cazeCreatedTime =
-        caseRepository.findById(TEST_CASE_ID).get().getCreatedDateTime();
+      ResponseManagementEvent managementEvent =
+          getTestResponseManagementRefusalEvent(RefusalType.HARD_REFUSAL);
+      managementEvent.getEvent().setTransactionId(UUID.randomUUID());
 
-    ResponseManagementEvent managementEvent =
-        getTestResponseManagementRefusalEvent(RefusalType.HARD_REFUSAL);
-    managementEvent.getEvent().setTransactionId(UUID.randomUUID());
+      RefusalDTO refusalDTO = managementEvent.getPayload().getRefusal();
+      refusalDTO.getCollectionCase().setId(TEST_CASE_ID.toString());
 
-    RefusalDTO refusalDTO = managementEvent.getPayload().getRefusal();
-    refusalDTO.getCollectionCase().setId(TEST_CASE_ID.toString());
+      String json = convertObjectToJson(managementEvent);
+      Message message =
+          MessageBuilder.withBody(json.getBytes())
+              .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+              .build();
 
-    String json = convertObjectToJson(managementEvent);
-    Message message =
-        MessageBuilder.withBody(json.getBytes())
-            .setContentType(MessageProperties.CONTENT_TYPE_JSON)
-            .build();
+      // WHEN
+      rabbitQueueHelper.sendMessage(inboundQueue, message);
 
-    // WHEN
-    rabbitQueueHelper.sendMessage(inboundQueue, message);
+      // THEN
+      rabbitQueueHelper.checkMessageIsNotReceived(rhCaseQueueSpy, 5);
 
-    // THEN
-    rabbitQueueHelper.checkMessageIsNotReceived(outboundQueue, 5);
+      Case actualCase = caseRepository.findById(TEST_CASE_ID).get();
+      assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
+      assertThat(actualCase.getRefusalReceived()).isEqualTo(RefusalType.EXTRAORDINARY_REFUSAL);
+      assertThat(actualCase.getLastUpdated()).isNotEqualTo(cazeCreatedTime);
 
-    Case actualCase = caseRepository.findById(TEST_CASE_ID).get();
-    assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
-    assertThat(actualCase.getRefusalReceived()).isEqualTo(RefusalType.EXTRAORDINARY_REFUSAL);
-    assertThat(actualCase.getLastUpdated()).isNotEqualTo(cazeCreatedTime);
+      List<Event> events = eventRepository.findAll();
+      assertThat(events.size()).isEqualTo(1);
 
-    List<Event> events = eventRepository.findAll();
-    assertThat(events.size()).isEqualTo(1);
-
-    RefusalDTO actualRefusal =
-        convertJsonToObject(events.get(0).getEventPayload(), RefusalDTO.class);
-    assertThat(actualRefusal.getType()).isEqualTo(RefusalType.HARD_REFUSAL);
-    assertThat(actualRefusal.getReport()).isEqualTo(refusalDTO.getReport());
-    assertThat(actualRefusal.getAgentId()).isEqualTo(refusalDTO.getAgentId());
-    assertThat(actualRefusal.getCollectionCase().getId())
-        .isEqualTo(refusalDTO.getCollectionCase().getId());
+      RefusalDTO actualRefusal =
+          convertJsonToObject(events.get(0).getEventPayload(), RefusalDTO.class);
+      assertThat(actualRefusal.getType()).isEqualTo(RefusalType.HARD_REFUSAL);
+      assertThat(actualRefusal.getReport()).isEqualTo(refusalDTO.getReport());
+      assertThat(actualRefusal.getAgentId()).isEqualTo(refusalDTO.getAgentId());
+      assertThat(actualRefusal.getCollectionCase().getId())
+          .isEqualTo(refusalDTO.getCollectionCase().getId());
+    }
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
@@ -89,18 +89,16 @@ public class SampleReceiverIT {
 
       // THEN
       ResponseManagementEvent responseManagementEvent =
-          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
+          rhCaseQueueSpy.checkExpectedMessageReceived();
       assertEquals(EventTypeDTO.CASE_CREATED, responseManagementEvent.getEvent().getType());
 
-      responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(rhUacQueueSpy);
+      responseManagementEvent = rhUacQueueSpy.checkExpectedMessageReceived();
       assertEquals(EventTypeDTO.UAC_UPDATED, responseManagementEvent.getEvent().getType());
 
       List<EventTypeDTO> eventTypesSeenDTO = new LinkedList<>();
-      responseManagementEvent =
-          rabbitQueueHelper.checkExpectedMessageReceived(actionSchedulerQueueSpy);
+      responseManagementEvent = actionSchedulerQueueSpy.checkExpectedMessageReceived();
       eventTypesSeenDTO.add(responseManagementEvent.getEvent().getType());
-      responseManagementEvent =
-          rabbitQueueHelper.checkExpectedMessageReceived(actionSchedulerQueueSpy);
+      responseManagementEvent = actionSchedulerQueueSpy.checkExpectedMessageReceived();
       eventTypesSeenDTO.add(responseManagementEvent.getEvent().getType());
 
       assertThat(

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
@@ -7,14 +7,12 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.BlockingQueue;
 import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,7 +20,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -36,12 +33,12 @@ import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 import uk.gov.ons.census.casesvc.model.repository.EventRepository;
 import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
+import uk.gov.ons.census.casesvc.testutil.QueueSpy;
 import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class SampleReceiverIT {
 
@@ -75,52 +72,55 @@ public class SampleReceiverIT {
   }
 
   @Test
-  public void testHappyPath() throws InterruptedException, IOException {
-    // GIVEN
-    BlockingQueue<String> rhCaseMessages = rabbitQueueHelper.listen(rhCaseQueue);
-    BlockingQueue<String> rhUacMessages = rabbitQueueHelper.listen(rhUacQueue);
-    BlockingQueue<String> actionMessages = rabbitQueueHelper.listen(actionSchedulerQueue);
+  public void testHappyPath() throws Exception {
+    try (QueueSpy rhCaseQueueSpy = rabbitQueueHelper.listen(rhCaseQueue);
+        QueueSpy rhUacQueueSpy = rabbitQueueHelper.listen(rhUacQueue);
+        QueueSpy actionSchedulerQueueSpy = rabbitQueueHelper.listen(actionSchedulerQueue)) {
+      // GIVEN
+      CreateCaseSample createCaseSample = new CreateCaseSample();
+      createCaseSample.setAddressType("HH");
+      createCaseSample.setPostcode("ABC123");
+      createCaseSample.setRegion("E12000009");
+      createCaseSample.setTreatmentCode("HH_LF3R2E");
+      createCaseSample.setCeExpectedCapacity(null);
+      createCaseSample.setSecureEstablishment(0);
+      // WHEN
+      rabbitQueueHelper.sendMessage(inboundQueue, createCaseSample);
 
-    CreateCaseSample createCaseSample = new CreateCaseSample();
-    createCaseSample.setAddressType("HH");
-    createCaseSample.setPostcode("ABC123");
-    createCaseSample.setRegion("E12000009");
-    createCaseSample.setTreatmentCode("HH_LF3R2E");
-    createCaseSample.setCeExpectedCapacity(null);
-    createCaseSample.setSecureEstablishment(0);
-    // WHEN
-    rabbitQueueHelper.sendMessage(inboundQueue, createCaseSample);
+      // THEN
+      ResponseManagementEvent responseManagementEvent =
+          rabbitQueueHelper.checkExpectedMessageReceived(rhCaseQueueSpy);
+      assertEquals(EventTypeDTO.CASE_CREATED, responseManagementEvent.getEvent().getType());
 
-    // THEN
-    ResponseManagementEvent responseManagementEvent =
-        rabbitQueueHelper.checkExpectedMessageReceived(rhCaseMessages);
-    assertEquals(EventTypeDTO.CASE_CREATED, responseManagementEvent.getEvent().getType());
+      responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(rhUacQueueSpy);
+      assertEquals(EventTypeDTO.UAC_UPDATED, responseManagementEvent.getEvent().getType());
 
-    responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(rhUacMessages);
-    assertEquals(EventTypeDTO.UAC_UPDATED, responseManagementEvent.getEvent().getType());
+      List<EventTypeDTO> eventTypesSeenDTO = new LinkedList<>();
+      responseManagementEvent =
+          rabbitQueueHelper.checkExpectedMessageReceived(actionSchedulerQueueSpy);
+      eventTypesSeenDTO.add(responseManagementEvent.getEvent().getType());
+      responseManagementEvent =
+          rabbitQueueHelper.checkExpectedMessageReceived(actionSchedulerQueueSpy);
+      eventTypesSeenDTO.add(responseManagementEvent.getEvent().getType());
 
-    List<EventTypeDTO> eventTypesSeenDTO = new LinkedList<>();
-    responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(actionMessages);
-    eventTypesSeenDTO.add(responseManagementEvent.getEvent().getType());
-    responseManagementEvent = rabbitQueueHelper.checkExpectedMessageReceived(actionMessages);
-    eventTypesSeenDTO.add(responseManagementEvent.getEvent().getType());
+      assertThat(
+          eventTypesSeenDTO,
+          containsInAnyOrder(EventTypeDTO.CASE_CREATED, EventTypeDTO.UAC_UPDATED));
 
-    assertThat(
-        eventTypesSeenDTO, containsInAnyOrder(EventTypeDTO.CASE_CREATED, EventTypeDTO.UAC_UPDATED));
+      List<Case> caseList = caseRepository.findAll();
+      assertEquals(1, caseList.size());
+      assertEquals("ABC123", caseList.get(0).getPostcode());
+      assertNull(caseList.get(0).getCeExpectedCapacity());
 
-    List<Case> caseList = caseRepository.findAll();
-    assertEquals(1, caseList.size());
-    assertEquals("ABC123", caseList.get(0).getPostcode());
-    assertNull(caseList.get(0).getCeExpectedCapacity());
+      List<Event> eventList = eventRepository.findAll();
+      assertThat(eventList.size()).isEqualTo(1);
+      Event actualEvent = eventList.get(0);
 
-    List<Event> eventList = eventRepository.findAll();
-    assertThat(eventList.size()).isEqualTo(1);
-    Event actualEvent = eventList.get(0);
+      CreateCaseSample actualcreateCaseSample =
+          new ObjectMapper().readValue(actualEvent.getEventPayload(), CreateCaseSample.class);
 
-    CreateCaseSample actualcreateCaseSample =
-        new ObjectMapper().readValue(actualEvent.getEventPayload(), CreateCaseSample.class);
-
-    assertThat(actualcreateCaseSample).isEqualTo(createCaseSample);
+      assertThat(actualcreateCaseSample).isEqualTo(createCaseSample);
+    }
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SurveyLaunchedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SurveyLaunchedReceiverIT.java
@@ -20,7 +20,6 @@ import org.springframework.amqp.core.MessageProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -38,7 +37,6 @@ import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class SurveyLaunchedReceiverIT {
   private static final UUID TEST_CASE_ID = UUID.randomUUID();

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/TransactionsIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/TransactionsIT.java
@@ -108,7 +108,7 @@ public class TransactionsIT {
       uacQidLinkRepository.saveAndFlush(uacQidLink);
 
       // Poll Queue, expected message to be there
-      rabbitQueueHelper.checkExpectedMessageReceived(rhUacQueueSpy);
+      rhUacQueueSpy.checkExpectedMessageReceived();
 
       // check Log Events
       assertThat(eventRepository.findAll().size()).isEqualTo(1);
@@ -157,7 +157,7 @@ public class TransactionsIT {
       uacQidLinkRepository.saveAndFlush(uacQidLink);
 
       // Poll Queue, expected message to be there
-      rabbitQueueHelper.checkExpectedMessageReceived(rhUacQueueSpy);
+      rhUacQueueSpy.checkExpectedMessageReceived();
 
       // check Log Events
       assertThat(eventRepository.findAll().size()).isEqualTo(1);

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/TransactionsIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/TransactionsIT.java
@@ -6,9 +6,7 @@ import static uk.gov.ons.census.casesvc.testutil.DataUtils.getTestResponseManage
 import static uk.gov.ons.census.casesvc.testutil.DataUtils.getTestResponseManagementReceiptEvent;
 import static uk.gov.ons.census.casesvc.utility.JsonHelper.convertObjectToJson;
 
-import java.io.IOException;
 import java.util.UUID;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.jeasy.random.EasyRandom;
 import org.junit.Before;
@@ -20,7 +18,6 @@ import org.springframework.amqp.core.MessageProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -32,12 +29,12 @@ import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 import uk.gov.ons.census.casesvc.model.repository.EventRepository;
 import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
+import uk.gov.ons.census.casesvc.testutil.QueueSpy;
 import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 
 @ContextConfiguration
 @ActiveProfiles("nologging")
 @SpringBootTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class TransactionsIT {
   private static final UUID TEST_CASE_ID = UUID.randomUUID();
@@ -71,97 +68,99 @@ public class TransactionsIT {
   }
 
   @Test
-  public void testReceiptTransactionality() throws InterruptedException, IOException {
-    // no cases on the database
-    BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(rhUacQueue);
+  public void testReceiptTransactionality() throws Exception {
+    try (QueueSpy rhUacQueueSpy = rabbitQueueHelper.listen(rhUacQueue)) {
+      // GIVEN
 
-    // WHEN
-    ResponseManagementEvent managementEvent = getTestResponseManagementReceiptEvent();
-    managementEvent.getPayload().getResponse().setQuestionnaireId(TEST_QID);
-    managementEvent.getEvent().setTransactionId(UUID.randomUUID());
+      // WHEN
+      ResponseManagementEvent managementEvent = getTestResponseManagementReceiptEvent();
+      managementEvent.getPayload().getResponse().setQuestionnaireId(TEST_QID);
+      managementEvent.getEvent().setTransactionId(UUID.randomUUID());
 
-    String json = convertObjectToJson(managementEvent);
-    Message message =
-        MessageBuilder.withBody(json.getBytes())
-            .setContentType(MessageProperties.CONTENT_TYPE_JSON)
-            .build();
-    rabbitQueueHelper.sendMessage(receiptInboundQueue, message);
+      String json = convertObjectToJson(managementEvent);
+      Message message =
+          MessageBuilder.withBody(json.getBytes())
+              .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+              .build();
+      rabbitQueueHelper.sendMessage(receiptInboundQueue, message);
 
-    // Poll Queue, expected failure
-    String actualMessage = outboundQueue.poll(5, TimeUnit.SECONDS);
-    assertNull(actualMessage);
+      // Poll Queue, expected failure
+      String actualMessage = rhUacQueueSpy.getQueue().poll(5, TimeUnit.SECONDS);
+      assertNull(actualMessage);
 
-    // Log events empty
-    assertThat(eventRepository.findAll().size()).isEqualTo(0);
+      // Log events empty
+      assertThat(eventRepository.findAll().size()).isEqualTo(0);
 
-    // Save case and UacQidLink
-    Case caze = easyRandom.nextObject(Case.class);
-    caze.setCaseId(TEST_CASE_ID);
-    caze.setUacQidLinks(null);
-    caze.setEvents(null);
-    caze.setCaseType("HH");
-    caze.setAddressLevel("U");
-    caze = caseRepository.saveAndFlush(caze);
+      // Save case and UacQidLink
+      Case caze = easyRandom.nextObject(Case.class);
+      caze.setCaseId(TEST_CASE_ID);
+      caze.setUacQidLinks(null);
+      caze.setEvents(null);
+      caze.setCaseType("HH");
+      caze.setAddressLevel("U");
+      caze = caseRepository.saveAndFlush(caze);
 
-    UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setId(UUID.randomUUID());
-    uacQidLink.setCaze(caze);
-    uacQidLink.setQid(TEST_QID);
-    uacQidLink.setUac(TEST_UAC);
-    uacQidLinkRepository.saveAndFlush(uacQidLink);
+      UacQidLink uacQidLink = new UacQidLink();
+      uacQidLink.setId(UUID.randomUUID());
+      uacQidLink.setCaze(caze);
+      uacQidLink.setQid(TEST_QID);
+      uacQidLink.setUac(TEST_UAC);
+      uacQidLinkRepository.saveAndFlush(uacQidLink);
 
-    // Poll Queue, expected message to be there
-    rabbitQueueHelper.checkExpectedMessageReceived(outboundQueue);
+      // Poll Queue, expected message to be there
+      rabbitQueueHelper.checkExpectedMessageReceived(rhUacQueueSpy);
 
-    // check Log Events
-    assertThat(eventRepository.findAll().size()).isEqualTo(1);
+      // check Log Events
+      assertThat(eventRepository.findAll().size()).isEqualTo(1);
+    }
   }
 
   @Test
-  public void testQuestionnaireLinkedTransactionality() throws InterruptedException, IOException {
-    // no cases on the database
-    BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(rhUacQueue);
+  public void testQuestionnaireLinkedTransactionality() throws Exception {
+    try (QueueSpy rhUacQueueSpy = rabbitQueueHelper.listen(rhUacQueue)) {
+      // GIVEN
 
-    // WHEN
-    ResponseManagementEvent managementEvent = getTestResponseManagementQuestionnaireLinkedEvent();
-    managementEvent.getEvent().setTransactionId(UUID.randomUUID());
-    UacDTO uac = managementEvent.getPayload().getUac();
-    uac.setCaseId(TEST_CASE_ID.toString());
-    uac.setQuestionnaireId(TEST_QID);
+      // WHEN
+      ResponseManagementEvent managementEvent = getTestResponseManagementQuestionnaireLinkedEvent();
+      managementEvent.getEvent().setTransactionId(UUID.randomUUID());
+      UacDTO uac = managementEvent.getPayload().getUac();
+      uac.setCaseId(TEST_CASE_ID.toString());
+      uac.setQuestionnaireId(TEST_QID);
 
-    String json = convertObjectToJson(managementEvent);
-    Message message =
-        MessageBuilder.withBody(json.getBytes())
-            .setContentType(MessageProperties.CONTENT_TYPE_JSON)
-            .build();
-    rabbitQueueHelper.sendMessage(questionnaireLinkedInboundQueue, message);
+      String json = convertObjectToJson(managementEvent);
+      Message message =
+          MessageBuilder.withBody(json.getBytes())
+              .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+              .build();
+      rabbitQueueHelper.sendMessage(questionnaireLinkedInboundQueue, message);
 
-    // Poll Queue, expected failure
-    String actualMessage = outboundQueue.poll(5, TimeUnit.SECONDS);
-    assertNull(actualMessage);
+      // Poll Queue, expected failure
+      String actualMessage = rhUacQueueSpy.getQueue().poll(5, TimeUnit.SECONDS);
+      assertNull(actualMessage);
 
-    // Log events empty
-    assertThat(eventRepository.findAll().size()).isEqualTo(0);
+      // Log events empty
+      assertThat(eventRepository.findAll().size()).isEqualTo(0);
 
-    // Save case
-    Case caze = easyRandom.nextObject(Case.class);
-    caze.setCaseId(TEST_CASE_ID);
-    caze.setUacQidLinks(null);
-    caze.setEvents(null);
-    caze.setCaseType("HH");
-    caze.setAddressLevel("U");
-    caseRepository.saveAndFlush(caze);
+      // Save case
+      Case caze = easyRandom.nextObject(Case.class);
+      caze.setCaseId(TEST_CASE_ID);
+      caze.setUacQidLinks(null);
+      caze.setEvents(null);
+      caze.setCaseType("HH");
+      caze.setAddressLevel("U");
+      caseRepository.saveAndFlush(caze);
 
-    UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setId(UUID.randomUUID());
-    uacQidLink.setQid(TEST_QID);
-    uacQidLink.setUac(TEST_UAC);
-    uacQidLinkRepository.saveAndFlush(uacQidLink);
+      UacQidLink uacQidLink = new UacQidLink();
+      uacQidLink.setId(UUID.randomUUID());
+      uacQidLink.setQid(TEST_QID);
+      uacQidLink.setUac(TEST_UAC);
+      uacQidLinkRepository.saveAndFlush(uacQidLink);
 
-    // Poll Queue, expected message to be there
-    rabbitQueueHelper.checkExpectedMessageReceived(outboundQueue);
+      // Poll Queue, expected message to be there
+      rabbitQueueHelper.checkExpectedMessageReceived(rhUacQueueSpy);
 
-    // check Log Events
-    assertThat(eventRepository.findAll().size()).isEqualTo(1);
+      // check Log Events
+      assertThat(eventRepository.findAll().size()).isEqualTo(1);
+    }
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UacCreatedEventReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UacCreatedEventReceiverIT.java
@@ -6,9 +6,7 @@ import static uk.gov.ons.census.casesvc.testutil.DataUtils.generateUacCreatedEve
 import static uk.gov.ons.census.casesvc.testutil.DataUtils.getRandomCase;
 import static uk.gov.ons.census.casesvc.utility.JsonHelper.convertObjectToJson;
 
-import java.io.IOException;
 import java.util.Optional;
-import java.util.concurrent.BlockingQueue;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,7 +16,6 @@ import org.springframework.amqp.core.MessageProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -29,13 +26,13 @@ import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 import uk.gov.ons.census.casesvc.model.repository.EventRepository;
 import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
+import uk.gov.ons.census.casesvc.testutil.QueueSpy;
 import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest
 @RunWith(SpringJUnit4ClassRunner.class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class UacCreatedEventReceiverIT {
 
   @Value("${queueconfig.rh-uac-queue}")
@@ -60,36 +57,38 @@ public class UacCreatedEventReceiverIT {
   }
 
   @Test
-  public void testReceiveRmUacCreatedEvent() throws IOException, InterruptedException {
-    // Given
-    Case linkedCase = getRandomCase();
-    caseRepository.saveAndFlush(linkedCase);
-    BlockingQueue<String> uacEventQueue = rabbitQueueHelper.listen(rhUacQueue);
+  public void testReceiveRmUacCreatedEvent() throws Exception {
+    try (QueueSpy rhUacQueueSpy = rabbitQueueHelper.listen(rhUacQueue)) {
+      // Given
+      Case linkedCase = getRandomCase();
+      caseRepository.saveAndFlush(linkedCase);
 
-    ResponseManagementEvent uacCreatedEvent = generateUacCreatedEvent(linkedCase);
+      ResponseManagementEvent uacCreatedEvent = generateUacCreatedEvent(linkedCase);
 
-    // When
-    String uacCreatedEventJson = convertObjectToJson(uacCreatedEvent);
-    Message message =
-        MessageBuilder.withBody(uacCreatedEventJson.getBytes())
-            .setContentType(MessageProperties.CONTENT_TYPE_JSON)
-            .build();
-    rabbitQueueHelper.sendMessage(uacQidCreatedQueue, message);
+      // When
+      String uacCreatedEventJson = convertObjectToJson(uacCreatedEvent);
+      Message message =
+          MessageBuilder.withBody(uacCreatedEventJson.getBytes())
+              .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+              .build();
+      rabbitQueueHelper.sendMessage(uacQidCreatedQueue, message);
 
-    // Then
-    // Check the UAC Updated event is emitted
-    ResponseManagementEvent uacUpdatedEvent =
-        rabbitQueueHelper.checkExpectedMessageReceived(uacEventQueue);
-    assertEquals(
-        uacCreatedEvent.getPayload().getUacQidCreated().getCaseId().toString(),
-        uacUpdatedEvent.getPayload().getUac().getCaseId());
+      // Then
+      // Check the UAC Updated event is emitted
+      ResponseManagementEvent uacUpdatedEvent =
+          rabbitQueueHelper.checkExpectedMessageReceived(rhUacQueueSpy);
+      assertEquals(
+          uacCreatedEvent.getPayload().getUacQidCreated().getCaseId().toString(),
+          uacUpdatedEvent.getPayload().getUac().getCaseId());
 
-    // Check the Uac Qid Link is created
-    Optional<UacQidLink> actualUacQidLink =
-        uacQidLinkRepository.findByQid(uacCreatedEvent.getPayload().getUacQidCreated().getQid());
-    assertTrue(actualUacQidLink.isPresent());
-    assertEquals(
-        uacCreatedEvent.getPayload().getUacQidCreated().getUac(), actualUacQidLink.get().getUac());
-    assertEquals(linkedCase.getCaseId(), actualUacQidLink.get().getCaze().getCaseId());
+      // Check the Uac Qid Link is created
+      Optional<UacQidLink> actualUacQidLink =
+          uacQidLinkRepository.findByQid(uacCreatedEvent.getPayload().getUacQidCreated().getQid());
+      assertTrue(actualUacQidLink.isPresent());
+      assertEquals(
+          uacCreatedEvent.getPayload().getUacQidCreated().getUac(),
+          actualUacQidLink.get().getUac());
+      assertEquals(linkedCase.getCaseId(), actualUacQidLink.get().getCaze().getCaseId());
+    }
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UacCreatedEventReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UacCreatedEventReceiverIT.java
@@ -75,8 +75,7 @@ public class UacCreatedEventReceiverIT {
 
       // Then
       // Check the UAC Updated event is emitted
-      ResponseManagementEvent uacUpdatedEvent =
-          rabbitQueueHelper.checkExpectedMessageReceived(rhUacQueueSpy);
+      ResponseManagementEvent uacUpdatedEvent = rhUacQueueSpy.checkExpectedMessageReceived();
       assertEquals(
           uacCreatedEvent.getPayload().getUacQidCreated().getCaseId().toString(),
           uacUpdatedEvent.getPayload().getUac().getCaseId());

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiverTestIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiverTestIT.java
@@ -59,7 +59,7 @@ public class UnaddressedReceiverTestIT {
 
       // THEN
       ResponseManagementEvent responseManagementEvent =
-          rabbitQueueHelper.checkExpectedMessageReceived(rhUacQueueSpy);
+          rhUacQueueSpy.checkExpectedMessageReceived();
       assertEquals(EventTypeDTO.UAC_UPDATED, responseManagementEvent.getEvent().getType());
       assertThat(responseManagementEvent.getPayload().getUac().getQuestionnaireId())
           .startsWith("21");

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiverTestIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiverTestIT.java
@@ -3,16 +3,13 @@ package uk.gov.ons.census.casesvc.messaging;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
-import java.io.IOException;
 import java.util.UUID;
-import java.util.concurrent.BlockingQueue;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -22,13 +19,13 @@ import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.casesvc.model.repository.EventRepository;
 import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
+import uk.gov.ons.census.casesvc.testutil.QueueSpy;
 import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest
 @RunWith(SpringJUnit4ClassRunner.class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class UnaddressedReceiverTestIT {
   @Value("${queueconfig.unaddressed-inbound-queue}")
   private String unaddressedQueue;
@@ -50,20 +47,22 @@ public class UnaddressedReceiverTestIT {
   }
 
   @Test
-  public void testHappyPath() throws IOException, InterruptedException {
-    // GIVEN
-    BlockingQueue<String> queue = rabbitQueueHelper.listen(rhUacQueue);
-    CreateUacQid createUacQid = new CreateUacQid();
-    createUacQid.setQuestionnaireType("21");
-    createUacQid.setBatchId(UUID.randomUUID());
+  public void testHappyPath() throws Exception {
+    try (QueueSpy rhUacQueueSpy = rabbitQueueHelper.listen(rhUacQueue)) {
+      // GIVEN
+      CreateUacQid createUacQid = new CreateUacQid();
+      createUacQid.setQuestionnaireType("21");
+      createUacQid.setBatchId(UUID.randomUUID());
 
-    // WHEN
-    rabbitQueueHelper.sendMessage(unaddressedQueue, createUacQid);
+      // WHEN
+      rabbitQueueHelper.sendMessage(unaddressedQueue, createUacQid);
 
-    // THEN
-    ResponseManagementEvent responseManagementEvent =
-        rabbitQueueHelper.checkExpectedMessageReceived(queue);
-    assertEquals(EventTypeDTO.UAC_UPDATED, responseManagementEvent.getEvent().getType());
-    assertThat(responseManagementEvent.getPayload().getUac().getQuestionnaireId()).startsWith("21");
+      // THEN
+      ResponseManagementEvent responseManagementEvent =
+          rabbitQueueHelper.checkExpectedMessageReceived(rhUacQueueSpy);
+      assertEquals(EventTypeDTO.UAC_UPDATED, responseManagementEvent.getEvent().getType());
+      assertThat(responseManagementEvent.getPayload().getUac().getQuestionnaireId())
+          .startsWith("21");
+    }
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiverIT.java
@@ -107,7 +107,7 @@ public class UndeliveredMailReceiverIT {
 
       // check the emitted eventDTO
       ResponseManagementEvent responseManagementEvent =
-          rabbitQueueHelper.checkExpectedMessageReceived(actionQueueSpy);
+          actionQueueSpy.checkExpectedMessageReceived();
 
       assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_UPDATED);
       assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
@@ -163,7 +163,7 @@ public class UndeliveredMailReceiverIT {
 
       // check the emitted eventDTO
       ResponseManagementEvent responseManagementEvent =
-          rabbitQueueHelper.checkExpectedMessageReceived(actionQueueSpy);
+          actionQueueSpy.checkExpectedMessageReceived();
 
       assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_UPDATED);
       assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UndeliveredMailReceiverIT.java
@@ -3,11 +3,9 @@ package uk.gov.ons.census.casesvc.messaging;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ons.census.casesvc.utility.JsonHelper.convertObjectToJson;
 
-import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.BlockingQueue;
 import org.jeasy.random.EasyRandom;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,7 +16,6 @@ import org.springframework.amqp.core.MessageProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -36,12 +33,12 @@ import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 import uk.gov.ons.census.casesvc.model.repository.EventRepository;
 import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
+import uk.gov.ons.census.casesvc.testutil.QueueSpy;
 import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 
 @ContextConfiguration
 @ActiveProfiles("test")
 @SpringBootTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class UndeliveredMailReceiverIT {
   private static final UUID TEST_CASE_ID = UUID.randomUUID();
@@ -72,119 +69,119 @@ public class UndeliveredMailReceiverIT {
   }
 
   @Test
-  public void testUndeliveredMailWithQid() throws InterruptedException, IOException {
-    // GIVEN
-    BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(actionQueue);
+  public void testUndeliveredMailWithQid() throws Exception {
+    try (QueueSpy actionQueueSpy = rabbitQueueHelper.listen(actionQueue)) {
+      // GIVEN
+      EasyRandom easyRandom = new EasyRandom();
+      Case caze = easyRandom.nextObject(Case.class);
+      caze.setCaseId(TEST_CASE_ID);
+      caze.setUacQidLinks(null);
+      caze.setEvents(null);
+      caze.setSurvey("CENSUS");
+      caze.setAddressInvalid(false);
+      caze.setRefusalReceived(null);
+      caze.setReceiptReceived(false);
+      caze = caseRepository.saveAndFlush(caze);
 
-    EasyRandom easyRandom = new EasyRandom();
-    Case caze = easyRandom.nextObject(Case.class);
-    caze.setCaseId(TEST_CASE_ID);
-    caze.setUacQidLinks(null);
-    caze.setEvents(null);
-    caze.setSurvey("CENSUS");
-    caze.setAddressInvalid(false);
-    caze.setRefusalReceived(null);
-    caze.setReceiptReceived(false);
-    caze = caseRepository.saveAndFlush(caze);
+      UacQidLink uacQidLink = new UacQidLink();
+      uacQidLink.setId(UUID.randomUUID());
+      uacQidLink.setCaze(caze);
+      uacQidLink.setQid(TEST_QID);
+      uacQidLink.setUac(TEST_UAC);
+      uacQidLinkRepository.saveAndFlush(uacQidLink);
 
-    UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setId(UUID.randomUUID());
-    uacQidLink.setCaze(caze);
-    uacQidLink.setQid(TEST_QID);
-    uacQidLink.setUac(TEST_UAC);
-    uacQidLinkRepository.saveAndFlush(uacQidLink);
+      ResponseManagementEvent event = new ResponseManagementEvent();
+      event.setEvent(new EventDTO());
+      event.getEvent().setDateTime(OffsetDateTime.now());
+      event.getEvent().setType(EventTypeDTO.UNDELIVERED_MAIL_REPORTED);
+      event.setPayload(new PayloadDTO());
+      event.getPayload().setFulfilmentInformation(new FulfilmentInformation());
+      event.getPayload().getFulfilmentInformation().setQuestionnaireId(TEST_QID);
 
-    ResponseManagementEvent event = new ResponseManagementEvent();
-    event.setEvent(new EventDTO());
-    event.getEvent().setDateTime(OffsetDateTime.now());
-    event.getEvent().setType(EventTypeDTO.UNDELIVERED_MAIL_REPORTED);
-    event.setPayload(new PayloadDTO());
-    event.getPayload().setFulfilmentInformation(new FulfilmentInformation());
-    event.getPayload().getFulfilmentInformation().setQuestionnaireId(TEST_QID);
+      String json = convertObjectToJson(event);
+      Message message =
+          MessageBuilder.withBody(json.getBytes())
+              .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+              .build();
+      rabbitQueueHelper.sendMessage(inboundQueue, message);
 
-    String json = convertObjectToJson(event);
-    Message message =
-        MessageBuilder.withBody(json.getBytes())
-            .setContentType(MessageProperties.CONTENT_TYPE_JSON)
-            .build();
-    rabbitQueueHelper.sendMessage(inboundQueue, message);
+      // check the emitted eventDTO
+      ResponseManagementEvent responseManagementEvent =
+          rabbitQueueHelper.checkExpectedMessageReceived(actionQueueSpy);
 
-    // check the emitted eventDTO
-    ResponseManagementEvent responseManagementEvent =
-        rabbitQueueHelper.checkExpectedMessageReceived(outboundQueue);
+      assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_UPDATED);
+      assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
+          .isEqualTo(ActionInstructionType.UPDATE);
+      assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
+          .isEqualTo(EventTypeDTO.UNDELIVERED_MAIL_REPORTED);
+      CollectionCase actualCase = responseManagementEvent.getPayload().getCollectionCase();
+      assertThat(actualCase.getId()).isEqualTo(TEST_CASE_ID.toString());
+      assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
 
-    assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_UPDATED);
-    assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
-        .isEqualTo(ActionInstructionType.UPDATE);
-    assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
-        .isEqualTo(EventTypeDTO.UNDELIVERED_MAIL_REPORTED);
-    CollectionCase actualCase = responseManagementEvent.getPayload().getCollectionCase();
-    assertThat(actualCase.getId()).isEqualTo(TEST_CASE_ID.toString());
-    assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
-
-    // check database for log eventDTO
-    List<Event> events = eventRepository.findAll();
-    assertThat(events.size()).isEqualTo(1);
-    Event loggedEvent = events.get(0);
-    assertThat(loggedEvent.getEventDescription()).isEqualTo("Undelivered mail reported");
-    UacQidLink actualUacQidLink = loggedEvent.getUacQidLink();
-    assertThat(actualUacQidLink.getQid()).isEqualTo(TEST_QID);
-    assertThat(actualUacQidLink.getUac()).isEqualTo(TEST_UAC);
-    assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
+      // check database for log eventDTO
+      List<Event> events = eventRepository.findAll();
+      assertThat(events.size()).isEqualTo(1);
+      Event loggedEvent = events.get(0);
+      assertThat(loggedEvent.getEventDescription()).isEqualTo("Undelivered mail reported");
+      UacQidLink actualUacQidLink = loggedEvent.getUacQidLink();
+      assertThat(actualUacQidLink.getQid()).isEqualTo(TEST_QID);
+      assertThat(actualUacQidLink.getUac()).isEqualTo(TEST_UAC);
+      assertThat(actualUacQidLink.getCaze().getCaseId()).isEqualTo(TEST_CASE_ID);
+    }
   }
 
   @Test
-  public void testUndeliveredMailWithCaseRef() throws InterruptedException, IOException {
-    // GIVEN
-    BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(actionQueue);
+  public void testUndeliveredMailWithCaseRef() throws Exception {
+    try (QueueSpy actionQueueSpy = rabbitQueueHelper.listen(actionQueue)) {
+      // GIVEN
+      EasyRandom easyRandom = new EasyRandom();
+      Case caze = easyRandom.nextObject(Case.class);
+      caze.setCaseId(TEST_CASE_ID);
+      caze.setCaseRef(TEST_CASE_REF);
+      caze.setUacQidLinks(null);
+      caze.setEvents(null);
+      caze.setSurvey("CENSUS");
+      caze.setAddressInvalid(false);
+      caze.setRefusalReceived(null);
+      caze.setReceiptReceived(false);
+      caseRepository.saveAndFlush(caze);
 
-    EasyRandom easyRandom = new EasyRandom();
-    Case caze = easyRandom.nextObject(Case.class);
-    caze.setCaseId(TEST_CASE_ID);
-    caze.setCaseRef(TEST_CASE_REF);
-    caze.setUacQidLinks(null);
-    caze.setEvents(null);
-    caze.setSurvey("CENSUS");
-    caze.setAddressInvalid(false);
-    caze.setRefusalReceived(null);
-    caze.setReceiptReceived(false);
-    caseRepository.saveAndFlush(caze);
+      ResponseManagementEvent event = new ResponseManagementEvent();
+      event.setEvent(new EventDTO());
+      event.getEvent().setDateTime(OffsetDateTime.now());
+      event.getEvent().setType(EventTypeDTO.UNDELIVERED_MAIL_REPORTED);
+      event.setPayload(new PayloadDTO());
+      event.getPayload().setFulfilmentInformation(new FulfilmentInformation());
+      event.getPayload().getFulfilmentInformation().setCaseRef(Long.toString(TEST_CASE_REF));
 
-    ResponseManagementEvent event = new ResponseManagementEvent();
-    event.setEvent(new EventDTO());
-    event.getEvent().setDateTime(OffsetDateTime.now());
-    event.getEvent().setType(EventTypeDTO.UNDELIVERED_MAIL_REPORTED);
-    event.setPayload(new PayloadDTO());
-    event.getPayload().setFulfilmentInformation(new FulfilmentInformation());
-    event.getPayload().getFulfilmentInformation().setCaseRef(Long.toString(TEST_CASE_REF));
+      String json = convertObjectToJson(event);
+      Message message =
+          MessageBuilder.withBody(json.getBytes())
+              .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+              .build();
+      rabbitQueueHelper.sendMessage(inboundQueue, message);
 
-    String json = convertObjectToJson(event);
-    Message message =
-        MessageBuilder.withBody(json.getBytes())
-            .setContentType(MessageProperties.CONTENT_TYPE_JSON)
-            .build();
-    rabbitQueueHelper.sendMessage(inboundQueue, message);
+      // check the emitted eventDTO
+      ResponseManagementEvent responseManagementEvent =
+          rabbitQueueHelper.checkExpectedMessageReceived(actionQueueSpy);
 
-    // check the emitted eventDTO
-    ResponseManagementEvent responseManagementEvent =
-        rabbitQueueHelper.checkExpectedMessageReceived(outboundQueue);
+      assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_UPDATED);
+      assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
+          .isEqualTo(ActionInstructionType.UPDATE);
+      assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
+          .isEqualTo(EventTypeDTO.UNDELIVERED_MAIL_REPORTED);
+      CollectionCase actualCase = responseManagementEvent.getPayload().getCollectionCase();
+      assertThat(actualCase.getId()).isEqualTo(TEST_CASE_ID.toString());
+      assertThat(actualCase.getCaseRef()).isEqualTo(Long.toString(TEST_CASE_REF));
+      assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
 
-    assertThat(responseManagementEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_UPDATED);
-    assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
-        .isEqualTo(ActionInstructionType.UPDATE);
-    assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
-        .isEqualTo(EventTypeDTO.UNDELIVERED_MAIL_REPORTED);
-    CollectionCase actualCase = responseManagementEvent.getPayload().getCollectionCase();
-    assertThat(actualCase.getId()).isEqualTo(TEST_CASE_ID.toString());
-    assertThat(actualCase.getCaseRef()).isEqualTo(Long.toString(TEST_CASE_REF));
-    assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
-
-    // check database for log eventDTO
-    List<Event> events = eventRepository.findAll();
-    assertThat(events.size()).isEqualTo(1);
-    Event loggedEvent = events.get(0);
-    assertThat(loggedEvent.getEventDescription()).isEqualTo("Undelivered mail reported");
-    Case actualEventCase = loggedEvent.getCaze();
-    assertThat(actualEventCase.getCaseRef()).isEqualTo(TEST_CASE_REF);
+      // check database for log eventDTO
+      List<Event> events = eventRepository.findAll();
+      assertThat(events.size()).isEqualTo(1);
+      Event loggedEvent = events.get(0);
+      assertThat(loggedEvent.getEventDescription()).isEqualTo("Undelivered mail reported");
+      Case actualEventCase = loggedEvent.getCaze();
+      assertThat(actualEventCase.getCaseRef()).isEqualTo(TEST_CASE_REF);
+    }
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/testutil/QueueSpy.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/testutil/QueueSpy.java
@@ -1,0 +1,17 @@
+package uk.gov.ons.census.casesvc.testutil;
+
+import java.util.concurrent.BlockingQueue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+
+@AllArgsConstructor
+public class QueueSpy implements AutoCloseable {
+  @Getter private BlockingQueue<String> queue;
+  private SimpleMessageListenerContainer container;
+
+  @Override
+  public void close() throws Exception {
+    container.stop();
+  }
+}

--- a/src/test/java/uk/gov/ons/census/casesvc/testutil/QueueSpy.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/testutil/QueueSpy.java
@@ -1,17 +1,73 @@
 package uk.gov.ons.census.casesvc.testutil;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 
 @AllArgsConstructor
 public class QueueSpy implements AutoCloseable {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  static {
+    objectMapper.registerModule(new JavaTimeModule());
+    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+  }
+
   @Getter private BlockingQueue<String> queue;
   private SimpleMessageListenerContainer container;
 
   @Override
   public void close() throws Exception {
     container.stop();
+  }
+
+  public ResponseManagementEvent checkExpectedMessageReceived()
+      throws IOException, InterruptedException {
+    String actualMessage = queue.poll(20, TimeUnit.SECONDS);
+    assertNotNull("Did not receive message before timeout", actualMessage);
+    ResponseManagementEvent responseManagementEvent =
+        objectMapper.readValue(actualMessage, ResponseManagementEvent.class);
+    assertNotNull(responseManagementEvent);
+    assertEquals("RM", responseManagementEvent.getEvent().getChannel());
+    return responseManagementEvent;
+  }
+
+  public void checkMessageIsNotReceived(int timeOut) throws InterruptedException {
+    String actualMessage = queue.poll(timeOut, TimeUnit.SECONDS);
+    assertNull("Message received when not expected", actualMessage);
+  }
+
+  public List<Integer> collectAllActualResponseCountsForCaseId(String caseId) throws IOException {
+    List<String> jsonList = new ArrayList<>();
+    queue.drainTo(jsonList);
+
+    List<Integer> actualActualResponseCountList = new ArrayList<>();
+
+    for (String jsonString : jsonList) {
+      ResponseManagementEvent responseManagementEvent =
+          objectMapper.readValue(jsonString, ResponseManagementEvent.class);
+
+      assertThat(responseManagementEvent.getPayload().getCollectionCase().getId())
+          .isEqualTo(caseId);
+
+      actualActualResponseCountList.add(
+          responseManagementEvent.getPayload().getCollectionCase().getCeActualResponses());
+    }
+
+    return actualActualResponseCountList;
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/testutil/RabbitQueueHelper.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/testutil/RabbitQueueHelper.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.springframework.amqp.core.AmqpAdmin;
+import org.springframework.amqp.core.MessageListener;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
@@ -41,14 +42,14 @@ public class RabbitQueueHelper {
 
   @Autowired private AmqpAdmin amqpAdmin;
 
-  public BlockingQueue<String> listen(String queueName) {
+  public QueueSpy listen(String queueName) {
     return listen(queueName, 50);
   }
 
-  public BlockingQueue<String> listen(String queueName, int capacity) {
+  public QueueSpy listen(String queueName, int capacity) {
     BlockingQueue<String> transfer = new ArrayBlockingQueue(capacity);
 
-    org.springframework.amqp.core.MessageListener messageListener =
+    MessageListener messageListener =
         message -> {
           String msgStr = new String(message.getBody());
           transfer.add(msgStr);
@@ -59,7 +60,7 @@ public class RabbitQueueHelper {
     container.setQueueNames(queueName);
     container.start();
 
-    return transfer;
+    return new QueueSpy(transfer, container);
   }
 
   public void sendMessage(String queueName, Object message) {
@@ -74,9 +75,9 @@ public class RabbitQueueHelper {
     amqpAdmin.purgeQueue(queueName);
   }
 
-  public ResponseManagementEvent checkExpectedMessageReceived(BlockingQueue<String> queue)
+  public ResponseManagementEvent checkExpectedMessageReceived(QueueSpy queueSpy)
       throws IOException, InterruptedException {
-    String actualMessage = queue.poll(20, TimeUnit.SECONDS);
+    String actualMessage = queueSpy.getQueue().poll(20, TimeUnit.SECONDS);
     assertNotNull("Did not receive message before timeout", actualMessage);
     ResponseManagementEvent responseManagementEvent =
         objectMapper.readValue(actualMessage, ResponseManagementEvent.class);
@@ -85,9 +86,9 @@ public class RabbitQueueHelper {
     return responseManagementEvent;
   }
 
-  public void checkMessageIsNotReceived(BlockingQueue<String> queue, int timeOut)
+  public void checkMessageIsNotReceived(QueueSpy queueSpy, int timeOut)
       throws InterruptedException {
-    String actualMessage = queue.poll(timeOut, TimeUnit.SECONDS);
+    String actualMessage = queueSpy.getQueue().poll(timeOut, TimeUnit.SECONDS);
     assertNull("Message received when not expected", actualMessage);
   }
 

--- a/src/test/java/uk/gov/ons/census/casesvc/testutil/RabbitQueueHelper.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/testutil/RabbitQueueHelper.java
@@ -1,17 +1,9 @@
 package uk.gov.ons.census.casesvc.testutil;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.TimeUnit;
 import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.core.MessageListener;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
@@ -23,19 +15,11 @@ import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.test.context.ActiveProfiles;
-import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 
 @Component
 @ActiveProfiles("test")
 @EnableRetry
 public class RabbitQueueHelper {
-  private static final ObjectMapper objectMapper = new ObjectMapper();
-
-  static {
-    objectMapper.registerModule(new JavaTimeModule());
-    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-  }
-
   @Autowired private ConnectionFactory connectionFactory;
 
   @Autowired private RabbitTemplate rabbitTemplate;
@@ -73,43 +57,5 @@ public class RabbitQueueHelper {
       backoff = @Backoff(delay = 5000))
   public void purgeQueue(String queueName) {
     amqpAdmin.purgeQueue(queueName);
-  }
-
-  public ResponseManagementEvent checkExpectedMessageReceived(QueueSpy queueSpy)
-      throws IOException, InterruptedException {
-    String actualMessage = queueSpy.getQueue().poll(20, TimeUnit.SECONDS);
-    assertNotNull("Did not receive message before timeout", actualMessage);
-    ResponseManagementEvent responseManagementEvent =
-        objectMapper.readValue(actualMessage, ResponseManagementEvent.class);
-    assertNotNull(responseManagementEvent);
-    assertEquals("RM", responseManagementEvent.getEvent().getChannel());
-    return responseManagementEvent;
-  }
-
-  public void checkMessageIsNotReceived(QueueSpy queueSpy, int timeOut)
-      throws InterruptedException {
-    String actualMessage = queueSpy.getQueue().poll(timeOut, TimeUnit.SECONDS);
-    assertNull("Message received when not expected", actualMessage);
-  }
-
-  public List<Integer> collectAllActualResponseCountsForCaseId(
-      BlockingQueue<String> rhCaseOutboundQueue, String caseId) throws IOException {
-    List<String> jsonList = new ArrayList<>();
-    rhCaseOutboundQueue.drainTo(jsonList);
-
-    List<Integer> actualActualResponseCountList = new ArrayList<>();
-
-    for (String jsonString : jsonList) {
-      ResponseManagementEvent responseManagementEvent =
-          objectMapper.readValue(jsonString, ResponseManagementEvent.class);
-
-      assertThat(responseManagementEvent.getPayload().getCollectionCase().getId())
-          .isEqualTo(caseId);
-
-      actualActualResponseCountList.add(
-          responseManagementEvent.getPayload().getCollectionCase().getCeActualResponses());
-    }
-
-    return actualActualResponseCountList;
   }
 }


### PR DESCRIPTION
# Motivation and Context
The case processor integration tests were slowing down the build more and more, with it taking in excess of 7 minutes. Also, lots of tests had to 'dirty' the Spring context in order to work reliably, which was an ugly hack.

# What has changed
Handle the cleanup of temporary queue listeners neatly and elegantly, such that tests which listen to the same queue don't end up consuming other tests' messages.

# How to test?
Should be like-for-like... only QUICKER!

# Links
Trello: https://trello.com/c/zrCqMG4A