### PR TITLE
Change refusal for estab case condition

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/RefusalService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/RefusalService.java
@@ -17,11 +17,8 @@ import uk.gov.ons.census.casesvc.model.entity.EventType;
 public class RefusalService {
 
   private static final String REFUSAL_RECEIVED = "Refusal Received";
-  private static final String ESTAB_INDIVIDUAL_REFUSAL_RECEIVED =
-      "Refusal received for individual on Estab";
   private static final String HARD_REFUSAL_FOR_ALREADY_EXTRAORDINARY_REFUSED_CASE =
       "Hard Refusal Received for case already marked Extraordinary refused";
-  private static final String ESTAB_ADDRESS_LEVEL = "E";
 
   private final CaseService caseService;
   private final EventLogger eventLogger;
@@ -55,12 +52,6 @@ public class RefusalService {
       OffsetDateTime messageTimestamp,
       RefusalDTO refusalDto) {
 
-    if (isEstabLevelAddressAndChannelIsNotField(refusedCase.getAddressLevel(), refusalEvent)) {
-      logRefusalCaseEvent(
-          refusalEvent, refusedCase, messageTimestamp, ESTAB_INDIVIDUAL_REFUSAL_RECEIVED);
-      return true;
-    }
-
     if (refusalDto.getType() == RefusalTypeDTO.HARD_REFUSAL
         && refusedCase.getRefusalReceived() != null
         && refusedCase.getRefusalReceived() == EXTRAORDINARY_REFUSAL) {
@@ -80,11 +71,6 @@ public class RefusalService {
       return buildMetadata(event.getEvent().getType(), ActionInstructionType.CANCEL);
     }
     return buildMetadata(event.getEvent().getType(), null);
-  }
-
-  private boolean isEstabLevelAddressAndChannelIsNotField(
-      String addressLevel, ResponseManagementEvent event) {
-    return addressLevel.equals(ESTAB_ADDRESS_LEVEL) && !isEventChannelField(event);
   }
 
   private void logRefusalCaseEvent(

--- a/src/test/java/uk/gov/ons/census/casesvc/service/RefusalServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/RefusalServiceTest.java
@@ -25,7 +25,6 @@ import uk.gov.ons.census.casesvc.model.entity.RefusalType;
 public class RefusalServiceTest {
 
   private static final String REFUSAL_RECEIVED = "Refusal Received";
-  private static final String ESTAB_ADDRESS_LEVEL = "E";
   private static final UUID TEST_CASE_ID = UUID.randomUUID();
 
   @Mock private CaseService caseService;
@@ -132,15 +131,16 @@ public class RefusalServiceTest {
   }
 
   @Test
-  public void testRefusalNotFromFieldForEstabAddressLevelCaseIsLoggedWithoutRefusingTheCase() {
+  public void testRefusalForCaseFromField() {
     // GIVEN
     ResponseManagementEvent managementEvent =
         getTestResponseManagementRefusalEvent(RefusalTypeDTO.HARD_REFUSAL);
-    managementEvent.getEvent().setChannel("NOT FROM FIELD");
-    managementEvent.getPayload().getRefusal().getCollectionCase().setId(TEST_CASE_ID.toString());
-
+    managementEvent.getEvent().setChannel("FIELD");
+    CollectionCase collectionCase = managementEvent.getPayload().getRefusal().getCollectionCase();
+    collectionCase.setId(TEST_CASE_ID.toString());
+    collectionCase.setRefusalReceived(RefusalTypeDTO.HARD_REFUSAL);
     Case testCase = getRandomCase();
-    testCase.setAddressLevel(ESTAB_ADDRESS_LEVEL);
+    testCase.setRefusalReceived(null);
     OffsetDateTime messageTimestamp = OffsetDateTime.now();
 
     when(caseService.getCaseByCaseId(TEST_CASE_ID)).thenReturn(testCase);
@@ -149,21 +149,34 @@ public class RefusalServiceTest {
     underTest.processRefusal(managementEvent, messageTimestamp);
 
     // THEN
-    // verify the event is logged
-    verify(eventLogger)
+    InOrder inOrder = inOrder(caseService, eventLogger);
+
+    inOrder.verify(caseService).getCaseByCaseId(any(UUID.class));
+
+    ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
+    ArgumentCaptor<Metadata> metadataArgumentCaptor = ArgumentCaptor.forClass(Metadata.class);
+    inOrder
+        .verify(caseService)
+        .saveCaseAndEmitCaseUpdatedEvent(
+            caseArgumentCaptor.capture(), metadataArgumentCaptor.capture());
+    Case actualCase = caseArgumentCaptor.getValue();
+    Metadata metadata = metadataArgumentCaptor.getValue();
+    verifyNoMoreInteractions(caseService);
+
+    assertThat(actualCase.getRefusalReceived()).isEqualTo(RefusalType.HARD_REFUSAL);
+    assertThat(metadata.getCauseEventType()).isEqualTo(EventTypeDTO.REFUSAL_RECEIVED);
+    assertThat(metadata.getFieldDecision()).isNull();
+    inOrder
+        .verify(eventLogger, times(1))
         .logCaseEvent(
             eq(testCase),
             any(OffsetDateTime.class),
-            eq("Refusal received for individual on Estab"),
+            eq(REFUSAL_RECEIVED),
             eq(EventType.REFUSAL_RECEIVED),
             eq(managementEvent.getEvent()),
             anyString(),
             eq(messageTimestamp));
     verifyNoMoreInteractions(eventLogger);
-
-    // verify we do not try to update the case in any way
-    verify(caseService, times(1)).getCaseByCaseId(any(UUID.class));
-    verifyNoMoreInteractions(caseService);
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
All refusals should now be sent to Fieldwork unless the original message channel is from Fieldwork.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Remove logic bits for checking "estab case and channel not from field"
* Updated test to check null metadata is sent in outbound message to fieldwork-adapter (which should then ignore the message and not send to Fieldwork)

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run the acceptance tests

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/u85DtO8j/1045-refusal-table-of-truth-changes-3