### PR TITLE
Individual response reminders - store HI case channel in metadata

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/CaseMetadata.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/CaseMetadata.java
@@ -6,4 +6,5 @@ import lombok.Data;
 public class CaseMetadata {
 
   private Boolean secureEstablishment;
+  private String channel;
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
@@ -248,7 +248,8 @@ public class CaseService {
     return collectionCase;
   }
 
-  public Case prepareIndividualResponseCaseFromParentCase(Case parentCase, UUID caseId, String channel) {
+  public Case prepareIndividualResponseCaseFromParentCase(
+      Case parentCase, UUID caseId, String channel) {
     Case individualResponseCase = new Case();
 
     individualResponseCase.setCaseId(caseId);

--- a/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
@@ -248,7 +248,7 @@ public class CaseService {
     return collectionCase;
   }
 
-  public Case prepareIndividualResponseCaseFromParentCase(Case parentCase, UUID caseId) {
+  public Case prepareIndividualResponseCaseFromParentCase(Case parentCase, UUID caseId, String channel) {
     Case individualResponseCase = new Case();
 
     individualResponseCase.setCaseId(caseId);
@@ -277,6 +277,10 @@ public class CaseService {
     individualResponseCase.setSkeleton(parentCase.isSkeleton());
     individualResponseCase.setSurvey(
         parentCase.getSurvey()); // Should only ever be "CENSUS" from the parent case
+
+    // We need to be able to filter individual cases by the channel from whence they were created
+    individualResponseCase.setMetadata(new CaseMetadata());
+    individualResponseCase.getMetadata().setChannel(channel);
 
     return individualResponseCase;
   }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
@@ -280,8 +280,9 @@ public class CaseService {
         parentCase.getSurvey()); // Should only ever be "CENSUS" from the parent case
 
     // We need to be able to filter individual cases by the channel from whence they were created
-    individualResponseCase.setMetadata(new CaseMetadata());
-    individualResponseCase.getMetadata().setChannel(channel);
+    CaseMetadata caseMetadata = new CaseMetadata();
+    caseMetadata.setChannel(channel);
+    individualResponseCase.setMetadata(caseMetadata);
 
     return individualResponseCase;
   }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestService.java
@@ -68,7 +68,8 @@ public class FulfilmentRequestService {
 
     // As part of a fulfilment, we might need to create a 'child' case (an individual).
     // We will do this only if the fulfilment is for an Individual and the caze caseType is HH.
-    handleIndividualFulfilmentForHHCase(fulfilmentRequestPayload, fulfilmentRequestEvent.getChannel(), caze);
+    handleIndividualFulfilmentForHHCase(
+        fulfilmentRequestPayload, fulfilmentRequestEvent.getChannel(), caze);
 
     // As part of a fulfilment, we might have created a new UAC-QID pair, which needs to be linked
     // to the case it belongs to

--- a/src/main/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestService.java
@@ -68,7 +68,7 @@ public class FulfilmentRequestService {
 
     // As part of a fulfilment, we might need to create a 'child' case (an individual).
     // We will do this only if the fulfilment is for an Individual and the caze caseType is HH.
-    handleIndividualFulfilmentForHHCase(fulfilmentRequestPayload, caze);
+    handleIndividualFulfilmentForHHCase(fulfilmentRequestPayload, fulfilmentRequestEvent.getChannel(), caze);
 
     // As part of a fulfilment, we might have created a new UAC-QID pair, which needs to be linked
     // to the case it belongs to
@@ -99,12 +99,12 @@ public class FulfilmentRequestService {
   }
 
   private void handleIndividualFulfilmentForHHCase(
-      FulfilmentRequestDTO fulfilmentRequestPayload, Case caze) {
+      FulfilmentRequestDTO fulfilmentRequestPayload, String eventChannel, Case caze) {
     if (caze.getCaseType().equals("HH")
         && individualResponseRequestCodes.contains(fulfilmentRequestPayload.getFulfilmentCode())) {
       Case individualResponseCase =
           caseService.prepareIndividualResponseCaseFromParentCase(
-              caze, UUID.fromString(fulfilmentRequestPayload.getIndividualCaseId()));
+              caze, UUID.fromString(fulfilmentRequestPayload.getIndividualCaseId()), eventChannel);
       individualResponseCase = caseService.saveNewCaseAndStampCaseRef(individualResponseCase);
 
       if (individualResponsePrintRequestCodes.contains(

--- a/src/main/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedService.java
@@ -53,11 +53,15 @@ public class QuestionnaireLinkedService {
 
     if (checkRequiredFieldsForIndividualHI(questionnaireId, caze.getCaseType())) {
       if (uac.getIndividualCaseId() == null) {
-        caze = caseService.prepareIndividualResponseCaseFromParentCase(caze, UUID.randomUUID());
+        caze =
+            caseService.prepareIndividualResponseCaseFromParentCase(
+                caze, UUID.randomUUID(), questionnaireLinkedEvent.getEvent().getChannel());
       } else {
         caze =
             caseService.prepareIndividualResponseCaseFromParentCase(
-                caze, UUID.fromString(uac.getIndividualCaseId()));
+                caze,
+                UUID.fromString(uac.getIndividualCaseId()),
+                questionnaireLinkedEvent.getEvent().getChannel());
       }
       caze = caseService.saveNewCaseAndStampCaseRef(caze);
       caseService.emitCaseCreatedEvent(caze);

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/FulfilmentRequestReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/FulfilmentRequestReceiverIT.java
@@ -199,11 +199,9 @@ public class FulfilmentRequestReceiverIT {
       rabbitQueueHelper.sendMessage(inboundQueue, message);
 
       // THEN
-      ResponseManagementEvent resultEvent =
-          rhCaseQueueSpy.checkExpectedMessageReceived();
+      ResponseManagementEvent resultEvent = rhCaseQueueSpy.checkExpectedMessageReceived();
       assertThat(resultEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_CREATED);
-      assertThat(
-              resultEvent.getPayload().getCollectionCase().getAddress().getEstabUprn())
+      assertThat(resultEvent.getPayload().getCollectionCase().getAddress().getEstabUprn())
           .isEqualTo(parentCase.getEstabUprn());
       assertThat(resultEvent.getPayload().getFulfilmentRequest())
           .isEqualTo(sourceEvent.getPayload().getFulfilmentRequest());
@@ -225,7 +223,8 @@ public class FulfilmentRequestReceiverIT {
       Case actualParentCase = caseRepository.findById(parentCase.getCaseId()).get();
       Case actualChildCase = caseRepository.findById(TEST_INDIVIDUAL_CASE_ID).get();
 
-      checkIndividualFulfilmentChildCase(actualParentCase, actualChildCase, sourceEvent, resultEvent);
+      checkIndividualFulfilmentChildCase(
+          actualParentCase, actualChildCase, sourceEvent, resultEvent);
     }
   }
 
@@ -268,11 +267,9 @@ public class FulfilmentRequestReceiverIT {
       rabbitQueueHelper.sendMessage(inboundQueue, message);
 
       // THEN
-      ResponseManagementEvent resultEvent =
-          rhCaseQueueSpy.checkExpectedMessageReceived();
+      ResponseManagementEvent resultEvent = rhCaseQueueSpy.checkExpectedMessageReceived();
       assertThat(resultEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_CREATED);
-      assertThat(
-              resultEvent.getPayload().getCollectionCase().getAddress().getEstabUprn())
+      assertThat(resultEvent.getPayload().getCollectionCase().getAddress().getEstabUprn())
           .isEqualTo(parentCase.getEstabUprn());
       assertThat(resultEvent.getPayload().getFulfilmentRequest())
           .isEqualTo(sourceEvent.getPayload().getFulfilmentRequest());
@@ -312,7 +309,8 @@ public class FulfilmentRequestReceiverIT {
       Case actualParentCase = caseRepository.findById(parentCase.getCaseId()).get();
       Case actualChildCase = caseRepository.findById(TEST_INDIVIDUAL_CASE_ID).get();
 
-      checkIndividualFulfilmentChildCase(actualParentCase, actualChildCase, sourceEvent, resultEvent);
+      checkIndividualFulfilmentChildCase(
+          actualParentCase, actualChildCase, sourceEvent, resultEvent);
     }
   }
 
@@ -349,11 +347,9 @@ public class FulfilmentRequestReceiverIT {
       rabbitQueueHelper.sendMessage(inboundQueue, message);
 
       // THEN
-      ResponseManagementEvent resultEvent =
-          rhCaseQueueSpy.checkExpectedMessageReceived();
+      ResponseManagementEvent resultEvent = rhCaseQueueSpy.checkExpectedMessageReceived();
       assertThat(resultEvent.getEvent().getType()).isEqualTo(EventTypeDTO.CASE_CREATED);
-      assertThat(
-              resultEvent.getPayload().getCollectionCase().getAddress().getEstabUprn())
+      assertThat(resultEvent.getPayload().getCollectionCase().getAddress().getEstabUprn())
           .isEqualTo(parentCase.getEstabUprn());
       assertThat(resultEvent.getPayload().getFulfilmentRequest()).isNull();
 
@@ -372,12 +368,16 @@ public class FulfilmentRequestReceiverIT {
       Case actualParentCase = caseRepository.findById(parentCase.getCaseId()).get();
       Case actualChildCase = caseRepository.findById(TEST_INDIVIDUAL_CASE_ID).get();
 
-      checkIndividualFulfilmentChildCase(actualParentCase, actualChildCase, sourceEvent, resultEvent);
+      checkIndividualFulfilmentChildCase(
+          actualParentCase, actualChildCase, sourceEvent, resultEvent);
     }
   }
 
   private void checkIndividualFulfilmentChildCase(
-      Case parentCase, Case childCase, ResponseManagementEvent sourceEvent, ResponseManagementEvent resultEvent) {
+      Case parentCase,
+      Case childCase,
+      ResponseManagementEvent sourceEvent,
+      ResponseManagementEvent resultEvent) {
     assertThat(childCase.getCaseId())
         .isEqualTo(UUID.fromString(resultEvent.getPayload().getCollectionCase().getId()));
 
@@ -393,7 +393,6 @@ public class FulfilmentRequestReceiverIT {
     assertThat(childCase.getHtcWillingness()).isNull();
     assertThat(childCase.getTreatmentCode()).isNull();
 
-    assertThat(childCase.getMetadata().getChannel())
-        .isEqualTo(sourceEvent.getEvent().getChannel());
+    assertThat(childCase.getMetadata().getChannel()).isEqualTo(sourceEvent.getEvent().getChannel());
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverIT.java
@@ -337,6 +337,7 @@ public class QuestionnaireLinkedReceiverIT {
       assertThat(actualHICase.getCaseType()).isEqualTo("HI");
       assertThat(actualHICase.getUprn()).isEqualTo(actualHHCase.getUprn());
       assertThat(actualHICase.getEstabUprn()).isEqualTo(actualHHCase.getEstabUprn());
+      assertThat(actualHICase.getMetadata().getChannel()).isEqualTo(managementEvent.getEvent().getChannel());
 
       // Check database that HI Case is linked to UacQidLink
       List<UacQidLink> uacQidLinks = uacQidLinkRepository.findAll();

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/QuestionnaireLinkedReceiverIT.java
@@ -337,7 +337,8 @@ public class QuestionnaireLinkedReceiverIT {
       assertThat(actualHICase.getCaseType()).isEqualTo("HI");
       assertThat(actualHICase.getUprn()).isEqualTo(actualHHCase.getUprn());
       assertThat(actualHICase.getEstabUprn()).isEqualTo(actualHHCase.getEstabUprn());
-      assertThat(actualHICase.getMetadata().getChannel()).isEqualTo(managementEvent.getEvent().getChannel());
+      assertThat(actualHICase.getMetadata().getChannel())
+          .isEqualTo(managementEvent.getEvent().getChannel());
 
       // Check database that HI Case is linked to UacQidLink
       List<UacQidLink> uacQidLinks = uacQidLinkRepository.findAll();

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SurveyLaunchedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SurveyLaunchedReceiverIT.java
@@ -60,6 +60,7 @@ public class SurveyLaunchedReceiverIT {
   @Transactional
   public void setUp() {
     rabbitQueueHelper.purgeQueue(inboundQueue);
+    rabbitQueueHelper.purgeQueue(rhCaseQueue);
     eventRepository.deleteAllInBatch();
     uacQidLinkRepository.deleteAllInBatch();
     caseRepository.deleteAllInBatch();

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
@@ -40,6 +40,7 @@ public class CaseServiceTest {
   private static final String TEST_POSTCODE = "TEST_POSTCODE";
   private static final String TEST_EXCHANGE = "TEST_EXCHANGE";
   private static final String TEST_ADDRESS_TYPE = "testy_address_type";
+  private static final String TEST_CHANNEL = "TEST_CHANNEL";
   private static final UUID TEST_UUID = UUID.randomUUID();
   private static final UUID TEST_ACTION_PLAN_ID = UUID.randomUUID();
   private static final UUID TEST_COLLECTION_EXERCISE_ID = UUID.randomUUID();
@@ -423,7 +424,7 @@ public class CaseServiceTest {
 
     // When
     Case actualChildCase =
-        underTest.prepareIndividualResponseCaseFromParentCase(parentCase, childCaseId);
+        underTest.prepareIndividualResponseCaseFromParentCase(parentCase, childCaseId, TEST_CHANNEL);
 
     // Then
     assertChildCaseIsCorrect(parentCase, childCaseId, actualChildCase);
@@ -440,7 +441,7 @@ public class CaseServiceTest {
 
     // When
     Case actualChildCase =
-        underTest.prepareIndividualResponseCaseFromParentCase(parentCase, childCaseId);
+        underTest.prepareIndividualResponseCaseFromParentCase(parentCase, childCaseId, TEST_CHANNEL);
 
     // Then
     assertChildCaseIsCorrect(parentCase, childCaseId, actualChildCase);
@@ -486,6 +487,7 @@ public class CaseServiceTest {
     assertThat(actualChildCase.getCeExpectedCapacity()).isNull();
     assertThat(actualChildCase.getAddressLevel()).isEqualTo(parentCase.getAddressLevel());
     assertThat(actualChildCase.isSkeleton()).isEqualTo(parentCase.isSkeleton());
+    assertThat(actualChildCase.getMetadata().getChannel()).isEqualTo(TEST_CHANNEL);
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
@@ -424,7 +424,8 @@ public class CaseServiceTest {
 
     // When
     Case actualChildCase =
-        underTest.prepareIndividualResponseCaseFromParentCase(parentCase, childCaseId, TEST_CHANNEL);
+        underTest.prepareIndividualResponseCaseFromParentCase(
+            parentCase, childCaseId, TEST_CHANNEL);
 
     // Then
     assertChildCaseIsCorrect(parentCase, childCaseId, actualChildCase);
@@ -441,7 +442,8 @@ public class CaseServiceTest {
 
     // When
     Case actualChildCase =
-        underTest.prepareIndividualResponseCaseFromParentCase(parentCase, childCaseId, TEST_CHANNEL);
+        underTest.prepareIndividualResponseCaseFromParentCase(
+            parentCase, childCaseId, TEST_CHANNEL);
 
     // Then
     assertChildCaseIsCorrect(parentCase, childCaseId, actualChildCase);

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseServiceTest.java
@@ -14,7 +14,6 @@ import static uk.gov.ons.census.casesvc.testutil.DataUtils.getRandomCase;
 import java.util.*;
 import ma.glasnost.orika.MapperFacade;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
-import org.jeasy.random.EasyRandom;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -418,8 +417,7 @@ public class CaseServiceTest {
   @Test
   public void checkIndividualCaseCreatedCorrectly() {
     // Given
-    EasyRandom easyRandom = new EasyRandom();
-    Case parentCase = easyRandom.nextObject(Case.class);
+    Case parentCase = getRandomCase();
     UUID childCaseId = UUID.randomUUID();
 
     // When
@@ -434,8 +432,7 @@ public class CaseServiceTest {
   @Test
   public void checkIndividualCaseCreatedCorrectlyFromSkeleton() {
     // Given
-    EasyRandom easyRandom = new EasyRandom();
-    Case parentCase = easyRandom.nextObject(Case.class);
+    Case parentCase = getRandomCase();
     UUID childCaseId = UUID.randomUUID();
 
     parentCase.setSkeleton(true);
@@ -447,6 +444,22 @@ public class CaseServiceTest {
 
     // Then
     assertChildCaseIsCorrect(parentCase, childCaseId, actualChildCase);
+  }
+
+  @Test
+  public void testSaveAndEmitCaseCreatedEventIncludesCaseMetadata() {
+    // Given
+    Case caze = getRandomCase();
+    CaseMetadata caseMetadata = new CaseMetadata();
+    caseMetadata.setSecureEstablishment(true);
+    caseMetadata.setChannel(TEST_CHANNEL);
+    caze.setMetadata(caseMetadata);
+
+    // When
+    PayloadDTO actualPayloadDTO = underTest.saveCaseAndEmitCaseCreatedEvent(caze);
+
+    // Then
+    assertThat(actualPayloadDTO.getCollectionCase().getMetadata()).isEqualTo(caseMetadata);
   }
 
   private void assertChildCaseIsCorrect(Case parentCase, UUID childCaseId, Case actualChildCase) {

--- a/src/test/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestServiceTest.java
@@ -234,7 +234,8 @@ public class FulfilmentRequestServiceTest {
         UUID.fromString(managementEvent.getPayload().getFulfilmentRequest().getIndividualCaseId());
 
     Case childCase = new Case();
-    when(caseService.prepareIndividualResponseCaseFromParentCase(parentCase, childCaseId, managementEvent.getEvent().getChannel()))
+    when(caseService.prepareIndividualResponseCaseFromParentCase(
+            parentCase, childCaseId, managementEvent.getEvent().getChannel()))
         .thenReturn(childCase);
     when(caseService.saveNewCaseAndStampCaseRef(childCase)).thenReturn(childCase);
 

--- a/src/test/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestServiceTest.java
@@ -185,7 +185,8 @@ public class FulfilmentRequestServiceTest {
         UUID.fromString(managementEvent.getPayload().getFulfilmentRequest().getIndividualCaseId());
 
     Case childCase = new Case();
-    when(caseService.prepareIndividualResponseCaseFromParentCase(parentCase, childCaseId))
+    when(caseService.prepareIndividualResponseCaseFromParentCase(
+            parentCase, childCaseId, managementEvent.getEvent().getChannel()))
         .thenReturn(childCase);
     when(caseService.saveNewCaseAndStampCaseRef(childCase)).thenReturn(childCase);
 
@@ -233,7 +234,7 @@ public class FulfilmentRequestServiceTest {
         UUID.fromString(managementEvent.getPayload().getFulfilmentRequest().getIndividualCaseId());
 
     Case childCase = new Case();
-    when(caseService.prepareIndividualResponseCaseFromParentCase(parentCase, childCaseId))
+    when(caseService.prepareIndividualResponseCaseFromParentCase(parentCase, childCaseId, managementEvent.getEvent().getChannel()))
         .thenReturn(childCase);
     when(caseService.saveNewCaseAndStampCaseRef(childCase)).thenReturn(childCase);
 

--- a/src/test/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedServiceTest.java
@@ -20,6 +20,7 @@ import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.casesvc.model.dto.UacDTO;
 import uk.gov.ons.census.casesvc.model.entity.Case;
+import uk.gov.ons.census.casesvc.model.entity.CaseMetadata;
 import uk.gov.ons.census.casesvc.model.entity.EventType;
 import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 
@@ -192,7 +193,7 @@ public class QuestionnaireLinkedServiceTest {
 
     when(uacService.findByQid(TEST_HI_QID)).thenReturn(testHIUacQidLink);
     when(caseService.getCaseByCaseId(TEST_CASE_ID_1)).thenReturn(testHHCase);
-    when(caseService.prepareIndividualResponseCaseFromParentCase(any(), any()))
+    when(caseService.prepareIndividualResponseCaseFromParentCase(any(), any(), anyString()))
         .thenReturn(testHICase);
     when(caseService.saveNewCaseAndStampCaseRef(testHICase)).thenReturn(testHICase);
 
@@ -206,7 +207,7 @@ public class QuestionnaireLinkedServiceTest {
     inOrder.verify(caseService).getCaseByCaseId(TEST_CASE_ID_1);
     inOrder
         .verify(caseService)
-        .prepareIndividualResponseCaseFromParentCase(eq(testHHCase), any(UUID.class));
+        .prepareIndividualResponseCaseFromParentCase(eq(testHHCase), any(UUID.class), anyString());
     inOrder.verify(caseService).saveNewCaseAndStampCaseRef(testHICase);
 
     ArgumentCaptor<Case> caseCaptor = ArgumentCaptor.forClass(Case.class);
@@ -325,7 +326,8 @@ public class QuestionnaireLinkedServiceTest {
 
     when(uacService.findByQid(TEST_HI_QID)).thenReturn(testHIUacQidLink);
     when(caseService.getCaseByCaseId(TEST_CASE_ID_1)).thenReturn(testHHCase);
-    when(caseService.prepareIndividualResponseCaseFromParentCase(any(), any()))
+    when(caseService.prepareIndividualResponseCaseFromParentCase(
+            any(), any(), eq(managementEvent.getEvent().getChannel())))
         .thenReturn(testHICase);
     when(caseService.saveNewCaseAndStampCaseRef(any())).thenReturn(testHICase);
 
@@ -338,7 +340,8 @@ public class QuestionnaireLinkedServiceTest {
     inOrder.verify(caseService).getCaseByCaseId(TEST_CASE_ID_1);
     inOrder
         .verify(caseService)
-        .prepareIndividualResponseCaseFromParentCase(eq(testHHCase), any(UUID.class));
+        .prepareIndividualResponseCaseFromParentCase(
+            eq(testHHCase), any(UUID.class), eq(managementEvent.getEvent().getChannel()));
     inOrder.verify(caseService).saveNewCaseAndStampCaseRef(testHICase);
     inOrder.verify(caseService).emitCaseCreatedEvent(testHICase);
 
@@ -612,7 +615,8 @@ public class QuestionnaireLinkedServiceTest {
 
     when(uacService.findByQid(TEST_HI_QID)).thenReturn(testHIUacQidLink);
     when(caseService.getCaseByCaseId(TEST_CASE_ID_1)).thenReturn(testHHCase);
-    when(caseService.prepareIndividualResponseCaseFromParentCase(any(), any()))
+    when(caseService.prepareIndividualResponseCaseFromParentCase(
+            any(), any(), eq(managementEvent.getEvent().getChannel())))
         .thenReturn(testHICase);
     when(caseService.saveNewCaseAndStampCaseRef(testHICase)).thenReturn(testHICase);
 
@@ -626,7 +630,8 @@ public class QuestionnaireLinkedServiceTest {
     inOrder.verify(caseService).getCaseByCaseId(TEST_CASE_ID_1);
     inOrder
         .verify(caseService)
-        .prepareIndividualResponseCaseFromParentCase(eq(testHHCase), any(UUID.class));
+        .prepareIndividualResponseCaseFromParentCase(
+            eq(testHHCase), any(UUID.class), eq(managementEvent.getEvent().getChannel()));
     inOrder.verify(caseService).saveNewCaseAndStampCaseRef(testHICase);
 
     ArgumentCaptor<Case> caseCaptor = ArgumentCaptor.forClass(Case.class);

--- a/src/test/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/QuestionnaireLinkedServiceTest.java
@@ -20,7 +20,6 @@ import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.casesvc.model.dto.UacDTO;
 import uk.gov.ons.census.casesvc.model.entity.Case;
-import uk.gov.ons.census.casesvc.model.entity.CaseMetadata;
 import uk.gov.ons.census.casesvc.model.entity.EventType;
 import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 


### PR DESCRIPTION
# Motivation and Context
For individual response reminders we need to be able to filter cases down to HI cases created by events from only `EQ`.

# What has changed
* Store the event channel in HI case metadata from fulfilment and PQ link events
* Update tests
* Fix tests failure due to not purging queue

# How to test?
Run with linked AT's and PR branches, see AT PR

# Links
https://trello.com/c/Rc8d1RmE/983-reminders-individual-response-8
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/296