### PR TITLE
Remove cases postcode index

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
@@ -23,7 +23,6 @@ import org.hibernate.annotations.*;
     indexes = {
       @Index(name = "cases_case_ref_idx", columnList = "case_ref"),
       @Index(name = "lsoa_idx", columnList = "lsoa"),
-      @Index(name = "postcode_idx", columnList = "postcode")
     })
 public class Case {
 


### PR DESCRIPTION
# Motivation and Context
The index on the postcode column alone did not aid the postcode search queries.

# What has changed
* Remove index on postcode column

# How to test?
No functional changes here.

# Links
https://trello.com/c/fg58euQh/1361-add-a-fancy-pants-index-on-postcode-column-to-speed-up-rops-query-time