### PR TITLE
Receipting Bug Fix When AR > ER

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/CaseReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CaseReceiptService.java
@@ -154,14 +154,9 @@ public class CaseReceiptService {
 
   BiFunction<Case, EventTypeDTO, Case> ceUnitRule =
       (caze, causeEventType) -> {
-        ActionInstructionType fieldInstruction = ActionInstructionType.UPDATE;
-
         Case lockedCase = incrementNoReceipt(caze);
 
-        if (hasCeUnitResponsesMetExpected(lockedCase)) {
-          lockedCase.setReceiptReceived(true);
-          fieldInstruction = ActionInstructionType.CANCEL;
-        }
+        ActionInstructionType fieldInstruction = decideWhatToSendToField(lockedCase);
 
         caseService.saveCaseAndEmitCaseUpdatedEvent(
             lockedCase, buildMetadata(causeEventType, fieldInstruction));
@@ -180,9 +175,27 @@ public class CaseReceiptService {
     private String formType;
   }
 
-  private boolean hasCeUnitResponsesMetExpected(Case caze) {
-    return caze.getCeExpectedCapacity() != null
-        && !caze.isReceiptReceived()
-        && caze.getCeActualResponses() >= caze.getCeExpectedCapacity();
+  private ActionInstructionType decideWhatToSendToField(Case caze) {
+
+    ActionInstructionType fieldInstruction = null;
+
+    // If case is already receipted we dont ned to tell Field about any more responses
+    if (!caze.isReceiptReceived()) {
+
+      // If we are still expecting some responses or we dont know how many responses we are due to
+      // receive, UPDATE field
+      if (caze.getCeExpectedCapacity() == null
+          || caze.getCeActualResponses() < caze.getCeExpectedCapacity()) {
+        fieldInstruction = ActionInstructionType.UPDATE;
+      } else {
+
+        // We now have all responses expected so tell Field to CANCEL the case and mark case as
+        // receipted
+        caze.setReceiptReceived(true);
+        fieldInstruction = ActionInstructionType.CANCEL;
+      }
+    }
+
+    return fieldInstruction;
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/service/CaseReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CaseReceiptService.java
@@ -156,7 +156,7 @@ public class CaseReceiptService {
       (caze, causeEventType) -> {
         Case lockedCase = incrementNoReceipt(caze);
 
-        ActionInstructionType fieldInstruction = decideWhatToSendToField(lockedCase);
+        ActionInstructionType fieldInstruction = decideWhatToSendToFieldAndWhetherToReceiptCase(lockedCase);
 
         caseService.saveCaseAndEmitCaseUpdatedEvent(
             lockedCase, buildMetadata(causeEventType, fieldInstruction));
@@ -175,7 +175,7 @@ public class CaseReceiptService {
     private String formType;
   }
 
-  private ActionInstructionType decideWhatToSendToField(Case caze) {
+  private ActionInstructionType decideWhatToSendToFieldAndWhetherToReceiptCase(Case caze) {
 
     ActionInstructionType fieldInstruction = null;
 

--- a/src/main/java/uk/gov/ons/census/casesvc/service/CaseReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CaseReceiptService.java
@@ -156,7 +156,8 @@ public class CaseReceiptService {
       (caze, causeEventType) -> {
         Case lockedCase = incrementNoReceipt(caze);
 
-        ActionInstructionType fieldInstruction = decideWhatToSendToFieldAndWhetherToReceiptCase(lockedCase);
+        ActionInstructionType fieldInstruction =
+            decideWhatToSendToFieldAndWhetherToReceiptCase(lockedCase);
 
         caseService.saveCaseAndEmitCaseUpdatedEvent(
             lockedCase, buildMetadata(causeEventType, fieldInstruction));

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTableTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTableTest.java
@@ -54,10 +54,12 @@ public class CaseReceiptServiceTableTest {
       {new Key("CE", "E", "Ind"), new Expectation("Y", "N", UPDATE)},
       {new Key("CE", "E", "CE1"), new Expectation("N", "Y", UPDATE)},
       {new Key("CE", "E", "Cont"), new Expectation("N", "N", null)},
-      {new Key("CE", "U", "HH"), new Expectation("Y", "Y AR >= ER", CANCEL)},
+      {new Key("CE", "U", "HH"), new Expectation("Y", "Y AR = ER", CANCEL)},
+      {new Key("CE", "U", "HH"), new Expectation("Y", "Y AR > ER", null)},
       {new Key("CE", "U", "HH"), new Expectation("Y", "N AR < ER", UPDATE)},
       {new Key("CE", "U", "HH"), new Expectation("Y", "N ER = null", UPDATE)},
-      {new Key("CE", "U", "Ind"), new Expectation("Y", "Y AR >= ER", CANCEL)},
+      {new Key("CE", "U", "Ind"), new Expectation("Y", "Y AR = ER", CANCEL)},
+      {new Key("CE", "U", "Ind"), new Expectation("Y", "Y AR > ER", null)},
       {new Key("CE", "U", "Ind"), new Expectation("Y", "N AR < ER", UPDATE)},
       {new Key("CE", "U", "Ind"), new Expectation("Y", "N ER = null", UPDATE)},
       {new Key("CE", "U", "CE1"), new Expectation("N", "N", null)},
@@ -85,7 +87,8 @@ public class CaseReceiptServiceTableTest {
         this.expectation.expectIncrement,
         this.expectation.expectedReceipt,
         this.expectation.expectedFieldInstruction,
-        this.expectation.expectedCapacity);
+        this.expectation.expectedCapacity,
+        this.expectation.expectedCaseAlreadyReceipted);
   }
 
   private void runReceiptingTest(
@@ -96,7 +99,8 @@ public class CaseReceiptServiceTableTest {
       boolean expectIncrement,
       boolean expectReceipt,
       ActionInstructionType expectedFieldInstruction,
-      Integer capacity) {
+      Integer capacity,
+      boolean receiptReceived) {
 
     CaseService caseService = mock(CaseService.class);
     CaseRepository caseRepository = mock(CaseRepository.class);
@@ -106,7 +110,7 @@ public class CaseReceiptServiceTableTest {
     caze.setCaseType(caseType);
     caze.setAddressLevel(addressLevel);
     caze.setCaseId(UUID.randomUUID());
-    caze.setReceiptReceived(false);
+    caze.setReceiptReceived(receiptReceived);
     caze.setCeActualResponses(0);
     caze.setTreatmentCode(treatmentCode);
     caze.setCeExpectedCapacity(capacity);
@@ -201,6 +205,7 @@ public class CaseReceiptServiceTableTest {
   }
 
   private static class Expectation {
+    public boolean expectedCaseAlreadyReceipted = false;
     boolean expectIncrement;
     boolean expectedReceipt;
     ActionInstructionType expectedFieldInstruction;
@@ -223,9 +228,15 @@ public class CaseReceiptServiceTableTest {
           expectedReceipt = false;
           break;
 
-        case "Y AR >= ER":
+        case "Y AR = ER":
           expectedReceipt = true;
           expectedCapacity = 1;
+          break;
+
+        case "Y AR > ER":
+          expectedCaseAlreadyReceipted = true;
+          expectedReceipt = true;
+          expectedCapacity = 0;
           break;
 
         case "N AR < ER":

--- a/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTableTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/CaseReceiptServiceTableTest.java
@@ -236,7 +236,6 @@ public class CaseReceiptServiceTableTest {
         case "Y AR > ER":
           expectedCaseAlreadyReceipted = true;
           expectedReceipt = true;
-          expectedCapacity = 0;
           break;
 
         case "N AR < ER":


### PR DESCRIPTION
# Motivation and Context
UPDATE message being sent to Field when AR > ER which shouldn't happen

# What has changed
Now follows these rules:

- AR < ER (Send UPDATE)
- AR = ER (Send CANCEL)
- AR > ER (Send nothing)
- ER = null (Send nothing)

# How to test?
Build image and run ATs
Load a sample and set the actualResponses/expected and check the variations send (or don't send) the correct output

# Links
https://trello.com/c/OEL6bfx5
https://collaborate2.ons.gov.uk/confluence/display/SDC/Receipting