### PR TITLE
Remove sending UPDATE to field when ER > AR

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/FieldCaseUpdatedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/FieldCaseUpdatedService.java
@@ -63,13 +63,11 @@ public class FieldCaseUpdatedService {
       Case caze, ResponseManagementEvent fieldCaseUpdatedPayload) {
     ActionInstructionType actionInstructionType = null;
 
-    if ("CE".equals(caze.getCaseType()) && "U".equals(caze.getAddressLevel())) {
-      if (fieldCaseUpdatedPayload.getPayload().getCollectionCase().getCeExpectedCapacity()
-          <= caze.getCeActualResponses()) {
-        actionInstructionType = ActionInstructionType.CANCEL;
-      } else {
-        actionInstructionType = ActionInstructionType.UPDATE;
-      }
+    if ("CE".equals(caze.getCaseType())
+        && "U".equals(caze.getAddressLevel())
+        && fieldCaseUpdatedPayload.getPayload().getCollectionCase().getCeExpectedCapacity()
+            <= caze.getCeActualResponses()) {
+      actionInstructionType = ActionInstructionType.CANCEL;
     }
 
     return buildMetadata(fieldCaseUpdatedPayload.getEvent().getType(), actionInstructionType);

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/FieldCaseUpdatedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/FieldCaseUpdatedReceiverIT.java
@@ -75,53 +75,6 @@ public class FieldCaseUpdatedReceiverIT {
   }
 
   @Test
-  public void testUpdateSentWhenCeExpectedCapacityUpdated() throws Exception {
-    try (QueueSpy fieldOutboundQueue = rabbitQueueHelper.listen(caseUpdatedQueueName)) {
-
-      ResponseManagementEvent managementEvent = getTestResponseManagementFieldUpdatedEvent();
-      managementEvent.getEvent().setTransactionId(UUID.randomUUID());
-      managementEvent.getPayload().getCollectionCase().setId(TEST_CASE_ID);
-      managementEvent.getPayload().getCollectionCase().setCeExpectedCapacity(6);
-
-      String json = convertObjectToJson(managementEvent);
-      Message message =
-          MessageBuilder.withBody(json.getBytes())
-              .setContentType(MessageProperties.CONTENT_TYPE_JSON)
-              .build();
-
-      // When
-      rabbitQueueHelper.sendMessage(inboundQueue, message);
-
-      // Then
-
-      // check messages sent
-      ResponseManagementEvent responseManagementEvent =
-          fieldOutboundQueue.checkExpectedMessageReceived();
-      CollectionCase actualCollectionCase =
-          responseManagementEvent.getPayload().getCollectionCase();
-      assertThat(actualCollectionCase.getId()).isEqualTo(TEST_CASE_ID);
-      assertThat(actualCollectionCase.getCeExpectedCapacity()).isEqualTo(6);
-
-      // check the metadata has a UPDATE decision
-      // check the metadata is included with field UPDATE decision
-      assertThat(responseManagementEvent.getPayload().getMetadata().getFieldDecision())
-          .isEqualTo(ActionInstructionType.UPDATE);
-      assertThat(responseManagementEvent.getPayload().getMetadata().getCauseEventType())
-          .isEqualTo(EventTypeDTO.FIELD_CASE_UPDATED);
-
-      Case actualCase = caseRepository.findById(TEST_CASE_ID).get();
-      assertThat(actualCase.getSurvey()).isEqualTo("CENSUS");
-      assertThat(actualCase.getCeExpectedCapacity()).isEqualTo(6);
-
-      // check database for log eventDTO
-      List<Event> events = eventRepository.findAll();
-      assertThat(events.size()).isEqualTo(1);
-      Event event = events.get(0);
-      assertThat(event.getEventDescription()).isEqualTo("Field case update received");
-    }
-  }
-
-  @Test
   public void testCeExpectedCapacityUpdated() throws Exception {
     try (QueueSpy fieldOutboundQueue = rabbitQueueHelper.listen(caseUpdatedQueueName)) {
 

--- a/src/test/java/uk/gov/ons/census/casesvc/service/FieldCaseUpdatedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/FieldCaseUpdatedServiceTest.java
@@ -76,50 +76,6 @@ public class FieldCaseUpdatedServiceTest {
   }
 
   @Test
-  public void testProcessFieldCaseUpdatedEventResultsInFieldUpdate() {
-
-    // Given
-    ResponseManagementEvent managementEvent = getTestResponseManagementFieldUpdatedEvent();
-
-    CollectionCase collectionCase = managementEvent.getPayload().getCollectionCase();
-    collectionCase.setId(TEST_CASE_ID);
-
-    Case testCase = getRandomCase();
-    testCase.setCaseId(TEST_CASE_ID);
-    testCase.setCaseType("CE");
-    testCase.setAddressLevel("U");
-    testCase.setCeExpectedCapacity(9);
-    testCase.setCeActualResponses(3);
-    OffsetDateTime messageTimestamp = OffsetDateTime.now();
-
-    when(caseService.getCaseAndLockIt(eq(TEST_CASE_ID))).thenReturn(testCase);
-
-    // When
-    underTest.processFieldCaseUpdatedEvent(managementEvent, messageTimestamp);
-
-    // Then
-
-    InOrder inOrder = Mockito.inOrder(caseRepository, eventLogger, caseService);
-
-    inOrder.verify(caseService).getCaseAndLockIt(any(UUID.class));
-
-    ArgumentCaptor<Case> caseArgumentCaptor = ArgumentCaptor.forClass(Case.class);
-    ArgumentCaptor<Metadata> metadataArgumentCaptor = ArgumentCaptor.forClass(Metadata.class);
-
-    inOrder
-        .verify(caseService)
-        .saveCaseAndEmitCaseUpdatedEvent(
-            caseArgumentCaptor.capture(), metadataArgumentCaptor.capture());
-    Case caze = caseArgumentCaptor.getValue();
-    Metadata metadata = metadataArgumentCaptor.getValue();
-
-    assertThat(caze.getCeExpectedCapacity()).isEqualTo(5);
-
-    assertThat(metadata.getFieldDecision()).isEqualTo(ActionInstructionType.UPDATE);
-    assertThat(metadata.getCauseEventType()).isEqualTo(EventTypeDTO.FIELD_CASE_UPDATED);
-  }
-
-  @Test
   public void testProcessFieldCaseUpdatedEventOnEstabDoesNotSendToField() {
     // Given
     ResponseManagementEvent managementEvent = getTestResponseManagementFieldUpdatedEvent();


### PR DESCRIPTION
# Motivation and Context
When the ticket was implemented, it said to send an UPDATE to field when ER > AR. The ticket was then amended, by whom and why is not known. The desired behaviour from product manager is _currently_ at time of writing, to only send CANCEL and never send UPDATE.

# What has changed
Removed UPDATE behaviour.

# How to test?
Don't bother. It's going to go through PO review anyway.

# Links
Trello: https://trello.com/c/C7cvRnRv