### PR TITLE
Allow batch ID to be sent on RM_UAC_CREATED

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/UacCreatedDTO.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/UacCreatedDTO.java
@@ -8,4 +8,5 @@ public class UacCreatedDTO {
   private String uac;
   private String qid;
   private UUID caseId;
+  private UUID batchId;
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/UacService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/UacService.java
@@ -132,7 +132,8 @@ public class UacService {
     Case linkedCase = caseService.getCaseByCaseId(uacCreated.getCaseId());
 
     UacQidLink uacQidLink =
-        buildUacQidLink(linkedCase, null, uacCreated.getUac(), uacCreated.getQid());
+        buildUacQidLink(
+            linkedCase, uacCreated.getBatchId(), uacCreated.getUac(), uacCreated.getQid());
 
     saveAndEmitUacUpdatedEvent(uacQidLink);
 

--- a/src/test/java/uk/gov/ons/census/casesvc/service/UacServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/UacServiceTest.java
@@ -121,6 +121,9 @@ public class UacServiceTest {
     assertEquals(
         uacCreatedEvent.getPayload().getUacQidCreated().getCaseId(),
         uacQidLinkArgumentCaptor.getValue().getCaze().getCaseId());
+    assertEquals(
+        uacCreatedEvent.getPayload().getUacQidCreated().getBatchId(),
+        uacQidLinkArgumentCaptor.getValue().getBatchId());
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/casesvc/testutil/DataUtils.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/testutil/DataUtils.java
@@ -269,6 +269,7 @@ public class DataUtils {
     UacCreatedDTO uacCreatedPayload = easyRandom.nextObject(UacCreatedDTO.class);
     uacCreatedPayload.setCaseId(linkedCase.getCaseId());
     uacCreatedPayload.setQid("01234567890");
+    uacCreatedPayload.setBatchId(UUID.randomUUID());
     EventDTO eventDTO = easyRandom.nextObject(EventDTO.class);
     eventDTO.setType(EventTypeDTO.RM_UAC_CREATED);
     PayloadDTO payloadDTO = new PayloadDTO();


### PR DESCRIPTION
# Motivation and Context
Although we don't store batch IDs anywhere - they're transient - we will be able to see all the UACs created by a particular Action (rule or fulfilment) batch, grouped together.

# What has changed
Allow batch ID to be sent, received and stored against any UACs created by RM.

# How to test?
Trigger a reminder rule. All the UACs that get created should have the same batch ID.

# Links
Trello: https://trello.com/c/ELepDger