### PR TITLE
Field address update CREATE/UPDATE decision hack

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/RmCaseUpdatedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/RmCaseUpdatedService.java
@@ -41,9 +41,9 @@ public class RmCaseUpdatedService {
 
     validateRmCaseUpdated(rmCaseUpdated);
 
-    boolean oaPresentOnOriginalCase = !StringUtils.isEmpty(caze.getOa());
-    boolean fieldCoordinatorIdPresentOnOriginalCase =
-        !StringUtils.isEmpty(caze.getFieldCoordinatorId());
+    boolean oaNotPresentOnOriginalCase = StringUtils.isEmpty(caze.getOa());
+    boolean fieldCoordinatorIdNotPresentOnOriginalCase =
+        StringUtils.isEmpty(caze.getFieldCoordinatorId());
 
     updateCase(caze, rmCaseUpdated);
 
@@ -63,18 +63,18 @@ public class RmCaseUpdatedService {
       // implementing the following:
       //
       // "The logic we need is:
-      // if (case before update had OA) or (case before update didn't have field coordinator ID):
-      // send field UPDATE
-      // else: send field CREATE"
+      // if (case before update didn't have OA) or (case before update didn't have field coord ID):
+      // send field CREATE
+      // else: send field UPDATE"
       //
       // Literally quoted from the ticket:
       // https://trello.com/c/i6xdQWau/1628-field-address-update-create-update-decision-hack-13
       //
       // Sorry.
-      if (oaPresentOnOriginalCase || !fieldCoordinatorIdPresentOnOriginalCase) {
-        eventMetadata.setFieldDecision(ActionInstructionType.UPDATE);
-      } else {
+      if (oaNotPresentOnOriginalCase || fieldCoordinatorIdNotPresentOnOriginalCase) {
         eventMetadata.setFieldDecision(ActionInstructionType.CREATE);
+      } else {
+        eventMetadata.setFieldDecision(ActionInstructionType.UPDATE);
       }
     }
 

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/RmCaseUpdatedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/RmCaseUpdatedReceiverIT.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.census.casesvc.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.ons.census.casesvc.model.dto.ActionInstructionType.UPDATE;
+import static uk.gov.ons.census.casesvc.model.dto.ActionInstructionType.CREATE;
 import static uk.gov.ons.census.casesvc.model.dto.EventTypeDTO.CASE_UPDATED;
 import static uk.gov.ons.census.casesvc.model.dto.EventTypeDTO.RM_CASE_UPDATED;
 import static uk.gov.ons.census.casesvc.testutil.DataUtils.convertJsonToObject;
@@ -89,7 +89,7 @@ public class RmCaseUpdatedReceiverIT {
       assertThat(actualEmittedMessage.getPayload().getMetadata().getCauseEventType())
           .isEqualTo(RM_CASE_UPDATED);
       assertThat(actualEmittedMessage.getPayload().getMetadata().getFieldDecision())
-          .isEqualTo(UPDATE);
+          .isEqualTo(CREATE);
 
       CollectionCase actualUpdatedCollectionCase =
           actualEmittedMessage.getPayload().getCollectionCase();

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/RmCaseUpdatedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/RmCaseUpdatedReceiverIT.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.census.casesvc.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.ons.census.casesvc.model.dto.ActionInstructionType.CREATE;
+import static uk.gov.ons.census.casesvc.model.dto.ActionInstructionType.UPDATE;
 import static uk.gov.ons.census.casesvc.model.dto.EventTypeDTO.CASE_UPDATED;
 import static uk.gov.ons.census.casesvc.model.dto.EventTypeDTO.RM_CASE_UPDATED;
 import static uk.gov.ons.census.casesvc.testutil.DataUtils.convertJsonToObject;
@@ -89,7 +89,7 @@ public class RmCaseUpdatedReceiverIT {
       assertThat(actualEmittedMessage.getPayload().getMetadata().getCauseEventType())
           .isEqualTo(RM_CASE_UPDATED);
       assertThat(actualEmittedMessage.getPayload().getMetadata().getFieldDecision())
-          .isEqualTo(CREATE);
+          .isEqualTo(UPDATE);
 
       CollectionCase actualUpdatedCollectionCase =
           actualEmittedMessage.getPayload().getCollectionCase();

--- a/src/test/java/uk/gov/ons/census/casesvc/service/RmCaseUpdatedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/RmCaseUpdatedServiceTest.java
@@ -73,7 +73,7 @@ public class RmCaseUpdatedServiceTest {
     verify(caseService)
         .saveCaseAndEmitCaseUpdatedEvent(eq(caseToUpdate), metadataArgumentCaptor.capture());
     Metadata eventMetadata = metadataArgumentCaptor.getValue();
-    assertThat(eventMetadata.getFieldDecision()).isEqualTo(ActionInstructionType.CREATE);
+    assertThat(eventMetadata.getFieldDecision()).isEqualTo(ActionInstructionType.UPDATE);
     assertThat(eventMetadata.getCauseEventType()).isEqualTo(EventTypeDTO.RM_CASE_UPDATED);
 
     verify(eventLogger)
@@ -184,7 +184,7 @@ public class RmCaseUpdatedServiceTest {
     verify(caseService)
         .saveCaseAndEmitCaseUpdatedEvent(eq(caseToUpdate), metadataArgumentCaptor.capture());
     Metadata eventMetadata = metadataArgumentCaptor.getValue();
-    assertThat(eventMetadata.getFieldDecision()).isEqualTo(ActionInstructionType.CREATE);
+    assertThat(eventMetadata.getFieldDecision()).isEqualTo(ActionInstructionType.UPDATE);
     assertThat(eventMetadata.getCauseEventType()).isEqualTo(EventTypeDTO.RM_CASE_UPDATED);
 
     verify(eventLogger)

--- a/src/test/java/uk/gov/ons/census/casesvc/service/RmCaseUpdatedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/RmCaseUpdatedServiceTest.java
@@ -73,7 +73,7 @@ public class RmCaseUpdatedServiceTest {
     verify(caseService)
         .saveCaseAndEmitCaseUpdatedEvent(eq(caseToUpdate), metadataArgumentCaptor.capture());
     Metadata eventMetadata = metadataArgumentCaptor.getValue();
-    assertThat(eventMetadata.getFieldDecision()).isEqualTo(ActionInstructionType.UPDATE);
+    assertThat(eventMetadata.getFieldDecision()).isEqualTo(ActionInstructionType.CREATE);
     assertThat(eventMetadata.getCauseEventType()).isEqualTo(EventTypeDTO.RM_CASE_UPDATED);
 
     verify(eventLogger)
@@ -111,7 +111,7 @@ public class RmCaseUpdatedServiceTest {
     verify(caseService)
         .saveCaseAndEmitCaseUpdatedEvent(eq(caseToUpdate), metadataArgumentCaptor.capture());
     Metadata eventMetadata = metadataArgumentCaptor.getValue();
-    assertThat(eventMetadata.getFieldDecision()).isEqualTo(ActionInstructionType.UPDATE);
+    assertThat(eventMetadata.getFieldDecision()).isEqualTo(ActionInstructionType.CREATE);
   }
 
   @Test
@@ -184,7 +184,7 @@ public class RmCaseUpdatedServiceTest {
     verify(caseService)
         .saveCaseAndEmitCaseUpdatedEvent(eq(caseToUpdate), metadataArgumentCaptor.capture());
     Metadata eventMetadata = metadataArgumentCaptor.getValue();
-    assertThat(eventMetadata.getFieldDecision()).isEqualTo(ActionInstructionType.UPDATE);
+    assertThat(eventMetadata.getFieldDecision()).isEqualTo(ActionInstructionType.CREATE);
     assertThat(eventMetadata.getCauseEventType()).isEqualTo(EventTypeDTO.RM_CASE_UPDATED);
 
     verify(eventLogger)


### PR DESCRIPTION
# Motivation and Context
For reasons too horrible to go into in this PR, we are hacking RM in a deeply regrettable way, as forced to by external teams.

# What has changed
Something so horrible and hacky that it's impossible to explain (and support, and maintain). Read the Trello ticket, but I doubt you'll be any the wiser.

# How to test?
Why even bother? This is so hacky. Nobody knows why this is being done (i.e. what requirement it meets) and nobody can understand the complex scenarios. This a departure from working high-quality software which can be supported and maintained, and will work reliably, into the territory of unsupportable, unreliable, buggy rubbish which won't work.

# Links
Trello: https://trello.com/c/i6xdQWau