### PR TITLE
Add postcode index to entity

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
@@ -22,7 +22,8 @@ import org.hibernate.annotations.*;
     name = "cases",
     indexes = {
       @Index(name = "cases_case_ref_idx", columnList = "case_ref"),
-      @Index(name = "lsoa_idx", columnList = "lsoa")
+      @Index(name = "lsoa_idx", columnList = "lsoa"),
+      @Index(name = "postcode_idx", columnList = "postcode")
     })
 public class Case {
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For postcode search in ops-ui we need to add an index into the cases table on the postcode column.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Updated entity to show postcode index

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run mvn clean install
- Run with other branches

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/qkkjvupd/1221-r-ops-search-for-case-and-show-results-13)

# Screenshots (if appropriate):