### PR TITLE
CCS Property Listed Shouldn't Use Default Rules

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/CCSPropertyListedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CCSPropertyListedService.java
@@ -11,7 +11,6 @@ import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
 import uk.gov.ons.census.casesvc.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.casesvc.model.entity.Case;
 import uk.gov.ons.census.casesvc.model.entity.EventType;
-import uk.gov.ons.census.casesvc.utility.FieldworkHelper;
 
 @Service
 public class CCSPropertyListedService {
@@ -38,7 +37,7 @@ public class CCSPropertyListedService {
 
     uacService.createUacQidLinkedToCCSCase(caze, ccsPropertyListedEvent.getEvent());
 
-    if (FieldworkHelper.shouldSendCaseToField(caze) && ccsProperty.isInterviewRequired()) {
+    if (ccsProperty.isInterviewRequired()) {
       caseService.saveCaseAndEmitCaseCreatedEvent(
           caze, buildMetadata(EventTypeDTO.CCS_ADDRESS_LISTED, ActionInstructionType.CREATE));
     }


### PR DESCRIPTION
# Motivation and Context
The default "don't send to field if..." rules are stopping CCS cases from going to field when they're missing certain data. Apparently we don't want that.

# What has changed
Removed the default rule check from CCS property listed.

# How to test?
Run the new unit test.

# Links
Trello: https://trello.com/c/YDlvY9oL