### PR TITLE
1558-change-logic-to-send-create-messages-to-field-for-household-new-addresses

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -118,7 +118,7 @@ public class NewAddressReportedService {
     }
 
     Metadata metadata =
-        getMetaDataToCreateFieldCaseIfConditionsMet(newCaseFromSourceCase, newAddressEvent);
+        getMetaDataToCreateFieldCaseIfConditionsMet(newAddressEvent);
 
     caseService.saveCaseAndEmitCaseCreatedEvent(newCaseFromSourceCase, metadata);
 
@@ -132,12 +132,7 @@ public class NewAddressReportedService {
         messageTimestamp);
   }
 
-  private Metadata getMetaDataToCreateFieldCaseIfConditionsMet(
-      Case caze, ResponseManagementEvent newAddressEvent) {
-
-    if (!caze.getCaseType().equals("SPG") && !caze.getCaseType().equals("CE")) {
-      return null;
-    }
+  private Metadata getMetaDataToCreateFieldCaseIfConditionsMet(ResponseManagementEvent newAddressEvent) {
 
     if (!newAddressEvent.getEvent().getChannel().equals("FIELD")) {
       return null;

--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -117,8 +117,7 @@ public class NewAddressReportedService {
       newCaseFromSourceCase.setEstabUprn(newCaseFromSourceCase.getUprn());
     }
 
-    Metadata metadata =
-        getMetaDataToCreateFieldCaseIfConditionsMet(newAddressEvent);
+    Metadata metadata = getMetaDataToCreateFieldCaseIfConditionsMet(newAddressEvent);
 
     caseService.saveCaseAndEmitCaseCreatedEvent(newCaseFromSourceCase, metadata);
 
@@ -132,7 +131,8 @@ public class NewAddressReportedService {
         messageTimestamp);
   }
 
-  private Metadata getMetaDataToCreateFieldCaseIfConditionsMet(ResponseManagementEvent newAddressEvent) {
+  private Metadata getMetaDataToCreateFieldCaseIfConditionsMet(
+      ResponseManagementEvent newAddressEvent) {
 
     if (!newAddressEvent.getEvent().getChannel().equals("FIELD")) {
       return null;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,11 @@ spring:
     initialization-mode: always
     hikari:
       maximumPoolSize: 50
+  cloud:
+    gcp:
+      pubsub:
+        emulator-host: localhost:8538
+        project-id: aims-new-address-project
 
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQL94Dialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,7 @@ spring:
     initialization-mode: always
     hikari:
       maximumPoolSize: 50
+
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQL94Dialect
     hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,12 +7,6 @@ spring:
     initialization-mode: always
     hikari:
       maximumPoolSize: 50
-  cloud:
-    gcp:
-      pubsub:
-        emulator-host: localhost:8538
-        project-id: aims-new-address-project
-
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQL94Dialect
     hibernate:

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/AddressReceiverIT.java
@@ -542,6 +542,8 @@ public class AddressReceiverIT {
       sourceCase.setRefusalReceived(null);
       sourceCase.setCollectionExerciseId(censuscollectionExerciseId);
       sourceCase.getMetadata().setSecureEstablishment(true);
+      sourceCase.setFieldCoordinatorId("FIELD_COORDINATOR_ID");
+      sourceCase.setFieldOfficerId("FIELD_OFFICER_ID");
       sourceCase = caseRepository.saveAndFlush(sourceCase);
 
       Address address = new Address();
@@ -552,6 +554,8 @@ public class AddressReceiverIT {
       CollectionCase collectionCase = new CollectionCase();
       collectionCase.setId(UUID.randomUUID());
       collectionCase.setAddress(address);
+      collectionCase.setFieldCoordinatorId("FIELD_COORDINATOR_ID");
+      collectionCase.setFieldOfficerId("FIELD_OFFICER_ID");
 
       NewAddress newAddress = new NewAddress();
       newAddress.setCollectionCase(collectionCase);
@@ -560,6 +564,7 @@ public class AddressReceiverIT {
       EventDTO eventDTO = new EventDTO();
       eventDTO.setType(NEW_ADDRESS_REPORTED);
       eventDTO.setDateTime(OffsetDateTime.now());
+      eventDTO.setChannel("FIELD");
 
       ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
       responseManagementEvent.setEvent(eventDTO);
@@ -612,6 +617,11 @@ public class AddressReceiverIT {
       assertThat(actualCase.getRefusalReceived()).isNull();
       assertThat(actualCase.isAddressInvalid()).isFalse();
       assertThat(actualCase.isHandDelivery()).isFalse();
+
+      assertThat(actualResponseManagementEvent.getPayload().getMetadata().getFieldDecision())
+          .isEqualTo(ActionInstructionType.CREATE);
+      assertThat(actualResponseManagementEvent.getPayload().getMetadata().getCauseEventType())
+          .isEqualTo(NEW_ADDRESS_REPORTED);
 
       // check database for log eventDTO
       List<Event> events = eventRepository.findAll();


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Field need to be sent new household cases back to them for new addresses

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Removed logic checking for case type in newaddressreported code

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run `mvn clean install`
- Run with the ATs branch
- Try sending a HH `newaddressreported` with source id from `FIELD`. There should be a create message on the `rm.field` once its been processed

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/TEbkKVfG/)
# Screenshots (if appropriate):