### PR TITLE
Switch to Megalinter Formatters flavour

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -41,7 +41,7 @@ jobs:
 
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.io/latest/flavors/
-        uses: oxsecurity/megalinter@v8
+        uses: oxsecurity/megalinter/flavors/formatters@v8
 
         id: ml
 

--- a/Makefile
+++ b/Makefile
@@ -33,14 +33,14 @@ megalint:  ## Run the mega-linter.
 	$(DOCKER) run --platform linux/amd64 --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock:rw \
 		-v $(shell pwd):/tmp/lint:rw \
-		oxsecurity/megalinter:v8
+		oxsecurity/megalinter-formatters:v8
 
 megalint-fix:  ## Run the mega-linter and attempt to auto fix any issues.
 	$(DOCKER) run --platform linux/amd64 --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock:rw \
 		-v $(shell pwd):/tmp/lint:rw \
 		-e APPLY_FIXES=all \
-		oxsecurity/megalinter:v8
+		oxsecurity/megalinter-formatters:v8
 
 clean_megalint: ## Clean the temporary files.
 	rm -rf megalinter-reports


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

We were using the default Megalinter image which includes all linters. We use the "formatters" provided flavour which is a much smaller image, reducing the download and improving its performance.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Switch to "formatters" Megalinter flavour

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run `make megalint` locally, check the action is passing.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://megalinter.io/latest/flavors/

