### PR TITLE
1183 am file new

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/CreateCaseSample.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/CreateCaseSample.java
@@ -33,4 +33,5 @@ public class CreateCaseSample {
   private String actionPlanId;
   private Integer secureEstablishment;
   private String printBatch;
+  private boolean bulkProcessed;
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/EventService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/EventService.java
@@ -20,9 +20,9 @@ import uk.gov.ons.census.casesvc.utility.QuestionnaireTypeHelper;
 public class EventService {
 
   public static final String CREATE_CASE_SAMPLE_RECEIVED = "Create case sample received";
-  public static final String CREATE_BULK_CASE_SAMPLE_RECEIVED = "Create bulk case sample received";
-  public static final String BULK_PROCESSING_EVENT_CHANNEL = "AR";
-  public static final String BULK_PROCESSING_EVENT_SOURCE = "RM";
+  private static final String CREATE_BULK_CASE_SAMPLE_RECEIVED = "Create bulk case sample received";
+  private static final String BULK_PROCESSING_EVENT_CHANNEL = "AR";
+  private static final String BULK_PROCESSING_EVENT_SOURCE = "RM";
 
   private final CaseService caseService;
   private final UacService uacService;

--- a/src/main/java/uk/gov/ons/census/casesvc/service/EventService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/EventService.java
@@ -21,7 +21,7 @@ public class EventService {
 
   public static final String CREATE_CASE_SAMPLE_RECEIVED = "Create case sample received";
   private static final String CREATE_BULK_CASE_SAMPLE_RECEIVED = "Create bulk case sample received";
-  private static final String BULK_PROCESSING_EVENT_CHANNEL = "AR";
+  private static final String BULK_PROCESSING_EVENT_CHANNEL = "AR"; // Address Resolution
   private static final String BULK_PROCESSING_EVENT_SOURCE = "RM";
 
   private final CaseService caseService;

--- a/src/main/java/uk/gov/ons/census/casesvc/service/EventService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/EventService.java
@@ -2,10 +2,12 @@ package uk.gov.ons.census.casesvc.service;
 
 import static uk.gov.ons.census.casesvc.utility.EventHelper.createEventDTO;
 import static uk.gov.ons.census.casesvc.utility.JsonHelper.convertObjectToJson;
+import static uk.gov.ons.census.casesvc.utility.MetadataHelper.buildMetadata;
 
 import java.time.OffsetDateTime;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.census.casesvc.logging.EventLogger;
+import uk.gov.ons.census.casesvc.model.dto.ActionInstructionType;
 import uk.gov.ons.census.casesvc.model.dto.CreateCaseSample;
 import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
@@ -18,6 +20,9 @@ import uk.gov.ons.census.casesvc.utility.QuestionnaireTypeHelper;
 public class EventService {
 
   public static final String CREATE_CASE_SAMPLE_RECEIVED = "Create case sample received";
+  public static final String CREATE_BULK_CASE_SAMPLE_RECEIVED = "Create bulk case sample received";
+  public static final String BULK_PROCESSING_EVENT_CHANNEL = "AR";
+  public static final String BULK_PROCESSING_EVENT_SOURCE = "RM";
 
   private final CaseService caseService;
   private final UacService uacService;
@@ -35,22 +40,39 @@ public class EventService {
     int questionnaireType =
         QuestionnaireTypeHelper.calculateQuestionnaireType(
             caze.getCaseType(), caze.getRegion(), caze.getAddressLevel());
-    UacQidLink uacQidLink = uacService.buildUacQidLink(caze, questionnaireType);
-    uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
-    caseService.saveCaseAndEmitCaseCreatedEvent(caze);
+    if (createCaseSample.isBulkProcessed()) {
+      caseService.saveCaseAndEmitCaseCreatedEvent(
+          caze, buildMetadata(EventTypeDTO.SAMPLE_LOADED, ActionInstructionType.CREATE));
 
-    eventLogger.logCaseEvent(
-        caze,
-        OffsetDateTime.now(),
-        CREATE_CASE_SAMPLE_RECEIVED,
-        EventType.SAMPLE_LOADED,
-        createEventDTO(EventTypeDTO.SAMPLE_LOADED),
-        convertObjectToJson(createCaseSample),
-        messageTimestamp);
-
-    if (QuestionnaireTypeHelper.isQuestionnaireWelsh(caze.getTreatmentCode())) {
-      uacQidLink = uacService.buildUacQidLink(caze, 3);
+      eventLogger.logCaseEvent(
+          caze,
+          OffsetDateTime.now(),
+          CREATE_BULK_CASE_SAMPLE_RECEIVED,
+          EventType.SAMPLE_LOADED,
+          createEventDTO(
+              EventTypeDTO.SAMPLE_LOADED,
+              BULK_PROCESSING_EVENT_CHANNEL,
+              BULK_PROCESSING_EVENT_SOURCE),
+          convertObjectToJson(createCaseSample),
+          messageTimestamp);
+    } else {
+      UacQidLink uacQidLink = uacService.buildUacQidLink(caze, questionnaireType);
       uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
+      caseService.saveCaseAndEmitCaseCreatedEvent(caze);
+
+      eventLogger.logCaseEvent(
+          caze,
+          OffsetDateTime.now(),
+          CREATE_CASE_SAMPLE_RECEIVED,
+          EventType.SAMPLE_LOADED,
+          createEventDTO(EventTypeDTO.SAMPLE_LOADED),
+          convertObjectToJson(createCaseSample),
+          messageTimestamp);
+
+      if (QuestionnaireTypeHelper.isQuestionnaireWelsh(caze.getTreatmentCode())) {
+        uacQidLink = uacService.buildUacQidLink(caze, 3);
+        uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
+      }
     }
   }
 

--- a/src/main/java/uk/gov/ons/census/casesvc/utility/EventHelper.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/utility/EventHelper.java
@@ -12,16 +12,21 @@ public class EventHelper {
   private static final String EVENT_CHANNEL = "RM";
   private static final String FIELD_CHANNEL = "FIELD";
 
-  public static EventDTO createEventDTO(EventTypeDTO eventType) {
+  public static EventDTO createEventDTO(
+      EventTypeDTO eventType, String event_channel, String event_source) {
     EventDTO eventDTO = new EventDTO();
 
-    eventDTO.setChannel(EVENT_CHANNEL);
-    eventDTO.setSource(EVENT_SOURCE);
+    eventDTO.setChannel(event_channel);
+    eventDTO.setSource(event_source);
     eventDTO.setDateTime(OffsetDateTime.now());
     eventDTO.setTransactionId(UUID.randomUUID());
     eventDTO.setType(eventType);
 
     return eventDTO;
+  }
+
+  public static EventDTO createEventDTO(EventTypeDTO eventType) {
+    return createEventDTO(eventType, EVENT_CHANNEL, EVENT_SOURCE);
   }
 
   public static boolean isEventChannelField(ResponseManagementEvent event) {

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
@@ -42,7 +42,7 @@ import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 @SpringBootTest
 @RunWith(SpringJUnit4ClassRunner.class)
 public class SampleReceiverIT {
-  private static final String BULK_PROCESSING_EVENT_CHANNEL = "AR";
+  private static final String BULK_PROCESSING_EVENT_CHANNEL = "AR"; // Address Resolution
   private static final String CREATE_BULK_CASE_SAMPLE_RECEIVED = "Create bulk case sample received";
 
   @Value("${queueconfig.inbound-queue}")

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
@@ -42,6 +42,8 @@ import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 @SpringBootTest
 @RunWith(SpringJUnit4ClassRunner.class)
 public class SampleReceiverIT {
+  private static final String BULK_PROCESSING_EVENT_CHANNEL = "AR";
+  private static final String CREATE_BULK_CASE_SAMPLE_RECEIVED = "Create bulk case sample received";
 
   @Value("${queueconfig.inbound-queue}")
   private String inboundQueue;
@@ -188,6 +190,8 @@ public class SampleReceiverIT {
       List<Event> eventList = eventRepository.findAll();
       assertThat(eventList.size()).isEqualTo(1);
       Event actualEvent = eventList.get(0);
+      assertEquals(actualEvent.getEventChannel(), BULK_PROCESSING_EVENT_CHANNEL);
+      assertEquals(actualEvent.getEventDescription(), CREATE_BULK_CASE_SAMPLE_RECEIVED);
 
       assertEquals(uacQidLinkRepository.count(), 0);
 

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
@@ -24,6 +24,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.ons.census.casesvc.model.dto.ActionInstructionType;
 import uk.gov.ons.census.casesvc.model.dto.CreateCaseSample;
 import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
@@ -54,6 +55,9 @@ public class SampleReceiverIT {
   @Value("${queueconfig.action-scheduler-queue}")
   private String actionSchedulerQueue;
 
+  @Value("${queueconfig.case-updated-queue}")
+  private String caseUpdatedQueueName;
+
   @Autowired private RabbitQueueHelper rabbitQueueHelper;
   @Autowired private CaseRepository caseRepository;
   @Autowired private EventRepository eventRepository;
@@ -66,6 +70,7 @@ public class SampleReceiverIT {
     rabbitQueueHelper.purgeQueue(rhCaseQueue);
     rabbitQueueHelper.purgeQueue(rhUacQueue);
     rabbitQueueHelper.purgeQueue(actionSchedulerQueue);
+    rabbitQueueHelper.purgeQueue(caseUpdatedQueueName);
     eventRepository.deleteAllInBatch();
     uacQidLinkRepository.deleteAllInBatch();
     caseRepository.deleteAllInBatch();
@@ -119,6 +124,72 @@ public class SampleReceiverIT {
       List<Event> eventList = eventRepository.findAll();
       assertThat(eventList.size()).isEqualTo(1);
       Event actualEvent = eventList.get(0);
+
+      CreateCaseSample actualcreateCaseSample =
+          new ObjectMapper().readValue(actualEvent.getEventPayload(), CreateCaseSample.class);
+
+      assertThat(actualcreateCaseSample).isEqualTo(createCaseSample);
+    }
+  }
+
+  @Test
+  public void testBulkProcessedNewAddresses() throws Exception {
+    try (QueueSpy rhCaseQueueSpy = rabbitQueueHelper.listen(rhCaseQueue);
+        QueueSpy rhUacQueueSpy = rabbitQueueHelper.listen(rhUacQueue);
+        QueueSpy actionSchedulerQueueSpy = rabbitQueueHelper.listen(actionSchedulerQueue);
+        QueueSpy fieldOutboundQueue = rabbitQueueHelper.listen(caseUpdatedQueueName)) {
+      // GIVEN
+      CreateCaseSample createCaseSample = new CreateCaseSample();
+      createCaseSample.setAddressType("HH");
+      createCaseSample.setPostcode("ABC123");
+      createCaseSample.setRegion("E12000009");
+      createCaseSample.setTreatmentCode("HH_LF3R2E");
+      createCaseSample.setCeExpectedCapacity(null);
+      createCaseSample.setSecureEstablishment(0);
+      createCaseSample.setBulkProcessed(true);
+      // WHEN
+      rabbitQueueHelper.sendMessage(inboundQueue, createCaseSample);
+
+      // THEN
+      ResponseManagementEvent responseManagementEvent =
+          rhCaseQueueSpy.checkExpectedMessageReceived();
+      assertEquals(EventTypeDTO.CASE_CREATED, responseManagementEvent.getEvent().getType());
+      assertThat(responseManagementEvent.getPayload().getCollectionCase().getCreatedDateTime())
+          .isNotNull();
+      assertThat(responseManagementEvent.getPayload().getCollectionCase().getLastUpdated())
+          .isNotNull();
+
+      ResponseManagementEvent responseManagementEventToField =
+          fieldOutboundQueue.checkExpectedMessageReceived();
+
+      assertThat(responseManagementEventToField.getPayload().getMetadata()).isNotNull();
+      assertEquals(
+          ActionInstructionType.CREATE,
+          responseManagementEventToField.getPayload().getMetadata().getFieldDecision());
+      assertEquals(
+          EventTypeDTO.SAMPLE_LOADED,
+          responseManagementEventToField.getPayload().getMetadata().getCauseEventType());
+
+      rhUacQueueSpy.checkMessageIsNotReceived(5);
+
+      List<EventTypeDTO> eventTypesSeenDTO = new LinkedList<>();
+      responseManagementEvent = actionSchedulerQueueSpy.checkExpectedMessageReceived();
+      eventTypesSeenDTO.add(responseManagementEvent.getEvent().getType());
+
+      assertThat(eventTypesSeenDTO, containsInAnyOrder(EventTypeDTO.CASE_CREATED));
+
+      List<Case> caseList = caseRepository.findAll();
+      assertEquals(1, caseList.size());
+      assertEquals("ABC123", caseList.get(0).getPostcode());
+      assertNull(caseList.get(0).getCeExpectedCapacity());
+      assertThat(caseList.get(0).getCreatedDateTime()).isNotNull();
+      assertThat(caseList.get(0).getLastUpdated()).isNotNull();
+
+      List<Event> eventList = eventRepository.findAll();
+      assertThat(eventList.size()).isEqualTo(1);
+      Event actualEvent = eventList.get(0);
+
+      assertEquals(uacQidLinkRepository.count(), 0);
 
       CreateCaseSample actualcreateCaseSample =
           new ObjectMapper().readValue(actualEvent.getEventPayload(), CreateCaseSample.class);

--- a/src/test/java/uk/gov/ons/census/casesvc/service/EventServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/EventServiceTest.java
@@ -1,7 +1,6 @@
 package uk.gov.ons.census.casesvc.service;
 
 import static org.mockito.Mockito.*;
-import static uk.gov.ons.census.casesvc.service.EventService.CREATE_BULK_CASE_SAMPLE_RECEIVED;
 import static uk.gov.ons.census.casesvc.service.EventService.CREATE_CASE_SAMPLE_RECEIVED;
 import static uk.gov.ons.census.casesvc.utility.JsonHelper.convertObjectToJson;
 import static uk.gov.ons.census.casesvc.utility.MetadataHelper.buildMetadata;
@@ -25,6 +24,7 @@ public class EventServiceTest {
   private static final long TEST_CASE_REF = 1234567890L;
   private static final UUID TEST_ACTION_RULE_ID = UUID.randomUUID();
   private static final UUID TEST_BATCH_ID = UUID.randomUUID();
+  private static final String CREATE_BULK_CASE_SAMPLE_RECEIVED = "Create bulk case sample received";
 
   @Mock CaseService caseService;
 

--- a/src/test/java/uk/gov/ons/census/casesvc/service/EventServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/EventServiceTest.java
@@ -78,9 +78,10 @@ public class EventServiceTest {
     caze.setRegion("E1000");
     caze.setCaseType("HH");
     when(caseService.saveCaseSample(createCaseSample)).thenReturn(caze);
-    when(caseService.saveCaseAndEmitCaseCreatedEvent(any(Case.class))).thenReturn(new PayloadDTO());
+    when(caseService.saveCaseAndEmitCaseCreatedEvent(any(Case.class), any(Metadata.class)))
+        .thenReturn(new PayloadDTO());
     Metadata expectedMetadata =
-            buildMetadata(EventTypeDTO.SAMPLE_LOADED, ActionInstructionType.CREATE);
+        buildMetadata(EventTypeDTO.SAMPLE_LOADED, ActionInstructionType.CREATE);
 
     OffsetDateTime messageTimestamp = OffsetDateTime.now();
 
@@ -92,16 +93,15 @@ public class EventServiceTest {
     verifyNoInteractions(uacService);
     verify(caseService).saveCaseAndEmitCaseCreatedEvent(eq(caze), eq(expectedMetadata));
     verify(eventLogger)
-            .logCaseEvent(
-                    eq(caze),
-                    any(OffsetDateTime.class),
-                    eq(CREATE_BULK_CASE_SAMPLE_RECEIVED),
-                    eq(EventType.SAMPLE_LOADED),
-                    any(EventDTO.class),
-                    eq(convertObjectToJson(createCaseSample)),
-                    eq(messageTimestamp));
+        .logCaseEvent(
+            eq(caze),
+            any(OffsetDateTime.class),
+            eq(CREATE_BULK_CASE_SAMPLE_RECEIVED),
+            eq(EventType.SAMPLE_LOADED),
+            any(EventDTO.class),
+            eq(convertObjectToJson(createCaseSample)),
+            eq(messageTimestamp));
   }
-
 
   @Test
   public void testWelshQuestionnaire() {


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When adding new addresses from AR as new cases in RM, we don't want them to create uac-qids and we want to send a create message to field when this has happened.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- When new addresses come in from the bulk processor, it creates cases without the uac-qids attached to the case.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run with other branches on PR ([toolbox](https://github.com/ONSdigital/census-rm-toolbox/pull/56), terraform and kubernetes). Should be able to put a file in the bucket and once the bulk processor has ran, new cases should be created from the addresses.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/ATLrBzMk)
[Toolbox](https://github.com/ONSdigital/census-rm-toolbox/pull/56)
[Kubernetes](https://github.com/ONSdigital/census-rm-kubernetes/pull/288)
[Terraform](https://github.com/ONSdigital/census-rm-terraform/pull/186)