### PR TITLE
Increase max retry attempts to 2 because 1 didn't retry

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/config/MessageConsumerConfig.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/config/MessageConsumerConfig.java
@@ -340,7 +340,7 @@ public class MessageConsumerConfig {
     // A single retry seems to work, but more than that is problematic.
     RetryOperationsInterceptor retryOperationsInterceptor =
         RetryInterceptorBuilder.stateless()
-            .maxAttempts(1) // DO NOT INCREASE TO MORE THAN 1 - NASTY SPRING BUG
+            .maxAttempts(2) // DO NOT INCREASE TO MORE THAN 2 - NASTY SPRING BUG
             .backOffPolicy(fixedBackOffPolicy)
             .recoverer(managedMessageRecoverer)
             .build();


### PR DESCRIPTION
# Motivation and Context
Having `maxAttempts` set to 1 for the `RetryOperationsInterceptor` didn't seem to retry a failed message even once.

# What has changed
Increased `maxAttempts` from 1 to 2.

# How to test?
It's difficult.

# Links
Trello: https://trello.com/c/RExzTzH3