### PR TITLE
link questionnaire to CE/SPG parent case even if ind case Id is present

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedService.java
@@ -51,8 +51,6 @@ public class QuestionnaireLinkedService {
 
     Case caze = caseService.getCaseByCaseId(UUID.fromString(uac.getCaseId()));
 
-    checkArgumentsValid(caze, questionnaireId, uac.getIndividualCaseId());
-
     if (checkRequiredFieldsForIndividualHI(questionnaireId, caze.getCaseType())) {
       if (uac.getIndividualCaseId() == null) {
         caze = caseService.prepareIndividualResponseCaseFromParentCase(caze, UUID.randomUUID());
@@ -110,16 +108,5 @@ public class QuestionnaireLinkedService {
 
   private boolean checkRequiredFieldsForIndividualHI(String questionnaireId, String caseType) {
     return (isIndividualQuestionnaireType(questionnaireId) && caseType.equals("HH"));
-  }
-
-  private void checkArgumentsValid(Case caze, String questionnaireId, String individualCaseId) {
-    if (isIndividualQuestionnaireType(questionnaireId)
-        && !caze.getCaseType().equals("HH")
-        && individualCaseId != null) {
-      throw new IllegalArgumentException(
-          String.format(
-              "CaseType on '%s' not HH where QID is individual on PQ link request where individualCaseId provided",
-              caze.getCaseId()));
-    }
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedServiceTest.java
@@ -525,8 +525,8 @@ public class QuestionnaireLinkedServiceTest {
             eq(testCase), eq(testUacQidLink), eq(EventTypeDTO.QUESTIONNAIRE_LINKED));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testErrorOnIndQIDAndIndCaseIdProvidedButCaseTypeNotHH() {
+  @Test
+  public void testIndCaseIdIsIgnoredWhenLinkingToCeParentCase() {
     ResponseManagementEvent managementEvent = getTestResponseManagementQuestionnaireLinkedEvent();
 
     UacDTO uac = managementEvent.getPayload().getUac();
@@ -550,17 +550,36 @@ public class QuestionnaireLinkedServiceTest {
     when(caseService.getCaseByCaseId(TEST_CASE_ID_1)).thenReturn(testCase);
     when(uacService.findByQid(TEST_HI_QID)).thenReturn(testUacQidLink);
 
-    String expectedErrorMessage =
-        String.format(
-            "CaseType on '%s' not HH where QID is individual on PQ link request where individualCaseId provided",
-            TEST_CASE_ID_1);
+    // WHEN
+    underTest.processQuestionnaireLinked(managementEvent, messageTimestamp);
 
-    try {
-      underTest.processQuestionnaireLinked(managementEvent, messageTimestamp);
-    } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage()).isEqualTo(expectedErrorMessage);
-      throw e;
-    }
+    // THEN
+    InOrder inOrder = inOrder(uacService, caseService, eventLogger);
+
+    inOrder.verify(uacService).findByQid(anyString());
+
+    inOrder.verify(caseService).getCaseByCaseId(any(UUID.class));
+    verifyNoMoreInteractions(caseService);
+
+    ArgumentCaptor<UacQidLink> uacQidLinkCaptor = ArgumentCaptor.forClass(UacQidLink.class);
+    inOrder.verify(uacService).saveAndEmitUacUpdatedEvent(uacQidLinkCaptor.capture());
+    UacQidLink actualUacQidLink = uacQidLinkCaptor.getValue();
+    assertThat(actualUacQidLink.getQid()).isEqualTo(testUacQidLink.getQid());
+    assertThat(actualUacQidLink.getUac()).isEqualTo(testUacQidLink.getUac());
+    assertThat(actualUacQidLink.isCcsCase()).isFalse();
+    assertThat(actualUacQidLink.getCaze().getSurvey()).isEqualTo("CENSUS");
+    verifyNoMoreInteractions(uacService);
+
+    verify(eventLogger)
+        .logUacQidEvent(
+            eq(testUacQidLink),
+            any(OffsetDateTime.class),
+            eq("Questionnaire Linked"),
+            eq(EventType.QUESTIONNAIRE_LINKED),
+            eq(managementEvent.getEvent()),
+            anyString(),
+            eq(messageTimestamp));
+    verifyNoMoreInteractions(eventLogger);
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently if a questionnaire linked event comes in with an individual case id present and the parent case is CE/SPG, it'll chuck an error. We now want to link the questionnaire to the parent case and ignore the individual case id.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Error chucking stuff removed. Tests updated.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build the branch. Test the branch with the [acceptance tests on the branch of the same name.](https://github.com/ONSdigital/census-rm-acceptance-tests/pull/273)
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/V7O2qqSV/1017-pq-link-ignore-individual-case-id-if-parent-case-is-not-hh-5
# Screenshots (if appropriate):