### PR TITLE
HOTFIX: Fix other places where dupe message might mess up cases

### DIFF
--- a/src/main/java/uk/gov/ons/census/casesvc/service/AddressTypeChangeService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/AddressTypeChangeService.java
@@ -76,6 +76,11 @@ public class AddressTypeChangeService {
       OffsetDateTime messageTimestamp,
       AddressTypeChange addressTypeChange,
       Case oldCase) {
+    if (caseService.checkIfCaseIdExists(addressTypeChange.getNewCaseId())) {
+      throw new RuntimeException(
+          "New case ID " + addressTypeChange.getNewCaseId() + " already present in database");
+    }
+
     Case newCase = new Case();
     newCase.setSkeleton(true);
     newCase.setCaseId(addressTypeChange.getNewCaseId());

--- a/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/CaseService.java
@@ -106,6 +106,10 @@ public class CaseService {
   }
 
   public Case createCCSCase(UUID caseId, SampleUnitDTO sampleUnit) {
+    if (checkIfCaseIdExists(caseId)) {
+      throw new RuntimeException("CCS case ID " + caseId + " already present in database");
+    }
+
     Case caze = mapperFacade.map(sampleUnit, Case.class);
     caze.setCaseType(sampleUnit.getAddressType());
     caze.setCaseId(caseId);
@@ -315,13 +319,7 @@ public class CaseService {
   }
 
   public boolean checkIfCaseIdExists(UUID caseId) {
-    Optional<Case> cazeResult = caseRepository.findById(caseId);
-
-    if (cazeResult.isEmpty()) {
-      return false;
-    }
-
-    return true;
+    return caseRepository.existsById(caseId);
   }
 
   public Case getCaseByCaseRef(long caseRef) {

--- a/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/service/NewAddressReportedService.java
@@ -151,6 +151,11 @@ public class NewAddressReportedService {
   }
 
   private Case createSkeletonCase(CollectionCase collectionCase) {
+    if (caseService.checkIfCaseIdExists(collectionCase.getId())) {
+      throw new RuntimeException(
+          "New case ID " + collectionCase.getId() + " already present in database");
+    }
+
     Case skeletonCase = new Case();
     skeletonCase.setSkeleton(true);
     skeletonCase.setCaseId(collectionCase.getId());
@@ -218,6 +223,10 @@ public class NewAddressReportedService {
   }
 
   private Case buildCaseFromSourceCaseAndEvent(CollectionCase newCollectionCase, Case sourceCase) {
+    if (caseService.checkIfCaseIdExists(newCollectionCase.getId())) {
+      throw new RuntimeException(
+          "New case ID " + newCollectionCase.getId() + " already present in database");
+    }
 
     Case newCase = new Case();
 


### PR DESCRIPTION
# Motivation and Context
We have a known issue when we are provided with a supposedly new and unique case ID in a message, but the message gets delivered: in this instance, it's likely that we will end up creating a second case with a secretSequenceNumber of zero, and a case ref which has already been used. This behaviour is an annoying aspect of Hibernate trying to be helpful when you ask it to save an entity to the database, and you provide the ID (primary key) of an _existing_ row.

# What has changed
Fixed all the places where this kind of bug might occur (although very unlikely to happen).

# How to test?
Run the ATs. Zero regression.

# Links
Trello: https://trello.com/c/6XXXsrvm