### PR TITLE
Add notes to Invalid Address DTO so that we capture them

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/InvalidAddress.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/InvalidAddress.java
@@ -5,5 +5,6 @@ import lombok.Data;
 @Data
 public class InvalidAddress {
   private String reason;
+  private String notes;
   private CollectionCaseCaseId collectionCase;
 }


### PR DESCRIPTION
# Motivation and Context
Specification changed. Nobody told us.

# What has changed
Added `notes` part which was secretly added to [part of the] specification.

# How to test?
Don't even bother. It made it this far without testing finding the issue.

# Links
Trello: https://trello.com/c/TlC16P4g