### PR TITLE
Check if indiv case has already beeen created

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
@@ -314,6 +314,16 @@ public class CaseService {
     return cazeResult.get();
   }
 
+  public boolean checkIfCaseIdExists(UUID caseId) {
+    Optional<Case> cazeResult = caseRepository.findById(caseId);
+
+    if (cazeResult.isEmpty()) {
+      return false;
+    }
+
+    return true;
+  }
+
   public Case getCaseByCaseRef(long caseRef) {
     Optional<Case> caseOptional = caseRepository.findByCaseRef(caseRef);
 

--- a/src/main/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestService.java
@@ -115,7 +115,7 @@ public class FulfilmentRequestService {
         throw new RuntimeException("Individual fulfilment must have an individual case ID");
       }
 
-      if (caseService.getCaseByCaseId(fulfilmentRequestPayload.getIndividualCaseId()) != null) {
+      if (caseService.checkIfCaseIdExists(fulfilmentRequestPayload.getIndividualCaseId())) {
         throw new RuntimeException(
             "Individual case ID "
                 + fulfilmentRequestPayload.getIndividualCaseId()

--- a/src/main/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestService.java
@@ -115,6 +115,10 @@ public class FulfilmentRequestService {
         throw new RuntimeException("Individual fulfilment must have an individual case ID");
       }
 
+      if (caseService.getCaseByCaseId(fulfilmentRequestPayload.getIndividualCaseId()) != null) {
+        throw new RuntimeException("Duplicate message");
+      }
+
       Case individualResponseCase =
           caseService.prepareIndividualResponseCaseFromParentCase(
               caze, fulfilmentRequestPayload.getIndividualCaseId(), eventChannel);

--- a/src/main/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestService.java
@@ -116,7 +116,10 @@ public class FulfilmentRequestService {
       }
 
       if (caseService.getCaseByCaseId(fulfilmentRequestPayload.getIndividualCaseId()) != null) {
-        throw new RuntimeException("Duplicate message");
+        throw new RuntimeException(
+            "Individual case ID "
+                + fulfilmentRequestPayload.getIndividualCaseId()
+                + " already present in database");
       }
 
       Case individualResponseCase =

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/FulfilmentRequestReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/FulfilmentRequestReceiverIT.java
@@ -41,7 +41,6 @@ public class FulfilmentRequestReceiverIT {
   private static final String TEST_REPLACEMENT_FULFILMENT_CODE = "UACHHT1";
   private static final String TEST_INDIVIDUAL_RESPONSE_FULFILMENT_CODE = "P_OR_I1";
   private static final String TEST_INDIVIDUAL_RESPONSE_FULFILMENT_CODE_SMS = "UACIT1";
-  private static final UUID TEST_INDIVIDUAL_CASE_ID = UUID.randomUUID();
 
   @Value("${queueconfig.fulfilment-request-inbound-queue}")
   private String inboundQueue;
@@ -180,7 +179,8 @@ public class FulfilmentRequestReceiverIT {
 
       ResponseManagementEvent sourceEvent = getTestResponseManagementFulfilmentRequestedEvent();
       sourceEvent.getPayload().getFulfilmentRequest().setCaseId(TEST_CASE_ID);
-      sourceEvent.getPayload().getFulfilmentRequest().setIndividualCaseId(TEST_INDIVIDUAL_CASE_ID);
+      UUID testIndividualCaseId = UUID.randomUUID();
+      sourceEvent.getPayload().getFulfilmentRequest().setIndividualCaseId(testIndividualCaseId);
       sourceEvent
           .getPayload()
           .getFulfilmentRequest()
@@ -218,7 +218,7 @@ public class FulfilmentRequestReceiverIT {
       assertThat(cases.size()).isEqualTo(2);
 
       Case actualParentCase = caseRepository.findById(parentCase.getCaseId()).get();
-      Case actualChildCase = caseRepository.findById(TEST_INDIVIDUAL_CASE_ID).get();
+      Case actualChildCase = caseRepository.findById(testIndividualCaseId).get();
 
       checkIndividualFulfilmentChildCase(
           actualParentCase, actualChildCase, sourceEvent, resultEvent);
@@ -239,7 +239,8 @@ public class FulfilmentRequestReceiverIT {
 
       ResponseManagementEvent sourceEvent = getTestResponseManagementFulfilmentRequestedEvent();
       sourceEvent.getPayload().getFulfilmentRequest().setCaseId(TEST_CASE_ID);
-      sourceEvent.getPayload().getFulfilmentRequest().setIndividualCaseId(TEST_INDIVIDUAL_CASE_ID);
+      UUID testIndividualCaseId = UUID.randomUUID();
+      sourceEvent.getPayload().getFulfilmentRequest().setIndividualCaseId(testIndividualCaseId);
       sourceEvent
           .getPayload()
           .getFulfilmentRequest()
@@ -247,7 +248,7 @@ public class FulfilmentRequestReceiverIT {
       sourceEvent.getEvent().setTransactionId(UUID.randomUUID());
 
       UacCreatedDTO uacQidCreated = new UacCreatedDTO();
-      uacQidCreated.setCaseId(TEST_INDIVIDUAL_CASE_ID);
+      uacQidCreated.setCaseId(testIndividualCaseId);
       uacQidCreated.setQid("123");
       uacQidCreated.setUac(UUID.randomUUID().toString());
       sourceEvent.getPayload().getFulfilmentRequest().setUacQidCreated(uacQidCreated);
@@ -286,7 +287,7 @@ public class FulfilmentRequestReceiverIT {
         } else if (event.getEventType() == EventType.RM_UAC_CREATED) {
           PayloadDTO payload = convertJsonToObject(event.getEventPayload(), PayloadDTO.class);
           UacCreatedDTO actualUacCreated = payload.getFulfilmentRequest().getUacQidCreated();
-          assertThat(actualUacCreated.getCaseId()).isEqualTo(TEST_INDIVIDUAL_CASE_ID);
+          assertThat(actualUacCreated.getCaseId()).isEqualTo(testIndividualCaseId);
           assertThat(actualUacCreated.getQid()).isEqualTo("123");
           assertThat(actualUacCreated.getUac()).isEqualTo("REDACTED");
           remainingMatches--;
@@ -301,7 +302,7 @@ public class FulfilmentRequestReceiverIT {
       assertThat(cases.size()).isEqualTo(2);
 
       Case actualParentCase = caseRepository.findById(parentCase.getCaseId()).get();
-      Case actualChildCase = caseRepository.findById(TEST_INDIVIDUAL_CASE_ID).get();
+      Case actualChildCase = caseRepository.findById(testIndividualCaseId).get();
 
       checkIndividualFulfilmentChildCase(
           actualParentCase, actualChildCase, sourceEvent, resultEvent);
@@ -322,7 +323,8 @@ public class FulfilmentRequestReceiverIT {
 
       ResponseManagementEvent sourceEvent = getTestResponseManagementFulfilmentRequestedEvent();
       sourceEvent.getPayload().getFulfilmentRequest().setCaseId(TEST_CASE_ID);
-      sourceEvent.getPayload().getFulfilmentRequest().setIndividualCaseId(TEST_INDIVIDUAL_CASE_ID);
+      UUID testIndividualCaseId = UUID.randomUUID();
+      sourceEvent.getPayload().getFulfilmentRequest().setIndividualCaseId(testIndividualCaseId);
       sourceEvent
           .getPayload()
           .getFulfilmentRequest()
@@ -357,7 +359,7 @@ public class FulfilmentRequestReceiverIT {
       assertThat(cases.size()).isEqualTo(2);
 
       Case actualParentCase = caseRepository.findById(parentCase.getCaseId()).get();
-      Case actualChildCase = caseRepository.findById(TEST_INDIVIDUAL_CASE_ID).get();
+      Case actualChildCase = caseRepository.findById(testIndividualCaseId).get();
 
       checkIndividualFulfilmentChildCase(
           actualParentCase, actualChildCase, sourceEvent, resultEvent);

--- a/src/test/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestServiceTest.java
@@ -139,7 +139,7 @@ public class FulfilmentRequestServiceTest {
   }
 
   @Test
-  public void testGoodIndividualResponseFulfilmentDuplicateCaseIdBlowsUp() {
+  public void tesIndividualResponseFulfilmentDuplicateCaseIdBlowsUp() {
     testIndividualResponseCodeDuplicateIndivdualCaseId(HOUSEHOLD_INDIVIDUAL_RESPONSE_REQUEST_ENGLAND_PRINT);
   }
 

--- a/src/test/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestServiceTest.java
@@ -140,7 +140,8 @@ public class FulfilmentRequestServiceTest {
 
   @Test
   public void tesIndividualResponseFulfilmentDuplicateCaseIdBlowsUp() {
-    testIndividualResponseCodeDuplicateIndivdualCaseId(HOUSEHOLD_INDIVIDUAL_RESPONSE_REQUEST_ENGLAND_PRINT);
+    testIndividualResponseCodeDuplicateIndivdualCaseId(
+        HOUSEHOLD_INDIVIDUAL_RESPONSE_REQUEST_ENGLAND_PRINT);
   }
 
   @Test
@@ -294,9 +295,9 @@ public class FulfilmentRequestServiceTest {
       underTest.processFulfilmentRequest(managementEvent, messageTimestamp);
       fail("Expected exception not thrown");
     } catch (RuntimeException runtimeException) {
-      if (!runtimeException.getMessage().equals("Individual case ID "
-          + childCaseId
-          + " already present in database")) {
+      if (!runtimeException
+          .getMessage()
+          .equals("Individual case ID " + childCaseId + " already present in database")) {
         fail("Unexpected exception thrown");
       }
     }

--- a/src/test/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/service/FulfilmentRequestServiceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.census.casesvc.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 import static uk.gov.ons.census.casesvc.model.entity.EventType.FULFILMENT_REQUESTED;
 import static uk.gov.ons.census.casesvc.testutil.DataUtils.getRandomCase;
@@ -138,6 +139,11 @@ public class FulfilmentRequestServiceTest {
   }
 
   @Test
+  public void testGoodIndividualResponseFulfilmentDuplicateCaseIdBlowsUp() {
+    testIndividualResponseCodeDuplicateIndivdualCaseId(HOUSEHOLD_INDIVIDUAL_RESPONSE_REQUEST_ENGLAND_PRINT);
+  }
+
+  @Test
   public void testIndividalResponseFulfilmentRequestForNonHHIsJustLogged() {
     // Given
     Case parentCase = getRandomCase();
@@ -261,5 +267,51 @@ public class FulfilmentRequestServiceTest {
             eq(messageTimestamp));
 
     verify(caseService).emitCaseCreatedEvent(childCase);
+  }
+
+  private void testIndividualResponseCodeDuplicateIndivdualCaseId(String individualResponseCode) {
+    // Given
+    Case parentCase = getRandomCase();
+    parentCase.setUacQidLinks(new ArrayList<>());
+    parentCase.setEvents(new ArrayList<>());
+    parentCase.setCaseType("HH");
+
+    ResponseManagementEvent managementEvent = getTestResponseManagementEvent();
+    FulfilmentRequestDTO expectedFulfilmentRequest =
+        managementEvent.getPayload().getFulfilmentRequest();
+    expectedFulfilmentRequest.setCaseId(parentCase.getCaseId());
+    expectedFulfilmentRequest.setFulfilmentCode(individualResponseCode);
+    expectedFulfilmentRequest.setIndividualCaseId(UUID.randomUUID());
+    OffsetDateTime messageTimestamp = OffsetDateTime.now();
+
+    when(caseService.getCaseByCaseId(expectedFulfilmentRequest.getCaseId())).thenReturn(parentCase);
+    when(caseService.checkIfCaseIdExists(any())).thenReturn(true);
+
+    UUID childCaseId = managementEvent.getPayload().getFulfilmentRequest().getIndividualCaseId();
+
+    // when
+    try {
+      underTest.processFulfilmentRequest(managementEvent, messageTimestamp);
+      fail("Expected exception not thrown");
+    } catch (RuntimeException runtimeException) {
+      if (!runtimeException.getMessage().equals("Individual case ID "
+          + childCaseId
+          + " already present in database")) {
+        fail("Unexpected exception thrown");
+      }
+    }
+
+    // then
+    verify(eventLogger, never())
+        .logCaseEvent(
+            eq(parentCase),
+            eq(managementEvent.getEvent().getDateTime()),
+            eq("Fulfilment Request Received"),
+            eq(FULFILMENT_REQUESTED),
+            eq(managementEvent.getEvent()),
+            any(),
+            eq(messageTimestamp));
+
+    verify(caseService, never()).emitCaseCreatedEvent(any());
   }
 }


### PR DESCRIPTION
# Motivation and Context
There's a bug when we process the same individual fulfilment message more than once, then Hibernate converts the INSERT of new case into an UPDATE, and mangles the data (deletes created timestamp and sets secret sequence number to zero, and then of course, sets case ref to be the same one every single time).

# What has changed
Check if individual case ID already exists; throw exception if it does.

# How to test?
Send an individiual fulfilment. Check that the case has been created. Send the same message AGAIN. This should result in "mangled" case data as described.

# Links
Trello: https://trello.com/c/cH8Gw1x2