### PR TITLE
Check ceExpectedCapacity not null when comparing actual to expected for CE U

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/CaseReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CaseReceiptService.java
@@ -141,8 +141,7 @@ public class CaseReceiptService {
 
         Case lockedCase = incrementNoReceipt(caze);
 
-        if (!caze.isReceiptReceived()
-            && lockedCase.getCeActualResponses() >= lockedCase.getCeExpectedCapacity()) {
+        if (hasCeUnitResponsesMetExpected(lockedCase)) {
           lockedCase.setReceiptReceived(true);
           fieldInstruction = ActionInstructionType.CANCEL;
         }
@@ -162,5 +161,11 @@ public class CaseReceiptService {
     private String caseType;
     private String addressLevel;
     private String formType;
+  }
+
+  private boolean hasCeUnitResponsesMetExpected(Case caze) {
+    return caze.getCeExpectedCapacity() != null
+        && !caze.isReceiptReceived()
+        && caze.getCeActualResponses() >= caze.getCeExpectedCapacity();
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTableTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTableTest.java
@@ -32,6 +32,8 @@ public class CaseReceiptServiceTableTest {
   private static final String EQ_EVENT_CHANNEL = "EQ";
   private Key key;
   private Expectation expectation;
+  private static final ActionInstructionType UPDATE = ActionInstructionType.UPDATE;
+  private static final ActionInstructionType CANCEL = ActionInstructionType.CANCEL;
 
   public CaseReceiptServiceTableTest(Key key, Expectation expectation) {
     this.key = key;
@@ -41,7 +43,7 @@ public class CaseReceiptServiceTableTest {
   @Parameterized.Parameters(name = "Test Key: {0}")
   public static Collection<Object[]> data() {
     Object[][] ruleToTest = {
-      {new Key("HH", "U", "HH"), new Expectation("N", "Y", ActionInstructionType.CANCEL)},
+      {new Key("HH", "U", "HH"), new Expectation("N", "Y", CANCEL)},
       {new Key("HH", "U", "Ind"), new Expectation()},
       {new Key("HH", "U", "CE1"), new Expectation()},
       {new Key("HH", "U", "Cont"), new Expectation("N", "N", null)},
@@ -50,20 +52,20 @@ public class CaseReceiptServiceTableTest {
       {new Key("HI", "U", "CE1"), new Expectation()},
       {new Key("HI", "U", "Cont"), new Expectation()},
       {new Key("CE", "E", "HH"), new Expectation()},
-      {new Key("CE", "E", "Ind"), new Expectation("Y", "N", ActionInstructionType.UPDATE)},
-      {new Key("CE", "E", "CE1"), new Expectation("N", "Y", ActionInstructionType.UPDATE)},
+      {new Key("CE", "E", "Ind"), new Expectation("Y", "N", UPDATE)},
+      {new Key("CE", "E", "CE1"), new Expectation("N", "Y", UPDATE)},
       {new Key("CE", "E", "Cont"), new Expectation()},
       {new Key("CE", "E", "HH"), new Expectation()},
-      {new Key("CE", "U", "Ind"), new Expectation("Y", "Y AR >= ER", ActionInstructionType.CANCEL)},
-      {new Key("CE", "U", "Ind"), new Expectation("Y", "N AR < ER", ActionInstructionType.UPDATE)},
-      {new Key("CE", "U", "Ind"), new Expectation("Y", "N ER = null", ActionInstructionType.UPDATE)},
+      {new Key("CE", "U", "Ind"), new Expectation("Y", "Y AR >= ER", CANCEL)},
+      {new Key("CE", "U", "Ind"), new Expectation("Y", "N AR < ER", UPDATE)},
+      {new Key("CE", "U", "Ind"), new Expectation("Y", "N ER = null", UPDATE)},
       {new Key("CE", "U", "CE1"), new Expectation()},
       {new Key("CE", "U", "Cont"), new Expectation()},
       {new Key("SPG", "E", "HH"), new Expectation("N", "N", null)},
       {new Key("SPG", "E", "Ind"), new Expectation("N", "N", null)},
       {new Key("SPG", "E", "CE1"), new Expectation()},
       {new Key("SPG", "E", "Cont"), new Expectation()},
-      {new Key("SPG", "U", "HH"), new Expectation("N", "Y", ActionInstructionType.CANCEL)},
+      {new Key("SPG", "U", "HH"), new Expectation("N", "Y", CANCEL)},
       {new Key("SPG", "U", "Ind"), new Expectation("N", "N", null)},
       {new Key("SPG", "U", "CE1"), new Expectation()},
       {new Key("SPG", "U", "Cont"), new Expectation("N", "N", null)}

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTableTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTableTest.java
@@ -56,6 +56,7 @@ public class CaseReceiptServiceTableTest {
       {new Key("CE", "E", "HH"), new Expectation()},
       {new Key("CE", "U", "Ind"), new Expectation("Y", "Y AR >= ER", ActionInstructionType.CANCEL)},
       {new Key("CE", "U", "Ind"), new Expectation("Y", "N AR < ER", ActionInstructionType.UPDATE)},
+      {new Key("CE", "U", "Ind"), new Expectation("Y", "N ER = null", ActionInstructionType.UPDATE)},
       {new Key("CE", "U", "CE1"), new Expectation()},
       {new Key("CE", "U", "Cont"), new Expectation()},
       {new Key("SPG", "E", "HH"), new Expectation("N", "N", null)},
@@ -92,7 +93,7 @@ public class CaseReceiptServiceTableTest {
       boolean expectIncrement,
       boolean expectReceipt,
       ActionInstructionType expectedFieldInstruction,
-      int capacity) {
+      Integer capacity) {
 
     CaseService caseService = mock(CaseService.class);
     CaseRepository caseRepository = mock(CaseRepository.class);
@@ -193,7 +194,7 @@ public class CaseReceiptServiceTableTest {
     boolean expectedReceipt;
     ActionInstructionType expectedFieldInstruction;
     boolean expectMappingException;
-    int expectedCapacity = 0;
+    Integer expectedCapacity = 0;
 
     public Expectation(
         String incrementStr, String receiptStr, ActionInstructionType expectedFieldInstruction) {
@@ -219,6 +220,11 @@ public class CaseReceiptServiceTableTest {
         case "N AR < ER":
           expectedReceipt = false;
           expectedCapacity = 2;
+          break;
+
+        case "N ER = null":
+          expectedReceipt = false;
+          expectedCapacity = null;
           break;
 
         default:


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There's a possibility that ceExpectedCapacity could be null. When a receipt for a CE Unit is received the actual response is incremented and then compared to ceExpectedCapacity. If ceExpectedCapacity is null a null pointer exception was thrown.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Added null check to comparison and moved into separate method.
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
The acceptance test receipted cases increment ceActualResponses is useful for this. Have a break point set after the sample is loaded for the CE U test and set the ceExpectedCapacity to null in the DB. Let it run and it shouldn't null pointer exception.
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/EtgoTcNJ/1077-incrementing-actual-response-count-is-broken-if-expected-response-count-is-null
# Screenshots (if appropriate):