### PR TITLE
Only log receipts on already receipted UAC-QIDs

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/QidReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/QidReceiptService.java
@@ -47,7 +47,6 @@ public class QidReceiptService {
 
     if (uacQidLink.isActive()) {
       uacQidLink.setActive(false);
-
       uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
 
       Case caze = uacQidLink.getCaze();

--- a/src/main/java/uk/gov/ons/census/casesvc/service/QidReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/QidReceiptService.java
@@ -44,19 +44,22 @@ public class QidReceiptService {
       processUnreceipt(receiptEvent, messageTimestamp, uacQidLink);
       return;
     }
-    uacQidLink.setActive(false);
 
-    uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
+    if (!uacQidLink.isActive()) {
+      uacQidLink.setActive(false);
 
-    Case caze = uacQidLink.getCaze();
+      uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
 
-    if (caze != null) {
-      caseReceiptService.receiptCase(uacQidLink, receiptEvent.getEvent());
-    } else {
-      log.with("qid", receiptPayload.getQuestionnaireId())
-          .with("tx_id", receiptEvent.getEvent().getTransactionId())
-          .with("channel", receiptEvent.getEvent().getChannel())
-          .warn("Receipt received for unaddressed UAC/QID pair not yet linked to a case");
+      Case caze = uacQidLink.getCaze();
+
+      if (caze != null) {
+        caseReceiptService.receiptCase(uacQidLink, receiptEvent.getEvent());
+      } else {
+        log.with("qid", receiptPayload.getQuestionnaireId())
+            .with("tx_id", receiptEvent.getEvent().getTransactionId())
+            .with("channel", receiptEvent.getEvent().getChannel())
+            .warn("Receipt received for unaddressed UAC/QID pair not yet linked to a case");
+      }
     }
 
     eventLogger.logUacQidEvent(

--- a/src/main/java/uk/gov/ons/census/casesvc/service/QidReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/QidReceiptService.java
@@ -45,7 +45,7 @@ public class QidReceiptService {
       return;
     }
 
-    if (!uacQidLink.isActive()) {
+    if (uacQidLink.isActive()) {
       uacQidLink.setActive(false);
 
       uacService.saveAndEmitUacUpdatedEvent(uacQidLink);

--- a/src/main/java/uk/gov/ons/census/casesvc/service/QidReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/QidReceiptService.java
@@ -45,7 +45,10 @@ public class QidReceiptService {
       return;
     }
 
-    if (uacQidLink.isActive()) {
+    // Deactivating a UAC which is already deactivated is madness, but the blank questionnaire
+    // scenarios are horrendously over-complicated, including the impossible scenario where
+    // a respondent attempts to use their UAC via EQ after THEY ALREADY SENT IT BACK TO US BLANK
+    if (uacQidLink.isActive() || uacQidLink.isBlankQuestionnaire()) {
       uacQidLink.setActive(false);
       uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
 

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/ReceiptReceiverIT.java
@@ -112,6 +112,7 @@ public class ReceiptReceiverIT {
       uacQidLink.setId(UUID.randomUUID());
       uacQidLink.setCaze(caze);
       uacQidLink.setCcsCase(false);
+      uacQidLink.setActive(true);
       uacQidLink.setQid(ENGLAND_HOUSEHOLD);
       uacQidLink.setUac(TEST_UAC);
       uacQidLinkRepository.saveAndFlush(uacQidLink);
@@ -313,6 +314,7 @@ public class ReceiptReceiverIT {
                 uacQidLink.setId(UUID.randomUUID());
                 uacQidLink.setCaze(finalCaze);
                 uacQidLink.setCcsCase(false);
+                uacQidLink.setActive(true);
                 uacQidLink.setQid(
                     HOUSEHOLD_INDIVIDUAL_QUESTIONNAIRE_REQUEST_ENGLAND
                         + easyRandom.nextObject(String.class));

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SpringRetryIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SpringRetryIT.java
@@ -104,6 +104,7 @@ public class SpringRetryIT {
       UacQidLink uacQidLink = new UacQidLink();
       uacQidLink.setId(UUID.randomUUID());
       uacQidLink.setCaze(caze);
+      uacQidLink.setActive(true);
       uacQidLink.setQid(TEST_QID);
       uacQidLink.setUac(TEST_UAC);
       uacQidLinkRepository.saveAndFlush(uacQidLink);

--- a/src/test/java/uk/gov/ons/census/casesvc/testutil/DataUtils.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/testutil/DataUtils.java
@@ -76,6 +76,7 @@ public class DataUtils {
     UacQidLink uacQidLink = generateRandomUacQidLink();
     uacQidLink.setCaze(linkedCase);
     uacQidLink.setEvents(null);
+    uacQidLink.setActive(true);
     linkedCase.setUacQidLinks(List.of(uacQidLink));
     return uacQidLink;
   }

--- a/src/test/java/uk/gov/ons/census/casesvc/testutil/RabbitQueueHelper.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/testutil/RabbitQueueHelper.java
@@ -41,6 +41,10 @@ public class RabbitQueueHelper {
     return new QueueSpy(transfer, container);
   }
 
+  @Retryable(
+      value = {java.io.IOException.class},
+      maxAttempts = 10,
+      backoff = @Backoff(delay = 5000))
   public void sendMessage(String queueName, Object message) {
     rabbitTemplate.convertAndSend(queueName, message);
   }


### PR DESCRIPTION
# Motivation and Context
"Actual" response count is a very rough figure, built on top of an already horrendously over-complex receipting pile of pain. As such, 'defects' are nonsensical, given that they might affect 2 or 3 respondents in the whole exercise of tens of millions of people.

# What has changed
Only log receipts which have already been receipted.

# How to test?
Don't even bother - waste of time.

# Links
Trello: https://trello.com/c/KYgOuyLj