### PR TITLE
Tweak logged event JSON to be inconsistent in a different way

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/FieldCaseUpdatedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/FieldCaseUpdatedService.java
@@ -56,7 +56,7 @@ public class FieldCaseUpdatedService {
         FIELD_CASE_UPDATED_DESCRIPTION,
         EventType.FIELD_CASE_UPDATED,
         responseManagementEvent.getEvent(),
-        convertObjectToJson(fieldCaseUpdatedPayload),
+        convertObjectToJson(responseManagementEvent.getPayload()),
         messageTimestamp);
   }
 

--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -84,7 +84,7 @@ public class NewAddressReportedService {
         "New Address reported",
         EventType.NEW_ADDRESS_REPORTED,
         newAddressEvent.getEvent(),
-        JsonHelper.convertObjectToJson(newAddressEvent.getPayload()),
+        JsonHelper.convertObjectToJson(newAddressEvent.getPayload().getNewAddress()),
         messageTimestamp);
   }
 

--- a/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
@@ -106,7 +106,7 @@ public class NewAddressReportedServiceTest {
             eq("New Address reported"),
             eq(EventType.NEW_ADDRESS_REPORTED),
             eq(eventDTO),
-            eq(JsonHelper.convertObjectToJson(newAddressEvent.getPayload())),
+            eq(JsonHelper.convertObjectToJson(newAddressEvent.getPayload().getNewAddress())),
             eq(expectedDateTime));
   }
 


### PR DESCRIPTION
# Motivation and Context
We were logging our event JSON inconsistently. We want to log it in a different way, but still inconsistently... but it's hopefully what's been agreed with Rob S and DAP, so it might be OK.

# What has changed
Did the changes requested by Rob S.

# How to test?
Don't bother - there are ITs. DAP will ingest the data eventually and tell is if it's OK for them.

# Links
Trello: https://trello.com/c/R3awWPFz