### PR TITLE
Fix flakey test which assumed order of items in list

### DIFF
--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/CCSPropertyListedIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/CCSPropertyListedIT.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 import org.jeasy.random.EasyRandom;
@@ -139,12 +140,15 @@ public class CCSPropertyListedIT {
 
       List<UacQidLink> actualUacQidLinks = uacQidLinkRepository.findAll();
       assertThat(actualUacQidLinks.size()).isEqualTo(3); // Including generated UAC/QID in receiver
+
+      actualUacQidLinks.sort(
+          Comparator.comparing(UacQidLink::getQid).thenComparing(UacQidLink::getId));
       testCheckUacQidLinks(
-          actualUacQidLinks.get(0), CCS_INTERVIEWER_HOUSEHOLD_QUESTIONNAIRE_FOR_ENGLAND_AND_WALES);
+          actualUacQidLinks.get(0), CCS_POSTBACK_CONTINUATION_QUESTIONNAIRE_FOR_ENGLAND_AND_WALES);
       testCheckUacQidLinks(
           actualUacQidLinks.get(1), CCS_INTERVIEWER_HOUSEHOLD_QUESTIONNAIRE_FOR_ENGLAND_AND_WALES);
       testCheckUacQidLinks(
-          actualUacQidLinks.get(2), CCS_POSTBACK_CONTINUATION_QUESTIONNAIRE_FOR_ENGLAND_AND_WALES);
+          actualUacQidLinks.get(2), CCS_INTERVIEWER_HOUSEHOLD_QUESTIONNAIRE_FOR_ENGLAND_AND_WALES);
 
       validateEvents(
           eventRepository.findAll(), responseManagementEvent.getPayload().getCcsProperty());


### PR DESCRIPTION
# Motivation and Context
RM makes no guarantee about the order which it'll process events. As such, we cannot assume the order of things in our tests.

# What has changed
Fixed test which assumed the order of events.

# How to test?
Run a billion times in Travis. If it works, it might still be wrong. Maybe it will fail months later.

# Links
Nope