### PR TITLE
Send UPDATE to FWMT-G for FieldCaseUpdated (CE Units only)

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/FieldCaseUpdatedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/FieldCaseUpdatedService.java
@@ -62,11 +62,17 @@ public class FieldCaseUpdatedService {
 
   private Metadata buildMetadataForFieldCaseUpdated(
       Case caze, ResponseManagementEvent fieldCaseUpdatedPayload) {
-    if (fieldCaseUpdatedPayload.getPayload().getCollectionCase().getCeExpectedCapacity()
-        <= caze.getCeActualResponses()) {
-      return buildMetadata(
-          fieldCaseUpdatedPayload.getEvent().getType(), ActionInstructionType.CANCEL);
+    ActionInstructionType actionInstructionType = null;
+
+    if ("CE".equals(caze.getCaseType()) && "U".equals(caze.getAddressLevel())) {
+      if (fieldCaseUpdatedPayload.getPayload().getCollectionCase().getCeExpectedCapacity()
+          <= caze.getCeActualResponses()) {
+        actionInstructionType = ActionInstructionType.CANCEL;
+      } else {
+        actionInstructionType = ActionInstructionType.UPDATE;
+      }
     }
-    return buildMetadata(fieldCaseUpdatedPayload.getEvent().getType(), null);
+
+    return buildMetadata(fieldCaseUpdatedPayload.getEvent().getType(), actionInstructionType);
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/FieldCaseUpdatedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/FieldCaseUpdatedReceiverIT.java
@@ -65,7 +65,7 @@ public class FieldCaseUpdatedReceiverIT {
     caze.setUacQidLinks(null);
     caze.setEvents(null);
     caze.setCaseType("CE");
-    caze.setAddressLevel("E");
+    caze.setAddressLevel("U");
     caze.setCeActualResponses(5);
     caze.setCeExpectedCapacity(8);
     caze.setAddressInvalid(false);
@@ -75,7 +75,7 @@ public class FieldCaseUpdatedReceiverIT {
   }
 
   @Test
-  public void testNoCancelSentWhenCeExpectedCapacityUpdated() throws Exception {
+  public void testUpdateSentWhenCeExpectedCapacityUpdated() throws Exception {
     try (QueueSpy fieldOutboundQueue = rabbitQueueHelper.listen(caseUpdatedQueueName)) {
 
       ResponseManagementEvent managementEvent = getTestResponseManagementFieldUpdatedEvent();
@@ -102,8 +102,10 @@ public class FieldCaseUpdatedReceiverIT {
       assertThat(actualCollectionCase.getId()).isEqualTo(TEST_CASE_ID);
       assertThat(actualCollectionCase.getCeExpectedCapacity()).isEqualTo(6);
 
-      // check the metadata does NOT have a CANCEL decision
-      assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision()).isNull();
+      // check the metadata has a UPDATE decision
+      // check the metadata is included with field UPDATE decision
+      assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
+          .isEqualTo(ActionInstructionType.UPDATE);
       assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
           .isEqualTo(EventTypeDTO.FIELD_CASE_UPDATED);
 


### PR DESCRIPTION
# Motivation and Context
Business requirements have changed.

# What has changed
Only send to field CE units. Send update if the actual response count is greater than the expected response count.

# How to test?
Try updating the case using FIELD_CASE_UPDATED event on CE unit cases. When the actual response count is equal to or greater than the expected response count, the Field case should be cancelled, otherwise it should be updated. Other case types and address levels should either be ignored or throw errors, per prior behaviour.

# Links
Trello: https://trello.com/c/E1Qk7n8H