### PR TITLE
Allow Contact Centre to send Estab Type OTHER for modifications and case type change modifications

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/AddressModificationService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/AddressModificationService.java
@@ -33,7 +33,8 @@ public class AddressModificationService {
 
     Case caze = caseService.getCaseByCaseId(addressModification.getCollectionCase().getId());
 
-    addressModificationValidator.validate(addressModification.getNewAddress());
+    addressModificationValidator.validate(
+        addressModification.getNewAddress(), responseManagementEvent.getEvent().getChannel());
 
     modifyCaseAddress(caze, addressModification);
     caseService.saveCaseAndEmitCaseUpdatedEvent(caze, null);

--- a/src/main/java/uk/gov/ons/census/casesvc/service/AddressTypeChangeService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/AddressTypeChangeService.java
@@ -45,7 +45,9 @@ public class AddressTypeChangeService {
     if (oldCase.getCaseType().equals("HI")) {
       throw new RuntimeException("Cannot change case of type HI");
     }
-    addressModificationValidator.validate(addressTypeChange.getCollectionCase().getAddress());
+    addressModificationValidator.validate(
+        addressTypeChange.getCollectionCase().getAddress(),
+        responseManagementEvent.getEvent().getChannel());
 
     invalidateOldCase(responseManagementEvent, messageTimestamp, addressTypeChange, oldCase);
 

--- a/src/main/java/uk/gov/ons/census/casesvc/utility/AddressModificationValidator.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/utility/AddressModificationValidator.java
@@ -15,7 +15,7 @@ public class AddressModificationValidator {
     this.estabTypes = estabTypes;
   }
 
-  public void validate(ModifiedAddress modifiedAddress) {
+  public void validate(ModifiedAddress modifiedAddress, String eventChannel) {
     if (modifiedAddress.getAddressLine1() != null
         && !modifiedAddress.getAddressLine1().isPresent()) {
       throw new RuntimeException(
@@ -32,10 +32,24 @@ public class AddressModificationValidator {
       throw new RuntimeException("Validation Failure: Mandatory estab type cannot be set to null");
     }
 
-    if (modifiedAddress.getEstabType() != null
-        && modifiedAddress.getEstabType().isPresent()
-        && !estabTypes.contains(modifiedAddress.getEstabType().get())) {
-      throw new RuntimeException("Validation Failure: Estab Type not valid");
+    if (modifiedAddress.getEstabType() != null && modifiedAddress.getEstabType().isPresent()) {
+
+      if ("CC".equals(eventChannel) && "OTHER".equals(modifiedAddress.getEstabType().get())) {
+        // ****************** HERE BE DRAGONS!!!! *******************
+        // Because of reasons of almost unimaginable awfulness, we are forced to accept this
+        // late-breaking kludge, which allows Contact Centre to use "OTHER" as the estab type
+        // instead of one of the vast number of specific ones which are allowed.
+        //
+        // See this card for more details: https://trello.com/c/ZUuPMYuQ
+        //
+        // This clause allows OTHER estab type from CC without throwing an exception, and it
+        // exists purely to document this highly undesirable behaviour, although functionally
+        // it does nothing, and a programmer without this knowledge would no doubt optimise it away.
+        //
+        // Sorry.
+      } else if (!estabTypes.contains(modifiedAddress.getEstabType().get())) {
+        throw new RuntimeException("Validation Failure: Estab Type not valid");
+      }
     }
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/utility/AddressModificationValidatorTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/utility/AddressModificationValidatorTest.java
@@ -131,6 +131,18 @@ public class AddressModificationValidatorTest {
     underTest.validate(modifiedAddress, "CC");
   }
 
+  // See "here be dragons" comments elsewhere. Sorry.
+  @Test
+  public void testOtherEstabTypeNotFromContactCentreIsNotAllowed() {
+    // Given
+    ModifiedAddress modifiedAddress = new ModifiedAddress();
+    modifiedAddress.setAddressType("HH");
+    modifiedAddress.setEstabType(Optional.of("OTHER"));
+
+    // When, then exception
+    checkValidationFailureThrown(modifiedAddress);
+  }
+
   private void checkValidationFailureThrown(ModifiedAddress modifiedAddress) {
     try {
       underTest.validate(modifiedAddress, "RH");

--- a/src/test/java/uk/gov/ons/census/casesvc/utility/AddressModificationValidatorTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/utility/AddressModificationValidatorTest.java
@@ -38,7 +38,7 @@ public class AddressModificationValidatorTest {
     modifiedAddress.setAddressType("HH");
 
     // When, then no exception
-    underTest.validate(modifiedAddress);
+    underTest.validate(modifiedAddress, "RH");
   }
 
   @Test
@@ -48,7 +48,7 @@ public class AddressModificationValidatorTest {
     modifiedAddress.setAddressType("HH");
 
     // When, then no exception
-    underTest.validate(modifiedAddress);
+    underTest.validate(modifiedAddress, "RH");
   }
 
   @Test
@@ -60,7 +60,7 @@ public class AddressModificationValidatorTest {
     modifiedAddress.setOrganisationName(Optional.empty());
 
     // When, then no exception
-    underTest.validate(modifiedAddress);
+    underTest.validate(modifiedAddress, "RH");
   }
 
   @Test
@@ -105,9 +105,35 @@ public class AddressModificationValidatorTest {
     checkValidationFailureThrown(modifiedAddress);
   }
 
+  // ****************** HERE BE DRAGONS!!!! *******************
+  // See comment above. Deliberately repeated here, because of kludginess spreading through
+  // codebase.
+  //
+  // Because of reasons of almost unimaginable awfulness, we are forced to accept this
+  // late-breaking kludge, which allows Contact Centre to use "OTHER" as the estab type
+  // instead of one of the vast number of specific ones which are allowed.
+  //
+  // See this card for more details: https://trello.com/c/ZUuPMYuQ
+  //
+  // This test proves that we allow OTHER estab type from CC without throwing an exception, and it
+  // exists purely to document this highly undesirable behaviour, although functionally it does
+  // nothing, and a programmer without this knowledge would  no doubt optimise it away.
+  //
+  // Sorry.
+  @Test
+  public void testOtherEstabTypeFromContactCentreIsAllowed() {
+    // Given
+    ModifiedAddress modifiedAddress = new ModifiedAddress();
+    modifiedAddress.setAddressType("HH");
+    modifiedAddress.setEstabType(Optional.of("OTHER"));
+
+    // When, then no exception
+    underTest.validate(modifiedAddress, "CC");
+  }
+
   private void checkValidationFailureThrown(ModifiedAddress modifiedAddress) {
     try {
-      underTest.validate(modifiedAddress);
+      underTest.validate(modifiedAddress, "RH");
       fail("Expected validation failure RuntimeException not thrown");
     } catch (RuntimeException e) {
       assertThat(e.getMessage()).startsWith("Validation Failure: ");

--- a/src/test/java/uk/gov/ons/census/casesvc/utility/AddressModificationValidatorTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/utility/AddressModificationValidatorTest.java
@@ -106,7 +106,7 @@ public class AddressModificationValidatorTest {
   }
 
   // ****************** HERE BE DRAGONS!!!! *******************
-  // See comment above. Deliberately repeated here, because of kludginess spreading through
+  // See comment elsewhere deliberately repeated here, because of kludginess spreading through
   // codebase.
   //
   // Because of reasons of almost unimaginable awfulness, we are forced to accept this


### PR DESCRIPTION
# Motivation and Context
I didn't want to do this, but it was too hard for other systems to make the necessary changes, so we had to kludge RM. I don't know. Read the Trello ticket for some background.

# What has changed
Allowed Contact Centre to send an estab type of "OTHER" although it is not one of the allowed ones.

# How to test?
Try sending an address modification with estab type "OTHER" from CC, and it should work. Try sending an address modification with estab type "OTHER" from RH, and it should throw an exception.

Try sending an address type change, with an address modification, with estab type "OTHER" from CC, and it should work. Try sending an an address type change, with an address modification, with estab type "OTHER" from RH, and it should throw an exception.

# Links
Trello: https://trello.com/c/ZUuPMYuQ