### PR TITLE
Apply dummy uprn on new address if not present on event

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -30,8 +30,8 @@ public class NewAddressReportedService {
   @Value("${censusconfig.actionplanid}")
   private String censusActionPlanId;
 
-  @Value("${uprnconfig.uprnprefix}")
-  private String uprnPrefix;
+  @Value("${uprnconfig.dummyuprnprefix}")
+  private String dummyUprnPrefix;
 
   public NewAddressReportedService(CaseService caseService, EventLogger eventLogger) {
     this.caseService = caseService;
@@ -280,6 +280,6 @@ public class NewAddressReportedService {
   }
 
   private void addDummyUprnToCase(Case newCase) {
-    newCase.setUprn(String.format("%s%s", uprnPrefix, newCase.getCaseRef()));
+    newCase.setUprn(String.format("%s%s", dummyUprnPrefix, newCase.getCaseRef()));
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -47,7 +47,7 @@ public class NewAddressReportedService {
     Case skeletonCase = createSkeletonCase(newCollectionCase);
 
     skeletonCase = caseService.saveNewCaseAndStampCaseRef(skeletonCase);
-    if (skeletonCase.getUprn() == null) {
+    if (StringUtils.isEmpty(skeletonCase.getUprn())) {
       addDummyUprnToCase(skeletonCase);
       caseService.saveCase(skeletonCase);
     }
@@ -73,7 +73,7 @@ public class NewAddressReportedService {
     Case newCaseFromSourceCase = buildCaseFromSourceCaseAndEvent(newCollectionCase, sourceCase);
 
     newCaseFromSourceCase = caseService.saveNewCaseAndStampCaseRef(newCaseFromSourceCase);
-    if (newCaseFromSourceCase.getUprn() == null) {
+    if (StringUtils.isEmpty(newCaseFromSourceCase.getUprn())) {
       addDummyUprnToCase(newCaseFromSourceCase);
     }
 
@@ -280,6 +280,6 @@ public class NewAddressReportedService {
   }
 
   private void addDummyUprnToCase(Case newCase) {
-    newCase.setUprn(String.format("%s%s", dummyUprnPrefix, newCase.getCaseRef()));
+    newCase.setUprn(String.format("%s%d", dummyUprnPrefix, newCase.getCaseRef()));
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -228,17 +228,15 @@ public class NewAddressReportedService {
         getEventValOverSource(
             sourceCase.getLongitude(), newCollectionCase.getAddress().getLongitude()));
 
-    // Set fields empty/null/blank unless they come from the event
-    newCase.setOrganisationName(
-        getEventValOverSource(null, newCollectionCase.getAddress().getOrganisationName()));
-    newCase.setCeExpectedCapacity(
-        getEventValOverSource(null, newCollectionCase.getCeExpectedCapacity()));
+    // Set fields from the event if they exist
+    newCase.setOrganisationName(newCollectionCase.getAddress().getOrganisationName());
+    newCase.setCeExpectedCapacity(newCollectionCase.getCeExpectedCapacity());
+    newCase.setTreatmentCode(newCollectionCase.getTreatmentCode());
+    newCase.setUprn(newCollectionCase.getAddress().getUprn());
+    // If no case type on event - set it to address type from event
     newCase.setCaseType(
         getEventValOverSource(
             newCollectionCase.getAddress().getAddressType(), newCollectionCase.getCaseType()));
-    newCase.setTreatmentCode(getEventValOverSource(null, newCollectionCase.getTreatmentCode()));
-    // If no uprn on event, a uprn will be created after case is stamped and saved with caseRef
-    newCase.setUprn(getEventValOverSource(null, newCollectionCase.getAddress().getUprn()));
 
     // Fields that do not come on the event but come from source case
     newCase.setEstabUprn(sourceCase.getEstabUprn());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -92,4 +92,4 @@ censusconfig:
   actionplanid: c4415287-0e37-447b-9c3d-1a011c9fa3db
 
 uprnconfig:
-  uprn-prefix: 999
+  dummyuprnprefix: 999

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -90,3 +90,6 @@ directdeliverytreatmentcodes: CE_LDIEE
 censusconfig:
   collectionexerciseid: 34d7f3bb-91c9-45d0-bb2d-90afce4fc790
   actionplanid: c4415287-0e37-447b-9c3d-1a011c9fa3db
+
+uprnconfig:
+  uprn-prefix: 999

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
@@ -309,7 +309,7 @@ public class AddressReceiverIT {
       assertThat(actualCase.getOrganisationName()).isNull();
       assertThat(actualCase.getLatitude()).isEqualTo(sourceCase.getLatitude());
       assertThat(actualCase.getLongitude()).isEqualTo(sourceCase.getLongitude());
-      assertThat(actualCase.getUprn()).isNull();
+      assertThat(actualCase.getUprn()).isEqualTo("999" + actualCase.getCaseRef());
       assertThat(actualCase.getTreatmentCode()).isNull();
 
       assertThat(actualCase.getEstabUprn()).isEqualTo(sourceCase.getEstabUprn());

--- a/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
@@ -40,7 +40,7 @@ public class NewAddressReportedServiceTest {
 
   private String EXPECTED_ACTION_PLAN_ID = UUID.randomUUID().toString();
 
-  private String UPRN_PREFIX = "999";
+  private String DUMMY_UPRN_PREFIX = "999";
 
   @Test
   public void testCreatingSkeletonCaseWithAllEventFields() {
@@ -200,7 +200,7 @@ public class NewAddressReportedServiceTest {
 
   @Test
   public void testNewAddressFromSourceCaseWithMinimalEventFields() {
-    ReflectionTestUtils.setField(underTest, "uprnPrefix", UPRN_PREFIX);
+    ReflectionTestUtils.setField(underTest, "dummyUprnPrefix", DUMMY_UPRN_PREFIX);
 
     EasyRandom easyRandom = new EasyRandom();
     Case sourceCase = easyRandom.nextObject(Case.class);
@@ -236,7 +236,7 @@ public class NewAddressReportedServiceTest {
 
     assertThat(newCase.getLongitude()).isEqualTo(sourceCase.getLongitude());
     assertThat(newCase.getLatitude()).isEqualTo(sourceCase.getLatitude());
-    assertThat(newCase.getUprn()).isEqualTo(UPRN_PREFIX + newCase.getCaseRef());
+    assertThat(newCase.getUprn()).isEqualTo(DUMMY_UPRN_PREFIX + newCase.getCaseRef());
   }
 
   @Test
@@ -436,7 +436,7 @@ public class NewAddressReportedServiceTest {
 
   @Test
   public void testNewAddressGetsDummyUprn() {
-    ReflectionTestUtils.setField(underTest, "uprnPrefix", UPRN_PREFIX);
+    ReflectionTestUtils.setField(underTest, "dummyUprnPrefix", DUMMY_UPRN_PREFIX);
     ResponseManagementEvent responseManagementEvent = getMinimalValidNewAddress();
     Case casetoEmit = new Case();
     casetoEmit.setCaseRef(1234L);
@@ -445,7 +445,7 @@ public class NewAddressReportedServiceTest {
     underTest.processNewAddress(responseManagementEvent, OffsetDateTime.now());
     verify(caseService).saveCase(any(Case.class));
 
-    assertThat(casetoEmit.getUprn()).isEqualTo(UPRN_PREFIX + casetoEmit.getCaseRef());
+    assertThat(casetoEmit.getUprn()).isEqualTo(DUMMY_UPRN_PREFIX + casetoEmit.getCaseRef());
   }
 
   private ResponseManagementEvent getMinimalValidNewAddress() {

--- a/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
@@ -40,6 +40,8 @@ public class NewAddressReportedServiceTest {
 
   private String EXPECTED_ACTION_PLAN_ID = UUID.randomUUID().toString();
 
+  private String UPRN_PREFIX = "999";
+
   @Test
   public void testCreatingSkeletonCaseWithAllEventFields() {
     // given
@@ -103,6 +105,9 @@ public class NewAddressReportedServiceTest {
     ReflectionTestUtils.setField(underTest, "censusCollectionExerciseId", collectionExerciseId);
 
     ResponseManagementEvent responseManagementEvent = getMinimalValidNewAddress();
+    Case casetoEmit = new Case();
+    casetoEmit.setUprn("1234");
+    when(caseService.saveNewCaseAndStampCaseRef(any(Case.class))).thenReturn(casetoEmit);
     underTest.processNewAddress(responseManagementEvent, OffsetDateTime.now());
     ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
 
@@ -123,6 +128,9 @@ public class NewAddressReportedServiceTest {
   @Test
   public void testMinimalGoodNewAddressDoesNotFailValidation() {
     ResponseManagementEvent responseManagementEvent = getMinimalValidNewAddress();
+    Case casetoEmit = new Case();
+    casetoEmit.setUprn("1234");
+    when(caseService.saveNewCaseAndStampCaseRef(any(Case.class))).thenReturn(casetoEmit);
     underTest.processNewAddress(responseManagementEvent, OffsetDateTime.now());
   }
 
@@ -192,6 +200,8 @@ public class NewAddressReportedServiceTest {
 
   @Test
   public void testNewAddressFromSourceCaseWithMinimalEventFields() {
+    ReflectionTestUtils.setField(underTest, "uprnPrefix", UPRN_PREFIX);
+
     EasyRandom easyRandom = new EasyRandom();
     Case sourceCase = easyRandom.nextObject(Case.class);
     sourceCase.setCaseId(UUID.randomUUID());
@@ -226,6 +236,7 @@ public class NewAddressReportedServiceTest {
 
     assertThat(newCase.getLongitude()).isEqualTo(sourceCase.getLongitude());
     assertThat(newCase.getLatitude()).isEqualTo(sourceCase.getLatitude());
+    assertThat(newCase.getUprn()).isEqualTo(UPRN_PREFIX + newCase.getCaseRef());
   }
 
   @Test
@@ -421,6 +432,20 @@ public class NewAddressReportedServiceTest {
     underTest.processNewAddressFromSourceId(newAddressEvent, timeNow, sourceCase.getCaseId());
 
     verify(caseService).saveCaseAndEmitCaseCreatedEvent(any(), eq(null));
+  }
+
+  @Test
+  public void testNewAddressGetsDummyUprn() {
+    ReflectionTestUtils.setField(underTest, "uprnPrefix", UPRN_PREFIX);
+    ResponseManagementEvent responseManagementEvent = getMinimalValidNewAddress();
+    Case casetoEmit = new Case();
+    casetoEmit.setCaseRef(1234L);
+
+    when(caseService.saveNewCaseAndStampCaseRef(any(Case.class))).thenReturn(casetoEmit);
+    underTest.processNewAddress(responseManagementEvent, OffsetDateTime.now());
+    verify(caseService).saveCase(any(Case.class));
+
+    assertThat(casetoEmit.getUprn()).isEqualTo(UPRN_PREFIX + casetoEmit.getCaseRef());
   }
 
   private ResponseManagementEvent getMinimalValidNewAddress() {


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If a new address event is ingested (with source case or without), unless a UPRN is on the event then there isn't one set. This PR adds functionality to apply a dummy PR to the new case.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Logic added to apply dummy UPRN if no uprn present. The dummy UPRN consists of a prefix and the case ref, so this UPRN has to be added after the new case is saved/
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build the branch. Run the branch with the [acceptance tests on the branch of the same name](https://github.com/ONSdigital/census-rm-acceptance-tests/pull/286).
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/nVFvsv29/1025-apply-dummy-uprn-5
# Screenshots (if appropriate):