### PR TITLE
Store source and channel on UACs

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiver.java
@@ -11,6 +11,7 @@ import org.springframework.messaging.Message;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.census.casesvc.logging.EventLogger;
 import uk.gov.ons.census.casesvc.model.dto.CreateUacQid;
+import uk.gov.ons.census.casesvc.model.dto.EventDTO;
 import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
 import uk.gov.ons.census.casesvc.model.dto.PayloadDTO;
 import uk.gov.ons.census.casesvc.model.entity.EventType;
@@ -33,9 +34,15 @@ public class UnaddressedReceiver {
   public void receiveMessage(Message<CreateUacQid> message) {
     CreateUacQid createUacQid = message.getPayload();
     OffsetDateTime messageTimestamp = getMsgTimeStamp(message);
+    EventDTO dummyEvent = new EventDTO();
+    dummyEvent.setSource("RM");
+    dummyEvent.setChannel("RM");
     UacQidLink uacQidLink =
         uacService.buildUacQidLink(
-            null, Integer.parseInt(createUacQid.getQuestionnaireType()), createUacQid.getBatchId());
+            null,
+            Integer.parseInt(createUacQid.getQuestionnaireType()),
+            createUacQid.getBatchId(),
+            dummyEvent);
     PayloadDTO uacPayloadDTO = uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
     eventLogger.logUacQidEvent(
         uacQidLink,

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/UacQidLink.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/UacQidLink.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.casesvc.model.entity;
 
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -13,6 +14,9 @@ import javax.persistence.Table;
 import lombok.Data;
 import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.TypeDefs;
 import org.hibernate.annotations.UpdateTimestamp;
 
 // The bidirectional relationships with other entities can cause stack overflows with the default
@@ -20,6 +24,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 @ToString(onlyExplicitlyIncluded = true)
 @Data
 @Entity
+@TypeDefs({@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)})
 @Table(
     indexes = {
       @Index(name = "qid_idx", columnList = "qid"),
@@ -55,4 +60,8 @@ public class UacQidLink {
   @Column(columnDefinition = "timestamp with time zone")
   @UpdateTimestamp
   private OffsetDateTime lastUpdated;
+
+  @Type(type = "jsonb")
+  @Column(columnDefinition = "jsonb")
+  private UacQidLinkMetadata metadata;
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/UacQidLinkMetadata.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/UacQidLinkMetadata.java
@@ -1,0 +1,9 @@
+package uk.gov.ons.census.casesvc.model.entity;
+
+import lombok.Data;
+
+@Data
+public class UacQidLinkMetadata {
+  String source;
+  String channel;
+}

--- a/src/main/java/uk/gov/ons/census/casesvc/service/CCSPropertyListedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CCSPropertyListedService.java
@@ -61,7 +61,7 @@ public class CCSPropertyListedService {
 
     // always generate a new uac-qid pair even if linking existing pair, this is in case field
     // worker has to visit address again and launch an EQ
-    uacService.createUacQidLinkedToCCSCase(caze);
+    uacService.createUacQidLinkedToCCSCase(caze, ccsPropertyListedEvent.getEvent());
     if (hasOneOrMoreQids) {
       handleUacQidLinksForCase(ccsProperty.getUac(), caze);
     } else {

--- a/src/main/java/uk/gov/ons/census/casesvc/service/EventService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/EventService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.ons.census.casesvc.logging.EventLogger;
 import uk.gov.ons.census.casesvc.model.dto.ActionInstructionType;
 import uk.gov.ons.census.casesvc.model.dto.CreateCaseSample;
+import uk.gov.ons.census.casesvc.model.dto.EventDTO;
 import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.casesvc.model.entity.Case;
@@ -56,7 +57,10 @@ public class EventService {
           convertObjectToJson(createCaseSample),
           messageTimestamp);
     } else {
-      UacQidLink uacQidLink = uacService.buildUacQidLink(caze, questionnaireType);
+      EventDTO dummyEvent = new EventDTO();
+      dummyEvent.setSource("RM");
+      dummyEvent.setChannel("RM");
+      UacQidLink uacQidLink = uacService.buildUacQidLink(caze, questionnaireType, null, dummyEvent);
       uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
       caseService.saveCaseAndEmitCaseCreatedEvent(caze);
 
@@ -70,7 +74,7 @@ public class EventService {
           messageTimestamp);
 
       if (QuestionnaireTypeHelper.isQuestionnaireWelsh(caze.getTreatmentCode())) {
-        uacQidLink = uacService.buildUacQidLink(caze, 3);
+        uacQidLink = uacService.buildUacQidLink(caze, 3, null, dummyEvent);
         uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
       }
     }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/UacService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/UacService.java
@@ -73,6 +73,7 @@ public class UacService {
     uacQidLink.setBatchId(batchId);
     uacQidLink.setActive(true);
     uacQidLink.setQid(qid);
+    uacQidLink.setMetadata(metadata);
 
     return uacQidLink;
   }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/UnaddressedReceiverTest.java
@@ -39,7 +39,9 @@ public class UnaddressedReceiverTest {
     UacQidLink uacQidLink = new UacQidLink();
     Message<CreateUacQid> message = constructMessageWithValidTimeStamp(createUacQid);
     OffsetDateTime expectedDate = MsgDateHelper.getMsgTimeStamp(message);
-    when(uacService.buildUacQidLink(null, 21, createUacQid.getBatchId())).thenReturn(uacQidLink);
+    when(uacService.buildUacQidLink(
+            eq(null), eq(21), eq(createUacQid.getBatchId()), any(EventDTO.class)))
+        .thenReturn(uacQidLink);
     when(uacService.saveAndEmitUacUpdatedEvent(any(UacQidLink.class))).thenReturn(new PayloadDTO());
 
     // When

--- a/src/test/java/uk/gov/ons/census/casesvc/service/EventServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/EventServiceTest.java
@@ -44,7 +44,7 @@ public class EventServiceTest {
     caze.setCaseType("HH");
     when(caseService.saveCaseSample(createCaseSample)).thenReturn(caze);
     UacQidLink uacQidLink = new UacQidLink();
-    when(uacService.buildUacQidLink(caze, 1)).thenReturn(uacQidLink);
+    when(uacService.buildUacQidLink(eq(caze), eq(1), eq(null), any())).thenReturn(uacQidLink);
     when(uacService.saveAndEmitUacUpdatedEvent(any(UacQidLink.class))).thenReturn(new PayloadDTO());
     when(caseService.saveCaseAndEmitCaseCreatedEvent(any(Case.class))).thenReturn(new PayloadDTO());
 
@@ -55,7 +55,7 @@ public class EventServiceTest {
 
     // Then
     verify(caseService).saveCaseSample(createCaseSample);
-    verify(uacService).buildUacQidLink(eq(caze), eq(1));
+    verify(uacService).buildUacQidLink(eq(caze), eq(1), eq(null), any());
     verify(uacService).saveAndEmitUacUpdatedEvent(uacQidLink);
     verify(caseService).saveCaseAndEmitCaseCreatedEvent(caze);
 
@@ -116,8 +116,8 @@ public class EventServiceTest {
     when(caseService.saveCaseSample(createCaseSample)).thenReturn(caze);
     UacQidLink uacQidLink = new UacQidLink();
     UacQidLink secondUacQidLink = new UacQidLink();
-    when(uacService.buildUacQidLink(caze, 2)).thenReturn(uacQidLink);
-    when(uacService.buildUacQidLink(caze, 3)).thenReturn(secondUacQidLink);
+    when(uacService.buildUacQidLink(eq(caze), eq(2), eq(null), any())).thenReturn(uacQidLink);
+    when(uacService.buildUacQidLink(eq(caze), eq(3), eq(null), any())).thenReturn(secondUacQidLink);
     when(uacService.saveAndEmitUacUpdatedEvent(any(UacQidLink.class))).thenReturn(new PayloadDTO());
     when(caseService.saveCaseAndEmitCaseCreatedEvent(any(Case.class))).thenReturn(new PayloadDTO());
 
@@ -128,7 +128,7 @@ public class EventServiceTest {
 
     // Then
     verify(caseService).saveCaseSample(createCaseSample);
-    verify(uacService, times(1)).buildUacQidLink(eq(caze), eq(2));
+    verify(uacService, times(1)).buildUacQidLink(eq(caze), eq(2), eq(null), any());
     verify(uacService, times(2)).saveAndEmitUacUpdatedEvent(uacQidLink);
     verify(caseService).saveCaseAndEmitCaseCreatedEvent(caze);
 

--- a/src/test/java/uk/gov/ons/census/casesvc/service/UacServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/UacServiceTest.java
@@ -216,6 +216,8 @@ public class UacServiceTest {
     assertThat(actualUacQidLink.getCaze().getSurvey()).isEqualTo("CCS");
     assertThat(actualUacQidLink.getCaze()).isNotNull();
     assertThat(actualUacQidLink.isCcsCase()).isTrue();
+    assertThat(actualUacQidLink.getMetadata().getChannel()).isEqualTo("DUMMY");
+    assertThat(actualUacQidLink.getMetadata().getSource()).isEqualTo("DUMMY");
 
     Case actualCase = actualUacQidLink.getCaze();
     assertThat(actualCase.getCaseId()).isEqualTo(TEST_CASE_ID);

--- a/src/test/java/uk/gov/ons/census/casesvc/service/UacServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/UacServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.ons.census.casesvc.cache.UacQidCache;
 import uk.gov.ons.census.casesvc.logging.EventLogger;
+import uk.gov.ons.census.casesvc.model.dto.EventDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.casesvc.model.dto.UacQidDTO;
 import uk.gov.ons.census.casesvc.model.entity.Case;
@@ -58,9 +59,13 @@ public class UacServiceTest {
     uacQidDTO.setQid("01testqid");
     when(uacCache.getUacQidPair(anyInt())).thenReturn(uacQidDTO);
 
+    EventDTO dummyEvent = new EventDTO();
+    dummyEvent.setSource("DUMMY");
+    dummyEvent.setChannel("DUMMY");
+
     // When
     UacQidLink result;
-    result = underTest.buildUacQidLink(caze, 1);
+    result = underTest.buildUacQidLink(caze, 1, null, dummyEvent);
 
     // Then
     assertEquals("01", result.getQid().substring(0, 2));
@@ -197,11 +202,15 @@ public class UacServiceTest {
     expectedCase.setCaseId(TEST_CASE_ID);
     expectedCase.setSurvey("CCS");
 
+    EventDTO dummyEvent = new EventDTO();
+    dummyEvent.setSource("DUMMY");
+    dummyEvent.setChannel("DUMMY");
+
     UacQidDTO expectedUacQidDTO = new UacQidDTO();
     when(uacCache.getUacQidPair(71)).thenReturn(expectedUacQidDTO);
 
     // When
-    UacQidLink actualUacQidLink = underTest.createUacQidLinkedToCCSCase(expectedCase);
+    UacQidLink actualUacQidLink = underTest.createUacQidLinkedToCCSCase(expectedCase, dummyEvent);
 
     // Then
     assertThat(actualUacQidLink.getCaze().getSurvey()).isEqualTo("CCS");


### PR DESCRIPTION
# Motivation and Context
To make it easier to figure out which UAC was added to a case for what purpose, when dealing with operational issues, it's useful to have the source and channel.

# What has changed
Stamped the source and channel onto UACs when they're created.

# How to test?
Create some UACs via various routes (Contact Centre via Case API, Field via Notify, Reminders via Action Scheduler etc) and check that the source shows up correctly in the database.

# Links
Trello: https://trello.com/c/RXayiIFg