### PR TITLE
Add more helpful error message when we get sent garbage

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestService.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import uk.gov.ons.census.casesvc.logging.EventLogger;
 import uk.gov.ons.census.casesvc.model.dto.EventDTO;
 import uk.gov.ons.census.casesvc.model.dto.FulfilmentRequestDTO;
@@ -108,6 +109,13 @@ public class FulfilmentRequestService {
       FulfilmentRequestDTO fulfilmentRequestPayload, String eventChannel, Case caze) {
     if (caze.getCaseType().equals("HH")
         && individualResponseRequestCodes.contains(fulfilmentRequestPayload.getFulfilmentCode())) {
+
+      // This check is mostly to help the testers, who often send malformed messages manually.
+      // Can be removed once testing is done exclusively via the *systems* and not handwritten JSON
+      if (StringUtils.isEmpty(fulfilmentRequestPayload.getIndividualCaseId())) {
+        throw new RuntimeException("Individual fulfilment must have an individual case ID");
+      }
+
       Case individualResponseCase =
           caseService.prepareIndividualResponseCaseFromParentCase(
               caze, fulfilmentRequestPayload.getIndividualCaseId(), eventChannel);


### PR DESCRIPTION
# Motivation and Context
We get sent loads of garbage during testing. The garbage is annoying. The error message doesn't make it clear exactly _why_ the message is garbage (except that we rejected it - it errors because it's garbage).

# What has changed
Make the "it's garbage" message more explicit about what kind of garbage we got sent.

# How to test?
Send some garbage.

# Links
Trello: https://trello.com/c/BlPsX8kS