### PR TITLE
Always increment CE actual response count where applicable 

### DIFF
--- a/src/test/java/uk/gov/ons/census/casesvc/service/BlankQuestionnaireServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/BlankQuestionnaireServiceTest.java
@@ -6,7 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.ons.census.casesvc.model.dto.EventTypeDTO.RESPONSE_RECEIVED;
 
@@ -161,8 +161,8 @@ public class BlankQuestionnaireServiceTest {
     underTest.handleBlankQuestionnaire(caze, uacQidLink, RESPONSE_RECEIVED);
 
     if (!expectation.unreceiptCase && !expectation.sendToField) {
-      verifyZeroInteractions(caseService);
-      verifyZeroInteractions(caseRepository);
+      verifyNoInteractions(caseService);
+      verifyNoInteractions(caseRepository);
       return;
     }
 
@@ -190,7 +190,7 @@ public class BlankQuestionnaireServiceTest {
     } catch (RuntimeException rte) {
       assertThat(rte).isInstanceOf(RuntimeException.class);
       assertThat(rte.getMessage()).endsWith(" does not map to any known processing rule");
-      verifyZeroInteractions(caseService);
+      verifyNoInteractions(caseService);
       return;
     }
 
@@ -243,8 +243,8 @@ public class BlankQuestionnaireServiceTest {
     underTest.handleBlankQuestionnaire(caze, uacQidLink, RESPONSE_RECEIVED);
 
     if (!expectation.unreceiptCase && !expectation.sendToField) {
-      verifyZeroInteractions(caseService);
-      verifyZeroInteractions(caseRepository);
+      verifyNoInteractions(caseService);
+      verifyNoInteractions(caseRepository);
       return;
     }
 
@@ -301,8 +301,8 @@ public class BlankQuestionnaireServiceTest {
     underTest.handleBlankQuestionnaire(caze, uacQidLink, RESPONSE_RECEIVED);
 
     if (!expectation.unreceiptCase) {
-      verifyZeroInteractions(caseService);
-      verifyZeroInteractions(caseRepository);
+      verifyNoInteractions(caseService);
+      verifyNoInteractions(caseRepository);
       return;
     }
 
@@ -356,8 +356,8 @@ public class BlankQuestionnaireServiceTest {
     underTest.handleBlankQuestionnaire(caze, uacQidLink, RESPONSE_RECEIVED);
 
     if (!expectation.unreceiptCase) {
-      verifyZeroInteractions(caseService);
-      verifyZeroInteractions(caseRepository);
+      verifyNoInteractions(caseService);
+      verifyNoInteractions(caseRepository);
       return;
     }
 

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTableTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTableTest.java
@@ -1,0 +1,237 @@
+package uk.gov.ons.census.casesvc.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static uk.gov.ons.census.casesvc.model.dto.EventTypeDTO.RESPONSE_RECEIVED;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.ArgumentCaptor;
+import uk.gov.ons.census.casesvc.model.dto.ActionInstructionType;
+import uk.gov.ons.census.casesvc.model.dto.EventDTO;
+import uk.gov.ons.census.casesvc.model.dto.Metadata;
+import uk.gov.ons.census.casesvc.model.entity.Case;
+import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
+import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
+
+@RunWith(Parameterized.class)
+public class CaseReceiptServiceTableTest {
+  private static final String HOUSEHOLD_INDIVIDUAL = "21";
+  private static final String HOUSEHOLD_HH_ENGLAND = "01";
+  private static final String ENGLAND_HOUSEHOLD_CONTINUATION = "11";
+  private static final String ENGLAND_CE_QID = "31";
+  private static final String EQ_EVENT_CHANNEL = "EQ";
+  private Key key;
+  private Expectation expectation;
+
+  public CaseReceiptServiceTableTest(Key key, Expectation expectation) {
+    this.key = key;
+    this.expectation = expectation;
+  }
+
+  @Parameterized.Parameters(name = "Test Key: {0}")
+  public static Collection<Object[]> data() {
+    Object[][] ruleToTest = {
+      {new Key("HH", "U", "HH"), new Expectation("N", "Y", ActionInstructionType.CANCEL)},
+      {new Key("HH", "U", "Ind"), new Expectation()},
+      {new Key("HH", "U", "CE1"), new Expectation()},
+      {new Key("HH", "U", "Cont"), new Expectation("N", "N", null)},
+      {new Key("HI", "U", "HH"), new Expectation()},
+      {new Key("HI", "U", "Ind"), new Expectation("N", "Y", null)},
+      {new Key("HI", "U", "CE1"), new Expectation()},
+      {new Key("HI", "U", "Cont"), new Expectation()},
+      {new Key("CE", "E", "HH"), new Expectation()},
+      {new Key("CE", "E", "Ind"), new Expectation("Y", "N", ActionInstructionType.UPDATE)},
+      {new Key("CE", "E", "CE1"), new Expectation("N", "Y", ActionInstructionType.UPDATE)},
+      {new Key("CE", "E", "Cont"), new Expectation()},
+      {new Key("CE", "E", "HH"), new Expectation()},
+      {new Key("CE", "U", "Ind"), new Expectation("Y", "Y AR >= ER", ActionInstructionType.CANCEL)},
+      {new Key("CE", "U", "Ind"), new Expectation("Y", "N AR < ER", ActionInstructionType.UPDATE)},
+      {new Key("CE", "U", "CE1"), new Expectation()},
+      {new Key("CE", "U", "Cont"), new Expectation()},
+      {new Key("SPG", "E", "HH"), new Expectation("N", "N", null)},
+      {new Key("SPG", "E", "Ind"), new Expectation("N", "N", null)},
+      {new Key("SPG", "E", "CE1"), new Expectation()},
+      {new Key("SPG", "E", "Cont"), new Expectation()},
+      {new Key("SPG", "U", "HH"), new Expectation("N", "Y", ActionInstructionType.CANCEL)},
+      {new Key("SPG", "U", "Ind"), new Expectation("N", "N", null)},
+      {new Key("SPG", "U", "CE1"), new Expectation()},
+      {new Key("SPG", "U", "Cont"), new Expectation("N", "N", null)}
+    };
+
+    return Arrays.asList(ruleToTest);
+  }
+
+  @Test
+  public void receiptingTableTests() {
+    runReceiptingTest(
+        this.key.caseType,
+        this.key.addressLevel,
+        getQid(this.key.formType),
+        this.key.formType.equals("CE1") ? "CE_treatmentCode" : "NotACE_TreatmentCode",
+        this.expectation.expectIncrement,
+        this.expectation.expectedReceipt,
+        this.expectation.expectedFieldInstruction,
+        this.expectation.expectedCapacity);
+  }
+
+  private void runReceiptingTest(
+      String caseType,
+      String addressLevel,
+      String qid,
+      String treatmentCode,
+      boolean expectIncrement,
+      boolean expectReceipt,
+      ActionInstructionType expectedFieldInstruction,
+      int capacity) {
+
+    CaseService caseService = mock(CaseService.class);
+    CaseRepository caseRepository = mock(CaseRepository.class);
+    CaseReceiptService underTest = new CaseReceiptService(caseService, caseRepository);
+
+    Case caze = new Case();
+    caze.setCaseType(caseType);
+    caze.setAddressLevel(addressLevel);
+    caze.setCaseId(UUID.randomUUID());
+    caze.setReceiptReceived(false);
+    caze.setCeActualResponses(0);
+    caze.setTreatmentCode(treatmentCode);
+    caze.setCeExpectedCapacity(capacity);
+
+    UacQidLink uacQidLink = new UacQidLink();
+    uacQidLink.setQid(qid);
+    uacQidLink.setCaze(caze);
+
+    when(caseService.getCaseAndLockIt(any())).thenReturn(caze);
+
+    try {
+      underTest.receiptCase(uacQidLink, getReceiptEventDTO());
+    } catch (RuntimeException ex) {
+      if (expectation.isRunTimeExceptionExpected()) {
+        verifyNoInteractions(caseService);
+        verifyNoInteractions(caseRepository);
+        return;
+      }
+
+      fail("Unexepcted exception" + ex.getMessage() + " for " + key.toString());
+    }
+
+    if (!expectReceipt && !expectIncrement) {
+      verifyNoInteractions(caseService);
+      verifyNoInteractions(caseRepository);
+      return;
+    }
+
+    ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
+    ArgumentCaptor<Metadata> metadataArgumentCaptor = ArgumentCaptor.forClass(Metadata.class);
+    verify(caseService)
+        .saveCaseAndEmitCaseUpdatedEvent(
+            caseArgumentCaptor.capture(), metadataArgumentCaptor.capture());
+    Case actualCase = caseArgumentCaptor.getValue();
+    assertThat(actualCase.getCaseId()).as("Case Id saved").isEqualTo(caze.getCaseId());
+    assertThat(actualCase.isReceiptReceived()).as("Case Receipted").isEqualTo(expectReceipt);
+
+    if (expectIncrement) {
+      verify(caseService).getCaseAndLockIt(eq(caze.getCaseId()));
+      assertThat(actualCase.getCeActualResponses()).isEqualTo(1);
+    }
+
+    Metadata metadata = metadataArgumentCaptor.getValue();
+    assertThat(metadata.getCauseEventType()).isEqualTo(RESPONSE_RECEIVED);
+    assertThat(metadata.getFieldDecision()).isEqualTo(expectedFieldInstruction);
+  }
+
+  private String getQid(String qidType) {
+    switch (qidType) {
+      case "HH":
+        return HOUSEHOLD_HH_ENGLAND;
+      case "Ind":
+        return HOUSEHOLD_INDIVIDUAL;
+      case "Cont":
+        return ENGLAND_HOUSEHOLD_CONTINUATION;
+      case "CE1":
+        return ENGLAND_CE_QID;
+      default:
+        fail("Unknown Qid Type: " + qidType);
+    }
+
+    return null;
+  }
+
+  private EventDTO getReceiptEventDTO() {
+    EventDTO receiptEventDTO = new EventDTO();
+    receiptEventDTO.setDateTime(OffsetDateTime.now());
+    receiptEventDTO.setTransactionId(UUID.randomUUID());
+    receiptEventDTO.setType(RESPONSE_RECEIVED);
+    receiptEventDTO.setChannel(EQ_EVENT_CHANNEL);
+    return receiptEventDTO;
+  }
+
+  @AllArgsConstructor
+  @EqualsAndHashCode
+  private static class Key {
+    private String caseType;
+    private String addressLevel;
+    private String formType;
+
+    public String toString() {
+      return caseType + "_" + addressLevel + "_" + formType;
+    }
+  }
+
+  private static class Expectation {
+    boolean expectIncrement;
+    boolean expectedReceipt;
+    ActionInstructionType expectedFieldInstruction;
+    boolean expectMappingException;
+    int expectedCapacity = 0;
+
+    public Expectation(
+        String incrementStr, String receiptStr, ActionInstructionType expectedFieldInstruction) {
+      this.expectIncrement = incrementStr.equals("Y");
+      this.expectedFieldInstruction = expectedFieldInstruction;
+      this.expectMappingException = false;
+      expectedCapacity = 0;
+
+      switch (receiptStr) {
+        case "Y":
+          expectedReceipt = true;
+          break;
+
+        case "N":
+          expectedReceipt = false;
+          break;
+
+        case "Y AR >= ER":
+          expectedReceipt = true;
+          expectedCapacity = 1;
+          break;
+
+        case "N AR < ER":
+          expectedReceipt = false;
+          expectedCapacity = 2;
+          break;
+
+        default:
+          fail("Unrecognised Expected Receipt param: " + receiptStr);
+      }
+    }
+
+    public Expectation() {
+      this.expectMappingException = true;
+    }
+
+    public boolean isRunTimeExceptionExpected() {
+      return expectMappingException;
+    }
+  }
+}

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTableTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTableTest.java
@@ -122,7 +122,7 @@ public class CaseReceiptServiceTableTest {
         return;
       }
 
-      fail("Unexepcted exception" + ex.getMessage() + " for " + key.toString());
+      fail("Unexpected exception" + ex.getMessage() + " for " + key.toString());
     }
 
     if (!expectReceipt && !expectIncrement) {

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTest.java
@@ -1,7 +1,6 @@
 package uk.gov.ons.census.casesvc.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 import static uk.gov.ons.census.casesvc.model.dto.EventTypeDTO.RESPONSE_RECEIVED;
 

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTest.java
@@ -117,8 +117,8 @@ public class CaseReceiptServiceTest {
       underTest.receiptCase(uacQidLink, getReceiptEventDTO());
     } catch (RuntimeException ex) {
       if (expectation.isRunTimeExceptionExpected()) {
-        verifyZeroInteractions(caseService);
-        verifyZeroInteractions(caseRepository);
+        verifyNoInteractions(caseService);
+        verifyNoInteractions(caseRepository);
         return;
       }
 
@@ -126,8 +126,8 @@ public class CaseReceiptServiceTest {
     }
 
     if (!expectReceipt && !expectIncrement) {
-      verifyZeroInteractions(caseService);
-      verifyZeroInteractions(caseRepository);
+      verifyNoInteractions(caseService);
+      verifyNoInteractions(caseRepository);
       return;
     }
 

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTest.java
@@ -7,15 +7,12 @@ import static org.mockito.Mockito.*;
 import static uk.gov.ons.census.casesvc.model.dto.EventTypeDTO.RESPONSE_RECEIVED;
 
 import java.time.OffsetDateTime;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.UUID;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.mockito.ArgumentCaptor;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ons.census.casesvc.model.dto.ActionInstructionType;
 import uk.gov.ons.census.casesvc.model.dto.EventDTO;
 import uk.gov.ons.census.casesvc.model.dto.Metadata;
@@ -23,132 +20,15 @@ import uk.gov.ons.census.casesvc.model.entity.Case;
 import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 
-@RunWith(Parameterized.class)
+@RunWith(MockitoJUnitRunner.class)
 public class CaseReceiptServiceTest {
-  private static final String HOUSEHOLD_INDIVIDUAL = "21";
-  private static final String HOUSEHOLD_HH_ENGLAND = "01";
+  private static final String HOUSEHOLD_INDIVIDUAL_QID_TYPE = "21";
+  private static final String HOUSEHOLD_HH_ENGLAND_QID_TYPE = "01";
   private static final String ENGLAND_HOUSEHOLD_CONTINUATION = "11";
   private static final String ENGLAND_CE_QID = "31";
   private static final String EQ_EVENT_CHANNEL = "EQ";
-  private Key key;
-  private Expectation expectation;
-
-  public CaseReceiptServiceTest(Key key, Expectation expectation) {
-    this.key = key;
-    this.expectation = expectation;
-  }
-
-  @Parameterized.Parameters(name = "Test Key: {0}")
-  public static Collection<Object[]> data() {
-    Object[][] ruleToTest = {
-      {new Key("HH", "U", "HH"), new Expectation("N", "Y", ActionInstructionType.CANCEL)},
-      {new Key("HH", "U", "Ind"), new Expectation(RuntimeException.class)},
-      {new Key("HH", "U", "CE1"), new Expectation(RuntimeException.class)},
-      {new Key("HH", "U", "Cont"), new Expectation("N", "N", null)},
-      {new Key("HI", "U", "HH"), new Expectation(RuntimeException.class)},
-      {new Key("HI", "U", "Ind"), new Expectation("N", "Y", null)},
-      {new Key("HI", "U", "CE1"), new Expectation(RuntimeException.class)},
-      {new Key("HI", "U", "Cont"), new Expectation(RuntimeException.class)},
-      {new Key("CE", "E", "HH"), new Expectation(RuntimeException.class)},
-      {new Key("CE", "E", "Ind"), new Expectation("Y", "N", ActionInstructionType.UPDATE)},
-      {new Key("CE", "E", "CE1"), new Expectation("N", "Y", ActionInstructionType.UPDATE)},
-      {new Key("CE", "E", "Cont"), new Expectation(RuntimeException.class)},
-      {new Key("CE", "E", "HH"), new Expectation(RuntimeException.class)},
-      {new Key("CE", "U", "Ind"), new Expectation("Y", "Y AR >= ER", ActionInstructionType.CANCEL)},
-      {new Key("CE", "U", "Ind"), new Expectation("Y", "N AR < ER", ActionInstructionType.UPDATE)},
-      {new Key("CE", "U", "CE1"), new Expectation(RuntimeException.class)},
-      {new Key("CE", "U", "Cont"), new Expectation(RuntimeException.class)},
-      {new Key("SPG", "E", "HH"), new Expectation("N", "N", null)},
-      {new Key("SPG", "E", "Ind"), new Expectation("N", "N", null)},
-      {new Key("SPG", "E", "CE1"), new Expectation(RuntimeException.class)},
-      {new Key("SPG", "E", "Cont"), new Expectation(RuntimeException.class)},
-      {new Key("SPG", "U", "HH"), new Expectation("N", "Y", ActionInstructionType.CANCEL)},
-      {new Key("SPG", "U", "Ind"), new Expectation("N", "N", null)},
-      {new Key("SPG", "U", "CE1"), new Expectation(RuntimeException.class)},
-      {new Key("SPG", "U", "Cont"), new Expectation("N", "N", null)}
-    };
-
-    return Arrays.asList(ruleToTest);
-  }
-
-  @Test
-  public void receiptingTableTests() {
-    runReceiptingTest(
-        this.key.caseType,
-        this.key.addressLevel,
-        getQid(this.key.formType),
-        this.key.formType.equals("CE1") ? "CE_treatmentCode" : "NotACE_TreatmentCode",
-        this.expectation.expectIncrement,
-        this.expectation.expectedReceipt,
-        this.expectation.expectedFieldInstruction,
-        this.expectation.expectedCapacity);
-  }
-
-  private void runReceiptingTest(
-      String caseType,
-      String addressLevel,
-      String qid,
-      String treatmentCode,
-      boolean expectIncrement,
-      boolean expectReceipt,
-      ActionInstructionType expectedFieldInstruction,
-      int capacity) {
-
-    CaseService caseService = mock(CaseService.class);
-    CaseRepository caseRepository = mock(CaseRepository.class);
-    CaseReceiptService underTest = new CaseReceiptService(caseService, caseRepository);
-
-    Case caze = new Case();
-    caze.setCaseType(caseType);
-    caze.setAddressLevel(addressLevel);
-    caze.setCaseId(UUID.randomUUID());
-    caze.setReceiptReceived(false);
-    caze.setCeActualResponses(0);
-    caze.setTreatmentCode(treatmentCode);
-    caze.setCeExpectedCapacity(capacity);
-
-    UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setQid(qid);
-    uacQidLink.setCaze(caze);
-
-    when(caseService.getCaseAndLockIt(any())).thenReturn(caze);
-
-    try {
-      underTest.receiptCase(uacQidLink, getReceiptEventDTO());
-    } catch (RuntimeException ex) {
-      if (expectation.isRunTimeExceptionExpected()) {
-        verifyNoInteractions(caseService);
-        verifyNoInteractions(caseRepository);
-        return;
-      }
-
-      fail("Unexepcted exception" + ex.getMessage() + " for " + key.toString());
-    }
-
-    if (!expectReceipt && !expectIncrement) {
-      verifyNoInteractions(caseService);
-      verifyNoInteractions(caseRepository);
-      return;
-    }
-
-    ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
-    ArgumentCaptor<Metadata> metadataArgumentCaptor = ArgumentCaptor.forClass(Metadata.class);
-    verify(caseService)
-        .saveCaseAndEmitCaseUpdatedEvent(
-            caseArgumentCaptor.capture(), metadataArgumentCaptor.capture());
-    Case actualCase = caseArgumentCaptor.getValue();
-    assertThat(actualCase.getCaseId()).as("Case Id saved").isEqualTo(caze.getCaseId());
-    assertThat(actualCase.isReceiptReceived()).as("Case Receipted").isEqualTo(expectReceipt);
-
-    if (expectIncrement) {
-      verify(caseService).getCaseAndLockIt(eq(caze.getCaseId()));
-      assertThat(actualCase.getCeActualResponses()).isEqualTo(1);
-    }
-
-    Metadata metadata = metadataArgumentCaptor.getValue();
-    assertThat(metadata.getCauseEventType()).isEqualTo(RESPONSE_RECEIVED);
-    assertThat(metadata.getFieldDecision()).isEqualTo(expectedFieldInstruction);
-  }
+  private static final String HOUSEHOLD_CASE_TYPE = "HH";
+  private static final String UNIT_ADDRESS_LEVEL = "U";
 
   @Test
   public void testInactiveQidDoesNotReceiptsCaseAlreadyReceipted() {
@@ -160,16 +40,18 @@ public class CaseReceiptServiceTest {
     Case caze = new Case();
     caze.setCaseId(UUID.randomUUID());
     caze.setReceiptReceived(true);
+    caze.setCaseType(HOUSEHOLD_CASE_TYPE);
+    caze.setAddressLevel(UNIT_ADDRESS_LEVEL);
 
     UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setQid(HOUSEHOLD_INDIVIDUAL);
+    uacQidLink.setQid(HOUSEHOLD_HH_ENGLAND_QID_TYPE);
     uacQidLink.setCaze(caze);
 
     // When
     caseReceiptService.receiptCase(uacQidLink, getReceiptEventDTO());
 
     // Then
-    verifyZeroInteractions(caseService);
+    verifyNoInteractions(caseService);
   }
 
   @Test
@@ -183,7 +65,7 @@ public class CaseReceiptServiceTest {
     caze.setCaseId(UUID.randomUUID());
 
     UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setQid(HOUSEHOLD_INDIVIDUAL);
+    uacQidLink.setQid(HOUSEHOLD_INDIVIDUAL_QID_TYPE);
     uacQidLink.setBlankQuestionnaire(true);
     uacQidLink.setCaze(caze);
     EventDTO receiptEvent = getReceiptEventDTO();
@@ -193,7 +75,7 @@ public class CaseReceiptServiceTest {
     caseReceiptService.receiptCase(uacQidLink, receiptEvent);
 
     // Then
-    verifyZeroInteractions(caseService);
+    verifyNoInteractions(caseService);
   }
 
   @Test
@@ -209,7 +91,7 @@ public class CaseReceiptServiceTest {
     caze.setAddressLevel("U");
 
     UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setQid(HOUSEHOLD_HH_ENGLAND);
+    uacQidLink.setQid(HOUSEHOLD_HH_ENGLAND_QID_TYPE);
     uacQidLink.setBlankQuestionnaire(true);
     uacQidLink.setCaze(caze);
 
@@ -239,9 +121,9 @@ public class CaseReceiptServiceTest {
   private String getQid(String qidType) {
     switch (qidType) {
       case "HH":
-        return HOUSEHOLD_HH_ENGLAND;
+        return HOUSEHOLD_HH_ENGLAND_QID_TYPE;
       case "Ind":
-        return HOUSEHOLD_INDIVIDUAL;
+        return HOUSEHOLD_INDIVIDUAL_QID_TYPE;
       case "Cont":
         return ENGLAND_HOUSEHOLD_CONTINUATION;
       case "CE1":
@@ -260,64 +142,5 @@ public class CaseReceiptServiceTest {
     receiptEventDTO.setType(RESPONSE_RECEIVED);
     receiptEventDTO.setChannel(EQ_EVENT_CHANNEL);
     return receiptEventDTO;
-  }
-
-  @AllArgsConstructor
-  @EqualsAndHashCode
-  private static class Key {
-    private String caseType;
-    private String addressLevel;
-    private String formType;
-
-    public String toString() {
-      return caseType + "_" + addressLevel + "_" + formType;
-    }
-  }
-
-  private static class Expectation {
-    boolean expectIncrement;
-    boolean expectedReceipt;
-    ActionInstructionType expectedFieldInstruction;
-    boolean expectMappingException;
-    int expectedCapacity = 0;
-
-    public Expectation(
-        String incrementStr, String receiptStr, ActionInstructionType expectedFieldInstruction) {
-      this.expectIncrement = incrementStr.equals("Y");
-      this.expectedFieldInstruction = expectedFieldInstruction;
-      this.expectMappingException = false;
-      expectedCapacity = 0;
-
-      switch (receiptStr) {
-        case "Y":
-          expectedReceipt = true;
-          break;
-
-        case "N":
-          expectedReceipt = false;
-          break;
-
-        case "Y AR >= ER":
-          expectedReceipt = true;
-          expectedCapacity = 1;
-          break;
-
-        case "N AR < ER":
-          expectedReceipt = false;
-          expectedCapacity = 2;
-          break;
-
-        default:
-          fail("Unrecognised Expected Receipt param: " + receiptStr);
-      }
-    }
-
-    public Expectation(Class<RuntimeException> runtimeExceptionClass) {
-      this.expectMappingException = true;
-    }
-
-    public boolean isRunTimeExceptionExpected() {
-      return expectMappingException;
-    }
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTest.java
@@ -116,23 +116,6 @@ public class CaseReceiptServiceTest {
     assertThat(metadata.getFieldDecision()).isEqualTo(ActionInstructionType.CANCEL);
   }
 
-  private String getQid(String qidType) {
-    switch (qidType) {
-      case "HH":
-        return HOUSEHOLD_HH_ENGLAND_QID_TYPE;
-      case "Ind":
-        return HOUSEHOLD_INDIVIDUAL_QID_TYPE;
-      case "Cont":
-        return ENGLAND_HOUSEHOLD_CONTINUATION;
-      case "CE1":
-        return ENGLAND_CE_QID;
-      default:
-        fail("Unknown Qid Type: " + qidType);
-    }
-
-    return null;
-  }
-
   private EventDTO getReceiptEventDTO() {
     EventDTO receiptEventDTO = new EventDTO();
     receiptEventDTO.setDateTime(OffsetDateTime.now());

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTest.java
@@ -2,13 +2,11 @@ package uk.gov.ons.census.casesvc.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static uk.gov.ons.census.casesvc.model.dto.EventTypeDTO.RESPONSE_RECEIVED;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;

--- a/src/test/java/uk/gov/ons/census/casesvc/service/QidReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/QidReceiptServiceTest.java
@@ -159,8 +159,8 @@ public class QidReceiptServiceTest {
     underTest.processUnreceipt(managementEvent, OffsetDateTime.now(), uacQidLink);
 
     // Then
-    verifyZeroInteractions(caseReceiptService);
-    verifyZeroInteractions(blankQuestionnaireService);
+    verifyNoInteractions(caseReceiptService);
+    verifyNoInteractions(blankQuestionnaireService);
     verify(eventLogger)
         .logUacQidEvent(
             eq(uacQidLink),
@@ -200,8 +200,8 @@ public class QidReceiptServiceTest {
     underTest.processUnreceipt(managementEvent, OffsetDateTime.now(), uacQidLink);
 
     // Then
-    verifyZeroInteractions(uacService);
-    verifyZeroInteractions(caseReceiptService);
-    verifyZeroInteractions(blankQuestionnaireService);
+    verifyNoInteractions(uacService);
+    verifyNoInteractions(caseReceiptService);
+    verifyNoInteractions(blankQuestionnaireService);
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedServiceTest.java
@@ -473,7 +473,7 @@ public class QuestionnaireLinkedServiceTest {
     assertThat(actualUacQidLink.getCaze().getSurvey()).isEqualTo("CENSUS");
     verifyNoMoreInteractions(uacService);
 
-    verifyZeroInteractions(caseReceiptService);
+    verifyNoInteractions(caseReceiptService);
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
The CE actual response count should be incremented regardless of whether the case is receipted or not.

# What has changed
* Always look up and run the receipting rule
* Check receipted status in receipting rules

# How to test?
Build and run linked AT's

# Links
https://trello.com/c/bhDgGx3H/1035-defect-ceactualresponse-count-not-increasing-for-ce-case
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/275