### PR TITLE
remove caseRefGenKey from app.yml

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,5 +93,3 @@ censusconfig:
 
 uprnconfig:
   dummyuprnprefix: 999
-
-caserefgeneratorkey: rPr3qsjlU42hsDX5npfuCzlyF4UYfDTO


### PR DESCRIPTION
# Motivation and Context
caesrefgenkey sneaked into application.yml like a sneaky thing 

https://trello.com/c/uVjhAeGK/1143-dont-include-prod-values-which-need-to-be-secret-in-default-config