### PR TITLE
NEW_ADDRESS_REPORTED Event Being Logged In 2 Different Ways

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -87,7 +87,7 @@ public class NewAddressReportedService {
         "New Address reported",
         EventType.NEW_ADDRESS_REPORTED,
         newAddressEvent.getEvent(),
-        newAddressEvent.getPayload().getNewAddress(),
+        newAddressEvent.getPayload(),
         messageTimestamp);
   }
 

--- a/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/NewAddressReportedServiceTest.java
@@ -107,7 +107,7 @@ public class NewAddressReportedServiceTest {
             eq("New Address reported"),
             eq(EventType.NEW_ADDRESS_REPORTED),
             eq(eventDTO),
-            eq(newAddressEvent.getPayload().getNewAddress()),
+            eq(newAddressEvent.getPayload()),
             eq(expectedDateTime));
   }
 
@@ -168,7 +168,7 @@ public class NewAddressReportedServiceTest {
             eq("New Address reported"),
             eq(EventType.NEW_ADDRESS_REPORTED),
             eq(eventDTO),
-            eq(newAddressEvent.getPayload().getNewAddress()),
+            eq(newAddressEvent.getPayload()),
             eq(expectedDateTime));
   }
 
@@ -282,7 +282,7 @@ public class NewAddressReportedServiceTest {
             eq("New Address reported"),
             eq(EventType.NEW_ADDRESS_REPORTED),
             eq(eventDTO),
-            eq(newAddressEvent.getPayload().getNewAddress()),
+            eq(newAddressEvent.getPayload()),
             eq(expectedDateTime));
   }
 


### PR DESCRIPTION
# Motivation and Context
The MI team have noticed that we are logging the NEW_ADDRESS_REPORTED event in 2 different ways

# What has changed
Removed method of logging new address through getPayload().getNewAddress()
Fixed tests

# How to test?
Maven Clean Install
Check it builds and tests pass

# Links
https://trello.com/c/YjISHq44

https://github.com/ONSdigital/census-rm-case-processor/blob/master/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java#L90

https://github.com/ONSdigital/census-rm-case-processor/blob/master/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java#L131