### PR TITLE
CN-39 reintroduce QID types

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseprocessor/cache/UacQidCache.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/cache/UacQidCache.java
@@ -8,6 +8,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -17,6 +19,9 @@ import uk.gov.ons.census.caseprocessor.model.dto.UacQidDTO;
 
 @Component
 public class UacQidCache {
+
+  private static final Logger log = LoggerFactory.getLogger(UacQidCache.class);
+
   private final UacQidServiceClient uacQidServiceClient;
 
   @Value("${uacservice.uacqid-cache-min}")
@@ -82,6 +87,10 @@ public class UacQidCache {
         return;
       }
     }
+    log.atInfo()
+        .setMessage("Topping up UAC-QID cache")
+        .addKeyValue("questionnaireType", questionnaireType)
+        .log();
 
     executor.execute(
         () -> {

--- a/src/main/java/uk/gov/ons/census/caseprocessor/cache/UacQidCache.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/cache/UacQidCache.java
@@ -30,8 +30,9 @@ public class UacQidCache {
 
   private static final Executor executor = Executors.newFixedThreadPool(8);
 
-  private Map<Integer, BlockingQueue<UacQidDTO>> uacQidLinkQueueMap = new ConcurrentHashMap<>();
-  private Set<Integer> isToppingUpQueue = ConcurrentHashMap.newKeySet();
+  private final Map<Integer, BlockingQueue<UacQidDTO>> uacQidLinkQueueMap =
+      new ConcurrentHashMap<>();
+  private final Set<Integer> isToppingUpQueue = ConcurrentHashMap.newKeySet();
 
   public UacQidCache(UacQidServiceClient uacQidServiceClient) {
     this.uacQidServiceClient = uacQidServiceClient;

--- a/src/main/java/uk/gov/ons/census/caseprocessor/cache/UacQidCache.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/cache/UacQidCache.java
@@ -1,6 +1,9 @@
 package uk.gov.ons.census.caseprocessor.cache;
 
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -27,24 +30,27 @@ public class UacQidCache {
 
   private static final Executor executor = Executors.newFixedThreadPool(8);
 
-  private BlockingQueue<UacQidDTO> uacQidLinkCache = new LinkedBlockingDeque<>();
-  private boolean isToppingUpCache = false;
-  private final Object lock = new Object();
+  private Map<Integer, BlockingQueue<UacQidDTO>> uacQidLinkQueueMap = new ConcurrentHashMap<>();
+  private Set<Integer> isToppingUpQueue = ConcurrentHashMap.newKeySet();
 
   public UacQidCache(UacQidServiceClient uacQidServiceClient) {
     this.uacQidServiceClient = uacQidServiceClient;
   }
 
-  public UacQidDTO getUacQidPair() {
+  public UacQidDTO getUacQidPair(int questionnaireType) {
+    uacQidLinkQueueMap.computeIfAbsent(questionnaireType, key -> new LinkedBlockingDeque<>());
+
     try {
-      topUpCache();
-      UacQidDTO uacQidDTO = uacQidLinkCache.poll(uacQidGetTimout, TimeUnit.SECONDS);
+      topUpQueue(questionnaireType);
+      UacQidDTO uacQidDTO =
+          uacQidLinkQueueMap.get(questionnaireType).poll(uacQidGetTimout, TimeUnit.SECONDS);
 
       if (uacQidDTO == null) {
         // The cache topper upper is executed in a separate thread, which can fail if uacqid api
         // down
         // So check we get a non null result otherwise throw a RunTimeException to re-enqueue msg
-        throw new RuntimeException("Timeout getting UacQidDTO");
+        throw new RuntimeException(
+            "Timeout getting UacQidDTO for questionnaireType :" + questionnaireType);
       }
 
       // Put the UAC-QID back into the cache if the transaction rolls back
@@ -54,7 +60,7 @@ public class UacQidCache {
               @Override
               public void afterCompletion(int status) {
                 if (status == STATUS_ROLLED_BACK) {
-                  uacQidLinkCache.add(uacQidDTO);
+                  uacQidLinkQueueMap.get(questionnaireType).add(uacQidDTO);
                 }
               }
             });
@@ -66,23 +72,25 @@ public class UacQidCache {
     }
   }
 
-  private void topUpCache() {
-    // We use synchronised on an empty object instead of the isToppingUpCache bool because it's
-    // bad practice to use it on a boolean literal.
-    synchronized (lock) {
-      if (!isToppingUpCache && uacQidLinkCache.size() < cacheMin) {
-        isToppingUpCache = true;
+  private void topUpQueue(int questionnaireType) {
+    synchronized (isToppingUpQueue) {
+      if (!isToppingUpQueue.contains(questionnaireType)
+          && uacQidLinkQueueMap.get(questionnaireType).size() < cacheMin) {
+        isToppingUpQueue.add(questionnaireType);
       } else {
         return;
       }
-      executor.execute(
-          () -> {
-            try {
-              uacQidLinkCache.addAll(uacQidServiceClient.getUacQids(cacheFetch));
-            } finally {
-              isToppingUpCache = false;
-            }
-          });
     }
+
+    executor.execute(
+        () -> {
+          try {
+            uacQidLinkQueueMap
+                .get(questionnaireType)
+                .addAll(uacQidServiceClient.getUacQids(questionnaireType, cacheFetch));
+          } finally {
+            isToppingUpQueue.remove(questionnaireType);
+          }
+        });
   }
 }

--- a/src/main/java/uk/gov/ons/census/caseprocessor/client/UacQidServiceClient.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/client/UacQidServiceClient.java
@@ -23,22 +23,25 @@ public class UacQidServiceClient {
   @Value("${uacservice.connection.port}")
   private String port;
 
-  public List<UacQidDTO> getUacQids(int numberToCreate) {
+  public List<UacQidDTO> getUacQids(int questionnaireType, int numberToCreate) {
     RestTemplate restTemplate = new RestTemplate();
 
-    UriComponents uriComponents = createUriComponents(numberToCreate, "multiple_qids");
+    UriComponents uriComponents =
+        createUriComponents(questionnaireType, numberToCreate, "multiple_qids");
     ResponseEntity<UacQidDTO[]> responseEntity =
         restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, null, UacQidDTO[].class);
 
     return Arrays.asList(responseEntity.getBody());
   }
 
-  private UriComponents createUriComponents(int numberToCreate, String path) {
+  private UriComponents createUriComponents(
+      int questionnaireType, int numberToCreate, String path) {
     return UriComponentsBuilder.newInstance()
         .scheme(scheme)
         .host(host)
         .port(port)
         .path(path)
+        .queryParam("questionnaireType", questionnaireType)
         .queryParam("numberToCreate", numberToCreate)
         .build()
         .encode();

--- a/src/main/java/uk/gov/ons/census/caseprocessor/service/ExportFileProcessor.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/service/ExportFileProcessor.java
@@ -48,6 +48,7 @@ public class ExportFileProcessor {
   public void process(FulfilmentToProcess fulfilmentToProcess) {
     ExportFileTemplate exportFileTemplate = fulfilmentToProcess.getExportFileTemplate();
 
+    // TODO Pass in questionnaireType from exportFileTemplate when it's been added.
     processExportFileRow(
         exportFileTemplate.getTemplate(),
         fulfilmentToProcess.getCaze(),
@@ -166,7 +167,9 @@ public class ExportFileProcessor {
   private UacQidDTO getUacQidForCase(
       Case caze, UUID correlationId, String originatingUser, Object metadata) {
 
-    UacQidDTO uacQidDTO = uacQidCache.getUacQidPair();
+    // TODO: Currently the questionnaireType is hardcoded to 1. This will need to be based on the
+    // questionnaireType from the export file template.
+    UacQidDTO uacQidDTO = uacQidCache.getUacQidPair(1);
     UacQidLink uacQidLink = new UacQidLink();
     uacQidLink.setId(UUID.randomUUID());
     uacQidLink.setQid(uacQidDTO.getQid());

--- a/src/test/java/uk/gov/ons/census/caseprocessor/cache/UacQidCacheTest.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/cache/UacQidCacheTest.java
@@ -38,9 +38,9 @@ public class UacQidCacheTest {
     uacQidDTO1.setQid("54321");
     listUacDtos.add(uacQidDTO2);
 
-    when(uacQidServiceClient.getUacQids(2)).thenReturn(listUacDtos);
+    when(uacQidServiceClient.getUacQids(1, 2)).thenReturn(listUacDtos);
 
-    UacQidDTO actualUacDto = underTest.getUacQidPair();
+    UacQidDTO actualUacDto = underTest.getUacQidPair(1);
     assertThat(actualUacDto.getQid()).isEqualTo(uacQidDTO1.getQid());
   }
 
@@ -52,10 +52,12 @@ public class UacQidCacheTest {
 
     List<UacQidDTO> listUacDtos = new ArrayList<>();
 
-    when(uacQidServiceClient.getUacQids(2)).thenReturn(listUacDtos);
+    when(uacQidServiceClient.getUacQids(1, 2)).thenReturn(listUacDtos);
 
-    RuntimeException thrown = assertThrows(RuntimeException.class, () -> underTest.getUacQidPair());
+    RuntimeException thrown =
+        assertThrows(RuntimeException.class, () -> underTest.getUacQidPair(1));
 
-    Assertions.assertThat(thrown.getMessage()).isEqualTo("Timeout getting UacQidDTO");
+    Assertions.assertThat(thrown.getMessage())
+        .isEqualTo("Timeout getting UacQidDTO for questionnaireType :1");
   }
 }

--- a/src/test/java/uk/gov/ons/census/caseprocessor/messaging/EmailFulfilmentReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/messaging/EmailFulfilmentReceiverIT.java
@@ -63,7 +63,7 @@ class EmailFulfilmentReceiverIT {
   void testEmailFulfilment() throws Exception {
     // Given
     // Get a new UAC QID pair
-    List<UacQidDTO> uacQidDTOList = uacQidServiceClient.getUacQids(1);
+    List<UacQidDTO> uacQidDTOList = uacQidServiceClient.getUacQids(1, 1);
     UacQidDTO emailUacQid = uacQidDTOList.get(0);
 
     // Create the case

--- a/src/test/java/uk/gov/ons/census/caseprocessor/messaging/SmsFulfilmentReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/messaging/SmsFulfilmentReceiverIT.java
@@ -63,7 +63,7 @@ class SmsFulfilmentReceiverIT {
   void testSmsFulfilment() throws Exception {
     // Given
     // Get a new UAC QID pair
-    List<UacQidDTO> uacQidDTOList = uacQidServiceClient.getUacQids(1);
+    List<UacQidDTO> uacQidDTOList = uacQidServiceClient.getUacQids(1, 1);
     UacQidDTO smsUacQid = uacQidDTOList.get(0);
 
     // Create the case

--- a/src/test/java/uk/gov/ons/census/caseprocessor/service/ExportFileProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/service/ExportFileProcessorTest.java
@@ -68,7 +68,7 @@ class ExportFileProcessorTest {
     uacQidDTO.setUac(UAC);
     uacQidDTO.setQid(QID);
 
-    when(uacQidCache.getUacQidPair()).thenReturn(uacQidDTO);
+    when(uacQidCache.getUacQidPair(anyInt())).thenReturn(uacQidDTO);
 
     // When
     underTest.processExportFileRow(
@@ -141,7 +141,7 @@ class ExportFileProcessorTest {
     uacQidDTO.setUac(UAC);
     uacQidDTO.setQid(QID);
 
-    when(uacQidCache.getUacQidPair()).thenReturn(uacQidDTO);
+    when(uacQidCache.getUacQidPair(anyInt())).thenReturn(uacQidDTO);
 
     // When
     underTest.process(fulfilmentToProcess);
@@ -207,7 +207,7 @@ class ExportFileProcessorTest {
     uacQidDTO.setUac(UAC);
     uacQidDTO.setQid(QID);
 
-    when(uacQidCache.getUacQidPair()).thenReturn(uacQidDTO);
+    when(uacQidCache.getUacQidPair(anyInt())).thenReturn(uacQidDTO);
 
     // When
     underTest.process(fulfilmentToProcess);
@@ -271,7 +271,7 @@ class ExportFileProcessorTest {
     uacQidDTO.setUac(UAC);
     uacQidDTO.setQid(QID);
 
-    when(uacQidCache.getUacQidPair()).thenReturn(uacQidDTO);
+    when(uacQidCache.getUacQidPair(anyInt())).thenReturn(uacQidDTO);
 
     // When
     underTest.process(fulfilmentToProcess);


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For Census we want to reintroduce QID Types into the codebase. This was previously removed in SRM since there was no need for different questionnaire types. 
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Updated UAC/QID cache to use the questionnaire type as a cache for multiple QIDS. This is using the previous code that was removed.
- Hardcoded exportfileprocessor to input a questionnaire type of `1`. Added a TODO to fix this on a future ticket
- Updated tests
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run with the UAC QID PR that's attached on the Jira ticket.
- Run an exportfile action rule and confirm all the UAC QIDs in the export file start with `01`
- You could always debug the code to confirm the cache mapping is working as expected.  It's copied from this old PR that removed it: https://github.com/ONSdigital/ssdc-rm-caseprocessor/pull/232/changes
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Jira](https://officefornationalstatistics.atlassian.net/browse/CN-39)
# Screenshots (if appropriate):
