### PR TITLE
Create or update after loading update file

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/RmCaseUpdatedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/RmCaseUpdatedService.java
@@ -41,7 +41,7 @@ public class RmCaseUpdatedService {
 
     validateRmCaseUpdated(rmCaseUpdated);
 
-    boolean oaPresent = updatedCase.getOa() != null && !updatedCase.getOa().isEmpty();
+    boolean oaPresent = !StringUtils.isEmpty(updatedCase.getOa());
 
     updateCase(updatedCase, rmCaseUpdated);
 
@@ -56,9 +56,12 @@ public class RmCaseUpdatedService {
       eventMetadata = new Metadata();
       eventMetadata.setCauseEventType(rme.getEvent().getType());
 
-      // Only send a CREATE on a case that field doesn't already know about
-      // Disclaimer - we were forced by field to use this hack and it should be refactored
-      // properly when time allows.
+      // We don't want to send an UPDATE for cases which FWMT-G already know about,
+      // but the only way we've got of **guessing** that is by looking to see if an OA is on the
+      // case or not. We imagine that OA would only be set on cases which FWMT-G know about,
+      // so we have been forced to use it as an ugly kludge, because of time pressure.
+      // TODO: This should be refactored/done properly. It's tech debt.
+
       if (oaPresent) {
         eventMetadata.setFieldDecision(ActionInstructionType.UPDATE);
       } else {

--- a/src/main/java/uk/gov/ons/census/casesvc/service/RmCaseUpdatedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/RmCaseUpdatedService.java
@@ -39,9 +39,9 @@ public class RmCaseUpdatedService {
     RmCaseUpdated rmCaseUpdated = rme.getPayload().getRmCaseUpdated();
     Case updatedCase = caseService.getCaseByCaseId(rmCaseUpdated.getCaseId());
 
-    boolean oaSet = updatedCase.getOa() != null;
-
     validateRmCaseUpdated(rmCaseUpdated);
+
+    boolean oaPresent = updatedCase.getOa() != null;
 
     updateCase(updatedCase, rmCaseUpdated);
 
@@ -55,8 +55,9 @@ public class RmCaseUpdatedService {
     if (shouldSendCaseToField(updatedCase, rme.getEvent().getChannel())) {
       eventMetadata = new Metadata();
       eventMetadata.setCauseEventType(rme.getEvent().getType());
+
       // Only send a CREATE on a case that field doesn't already know about
-      if (oaSet) {
+      if (oaPresent) {
         eventMetadata.setFieldDecision(ActionInstructionType.UPDATE);
       } else {
         eventMetadata.setFieldDecision(ActionInstructionType.CREATE);
@@ -230,5 +231,9 @@ public class RmCaseUpdatedService {
         || StringUtils.isEmpty(caze.getFieldOfficerId())) {
       throw new RuntimeException("Case missing mandatory fields after RM Case Updated");
     }
+  }
+
+  public boolean isOaPresent(Case originalCase) {
+    return originalCase.getOa() != null;
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/RmCaseUpdatedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/RmCaseUpdatedService.java
@@ -41,7 +41,7 @@ public class RmCaseUpdatedService {
 
     validateRmCaseUpdated(rmCaseUpdated);
 
-    boolean oaPresent = updatedCase.getOa() != null;
+    boolean oaPresent = updatedCase.getOa() != null && !updatedCase.getOa().isEmpty();
 
     updateCase(updatedCase, rmCaseUpdated);
 
@@ -57,6 +57,8 @@ public class RmCaseUpdatedService {
       eventMetadata.setCauseEventType(rme.getEvent().getType());
 
       // Only send a CREATE on a case that field doesn't already know about
+      // Disclaimer - we were forced by field to use this hack and it should be refactored
+      // properly when time allows.
       if (oaPresent) {
         eventMetadata.setFieldDecision(ActionInstructionType.UPDATE);
       } else {
@@ -231,9 +233,5 @@ public class RmCaseUpdatedService {
         || StringUtils.isEmpty(caze.getFieldOfficerId())) {
       throw new RuntimeException("Case missing mandatory fields after RM Case Updated");
     }
-  }
-
-  public boolean isOaPresent(Case originalCase) {
-    return originalCase.getOa() != null;
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/service/RmCaseUpdatedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/RmCaseUpdatedServiceTest.java
@@ -87,6 +87,33 @@ public class RmCaseUpdatedServiceTest {
             any());
   }
 
+  //  @Test
+  //  public void testUpdateActionToField() {
+  //    // Given
+  //    // Set up minimum expected data on a skeleton case
+  //    Case caseToUpdate = setUpMinimumGoodSkeletonCase();
+  //    caseToUpdate.setOa("Test OA");
+  //
+  //    ResponseManagementEvent rme = setUpMinimumGoodRmCaseUpdatedEvent();
+  //    RmCaseUpdated rmCaseUpdated = rme.getPayload().getRmCaseUpdated();
+  //
+  //    OffsetDateTime messageTimestamp = OffsetDateTime.now();
+  //
+  //    when(caseService.getCaseByCaseId(any())).thenReturn(caseToUpdate);
+  //    when(estabTypes.contains(eq("TEST_ESTAB_TYPE"))).thenReturn(true);
+  //
+  //    // When
+  //    underTest.processMessage(rme, messageTimestamp);
+  //
+  //    // Then
+  //    // UPDATE should be sent if field already know about it (OA value present on original case)
+  //    ArgumentCaptor<Metadata> metadataArgumentCaptor = ArgumentCaptor.forClass(Metadata.class);
+  //    verify(caseService)
+  //        .saveCaseAndEmitCaseUpdatedEvent(eq(caseToUpdate), metadataArgumentCaptor.capture());
+  //    Metadata eventMetadata = metadataArgumentCaptor.getValue();
+  //    assertThat(eventMetadata.getFieldDecision()).isEqualTo(ActionInstructionType.UPDATE);
+  //  }
+
   @Test
   public void testMaximumChanges() {
     // Given

--- a/src/test/java/uk/gov/ons/census/casesvc/service/RmCaseUpdatedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/RmCaseUpdatedServiceTest.java
@@ -87,32 +87,32 @@ public class RmCaseUpdatedServiceTest {
             any());
   }
 
-  //  @Test
-  //  public void testUpdateActionToField() {
-  //    // Given
-  //    // Set up minimum expected data on a skeleton case
-  //    Case caseToUpdate = setUpMinimumGoodSkeletonCase();
-  //    caseToUpdate.setOa("Test OA");
-  //
-  //    ResponseManagementEvent rme = setUpMinimumGoodRmCaseUpdatedEvent();
-  //    RmCaseUpdated rmCaseUpdated = rme.getPayload().getRmCaseUpdated();
-  //
-  //    OffsetDateTime messageTimestamp = OffsetDateTime.now();
-  //
-  //    when(caseService.getCaseByCaseId(any())).thenReturn(caseToUpdate);
-  //    when(estabTypes.contains(eq("TEST_ESTAB_TYPE"))).thenReturn(true);
-  //
-  //    // When
-  //    underTest.processMessage(rme, messageTimestamp);
-  //
-  //    // Then
-  //    // UPDATE should be sent if field already know about it (OA value present on original case)
-  //    ArgumentCaptor<Metadata> metadataArgumentCaptor = ArgumentCaptor.forClass(Metadata.class);
-  //    verify(caseService)
-  //        .saveCaseAndEmitCaseUpdatedEvent(eq(caseToUpdate), metadataArgumentCaptor.capture());
-  //    Metadata eventMetadata = metadataArgumentCaptor.getValue();
-  //    assertThat(eventMetadata.getFieldDecision()).isEqualTo(ActionInstructionType.UPDATE);
-  //  }
+  @Test
+  public void testUpdateActionToField() {
+    // Given
+    // Set up minimum expected data on a skeleton case
+    Case caseToUpdate = setUpMinimumGoodSkeletonCase();
+    caseToUpdate.setOa("Test OA");
+
+    ResponseManagementEvent rme = setUpMinimumGoodRmCaseUpdatedEvent();
+    RmCaseUpdated rmCaseUpdated = rme.getPayload().getRmCaseUpdated();
+
+    OffsetDateTime messageTimestamp = OffsetDateTime.now();
+
+    when(caseService.getCaseByCaseId(any())).thenReturn(caseToUpdate);
+    when(estabTypes.contains(eq("TEST_ESTAB_TYPE"))).thenReturn(true);
+
+    // When
+    underTest.processMessage(rme, messageTimestamp);
+
+    // Then
+    // UPDATE should be sent if field already know about it (OA value present on original case)
+    ArgumentCaptor<Metadata> metadataArgumentCaptor = ArgumentCaptor.forClass(Metadata.class);
+    verify(caseService)
+        .saveCaseAndEmitCaseUpdatedEvent(eq(caseToUpdate), metadataArgumentCaptor.capture());
+    Metadata eventMetadata = metadataArgumentCaptor.getValue();
+    assertThat(eventMetadata.getFieldDecision()).isEqualTo(ActionInstructionType.UPDATE);
+  }
 
   @Test
   public void testMaximumChanges() {


### PR DESCRIPTION
# Motivation and Context
When dealing with address updates, if we sent a CREATE action to field for a case that they already know about then it causes them problems.  If an oa value is present for the original case then we need to send an UPDATE action instead.

# What has changed
If the oa is not null on the original case (before address updates have been applied) then we send an UPDATE action instead of a CREATE.

# How to test?
 - Run an address update (send a manual message or run the bulk updater from toolbox) for a case that doesn't have an oa value against it.  A CREATE field decision should be sent to field.
- Send another update against the same case. The case will now already have an oa value against it so an UPDATE should be sent to field.

# Links
- https://trello.com/c/vlpzyc7c
