### PR TITLE
Pass in questionnaire type to get uac/qid calls

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@ONSdigital/ons-template-admins
+@ONSdigital/census-response-management

--- a/src/main/java/uk/gov/ons/census/caseprocessor/schedule/ActionRuleTriggerer.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/schedule/ActionRuleTriggerer.java
@@ -66,7 +66,7 @@ public class ActionRuleTriggerer {
                           "__uac__".equals(templateValue) || "__qid__".equals(templateValue));
 
           if (requiresUacQid && questionnaireType == null) {
-            throw new IllegalStateException(
+            throw new IllegalArgumentException(
                 "Export file template contains __uac__ or __qid__ but questionnaire type is null");
           }
         }
@@ -101,7 +101,7 @@ public class ActionRuleTriggerer {
         triggeredActionRule.setHasTriggered(true);
         actionRuleRepository.save(triggeredActionRule);
 
-      } catch (IllegalStateException e) {
+      } catch (IllegalArgumentException e) {
         // This exception will occur if we have an EXPORT_FILE action rule that wants an uac or qid
         // but the questionnaire type on the template is null. In this case, the rule will never
         // work and should be aborted. The Action Rule will be marked as errored
@@ -109,7 +109,7 @@ public class ActionRuleTriggerer {
         String errorMessage =
             "ActionRule "
                 + triggeredActionRule.getId()
-                + " failed with an IllegalStateException,"
+                + " failed with an IllegalArgumentException,"
                 + " it has been marked Triggered to stop it running until it is fixed."
                 + " Exception Message: "
                 + e.getMessage();

--- a/src/main/java/uk/gov/ons/census/caseprocessor/schedule/ActionRuleTriggerer.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/schedule/ActionRuleTriggerer.java
@@ -3,6 +3,7 @@ package uk.gov.ons.census.caseprocessor.schedule;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.OffsetDateTime;
+import java.util.Arrays;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,6 +13,8 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.census.caseprocessor.model.repository.ActionRuleRepository;
 import uk.gov.ons.census.common.model.entity.ActionRule;
 import uk.gov.ons.census.common.model.entity.ActionRuleStatus;
+import uk.gov.ons.census.common.model.entity.ActionRuleType;
+import uk.gov.ons.census.common.model.entity.ExportFileTemplate;
 
 @Component
 public class ActionRuleTriggerer {
@@ -53,6 +56,21 @@ public class ActionRuleTriggerer {
         actionRuleProcessor.updateActionRuleStatus(
             triggeredActionRule, ActionRuleStatus.SELECTING_CASES);
 
+        if (triggeredActionRule.getType() == ActionRuleType.EXPORT_FILE) {
+          ExportFileTemplate exportFileTemplate = triggeredActionRule.getExportFileTemplate();
+          Integer questionnaireType = exportFileTemplate.getQuestionnaireType();
+          boolean requiresUacQid =
+              Arrays.stream(exportFileTemplate.getTemplate())
+                  .anyMatch(
+                      templateValue ->
+                          "__uac__".equals(templateValue) || "__qid__".equals(templateValue));
+
+          if (requiresUacQid && questionnaireType == null) {
+            throw new IllegalStateException(
+                "Export file template contains __uac__ or __qid__ but questionnaire type is null");
+          }
+        }
+
         // This call will block for the duration of selecting and enqueuing the cases
         actionRuleProcessor.processTriggeredActionRule(triggeredActionRule);
 
@@ -83,6 +101,26 @@ public class ActionRuleTriggerer {
         triggeredActionRule.setHasTriggered(true);
         actionRuleRepository.save(triggeredActionRule);
 
+      } catch (IllegalStateException e) {
+        // This exception will occur if we have an EXPORT_FILE action rule that wants an uac or qid
+        // but the questionnaire type on the template is null. In this case, the rule will never
+        // work and should be aborted. The Action Rule will be marked as errored
+        // to stop it failing indefinitely.
+        String errorMessage =
+            "ActionRule "
+                + triggeredActionRule.getId()
+                + " failed with an IllegalStateException,"
+                + " it has been marked Triggered to stop it running until it is fixed."
+                + " Exception Message: "
+                + e.getMessage();
+        log.atError()
+            .setMessage(errorMessage)
+            .addKeyValue("hostName", hostName)
+            .addKeyValue("id", triggeredActionRule.getId())
+            .log();
+        triggeredActionRule.setActionRuleStatus(ActionRuleStatus.ERRORED);
+        triggeredActionRule.setHasTriggered(true);
+        actionRuleRepository.save(triggeredActionRule);
       } catch (Exception e) {
         // Log any unexpected/unknown errors, but allow the transaction to rollback so that it
         // can be retried, in the case the errors are transient.

--- a/src/main/java/uk/gov/ons/census/caseprocessor/service/CaseToProcessProcessor.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/service/CaseToProcessProcessor.java
@@ -37,6 +37,7 @@ public class CaseToProcessProcessor {
             exportFileTemplate.getExportFileDestination(),
             caseToProcess.getActionRule().getId(),
             null,
+            exportFileTemplate.getQuestionnaireType(),
             caseToProcess.getActionRule().getUacMetadata());
         break;
       case DEACTIVATE_UAC:

--- a/src/main/java/uk/gov/ons/census/caseprocessor/service/ExportFileProcessor.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/service/ExportFileProcessor.java
@@ -48,7 +48,6 @@ public class ExportFileProcessor {
   public void process(FulfilmentToProcess fulfilmentToProcess) {
     ExportFileTemplate exportFileTemplate = fulfilmentToProcess.getExportFileTemplate();
 
-    // TODO Pass in questionnaireType from exportFileTemplate when it's been added.
     processExportFileRow(
         exportFileTemplate.getTemplate(),
         fulfilmentToProcess.getCaze(),
@@ -59,6 +58,7 @@ public class ExportFileProcessor {
         fulfilmentToProcess.getCorrelationId(),
         fulfilmentToProcess.getOriginatingUser(),
         fulfilmentToProcess.getUacMetadata(),
+        exportFileTemplate.getQuestionnaireType(),
         fulfilmentToProcess.getPersonalisation());
   }
 
@@ -71,6 +71,7 @@ public class ExportFileProcessor {
       String exportFileDestination,
       UUID correlationId,
       String originatingUser,
+      Integer questionnaireType,
       Object uacMetadata) {
     // Supply empty personalisation if the caller does not
     processExportFileRow(
@@ -83,6 +84,7 @@ public class ExportFileProcessor {
         correlationId,
         originatingUser,
         uacMetadata,
+        questionnaireType,
         Map.of());
   }
 
@@ -96,6 +98,7 @@ public class ExportFileProcessor {
       UUID correlationId,
       String originatingUser,
       Object uacMetadata,
+      Integer questionnaireType,
       Map<String, String> personalisation) {
 
     UacQidDTO uacQidDTO = null;
@@ -110,14 +113,18 @@ public class ExportFileProcessor {
           break;
         case "__uac__":
           if (uacQidDTO == null) {
-            uacQidDTO = getUacQidForCase(caze, correlationId, originatingUser, uacMetadata);
+            uacQidDTO =
+                getUacQidForCase(
+                    caze, correlationId, originatingUser, uacMetadata, questionnaireType);
           }
 
           rowStrings[i] = uacQidDTO.getUac();
           break;
         case "__qid__":
           if (uacQidDTO == null) {
-            uacQidDTO = getUacQidForCase(caze, correlationId, originatingUser, uacMetadata);
+            uacQidDTO =
+                getUacQidForCase(
+                    caze, correlationId, originatingUser, uacMetadata, questionnaireType);
           }
 
           rowStrings[i] = uacQidDTO.getQid();
@@ -165,11 +172,13 @@ public class ExportFileProcessor {
   }
 
   private UacQidDTO getUacQidForCase(
-      Case caze, UUID correlationId, String originatingUser, Object metadata) {
+      Case caze,
+      UUID correlationId,
+      String originatingUser,
+      Object metadata,
+      Integer questionnaireType) {
 
-    // TODO: Currently the questionnaireType is hardcoded to 1. This will need to be based on the
-    // questionnaireType from the export file template.
-    UacQidDTO uacQidDTO = uacQidCache.getUacQidPair(1);
+    UacQidDTO uacQidDTO = uacQidCache.getUacQidPair(questionnaireType);
     UacQidLink uacQidLink = new UacQidLink();
     uacQidLink.setId(UUID.randomUUID());
     uacQidLink.setQid(uacQidDTO.getQid());

--- a/src/test/java/uk/gov/ons/census/caseprocessor/schedule/ActionRuleIT.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/schedule/ActionRuleIT.java
@@ -166,6 +166,7 @@ class ActionRuleIT {
     exportFileTemplate.setPackCode(PACK_CODE);
     exportFileTemplate.setExportFileDestination(EXPORT_FILE_DESTINATION);
     exportFileTemplate.setDescription("Test description");
+    exportFileTemplate.setQuestionnaireType(1);
     return exportFileTemplateRepository.saveAndFlush(exportFileTemplate);
   }
 

--- a/src/test/java/uk/gov/ons/census/caseprocessor/schedule/ActionRuleIT.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/schedule/ActionRuleIT.java
@@ -82,7 +82,7 @@ class ActionRuleIT {
         pubsubHelper.pubsubProjectListen(OUTBOUND_UAC_SUBSCRIPTION, EventDTO.class)) {
       // Given
       Case caze = junkDataHelper.setupJunkCase();
-      ExportFileTemplate exportFileTemplate = setUpExportFileTemplate();
+      ExportFileTemplate exportFileTemplate = setUpExportFileTemplate(1);
 
       // When
       setUpActionRule(
@@ -108,6 +108,62 @@ class ActionRuleIT {
       assertThat(rme.getHeader().getTopic()).isEqualTo(uacUpdateTopic);
       assertThat(rme.getPayload().getUacUpdate().getCaseId()).isEqualTo(caze.getId());
     }
+  }
+
+  @Test
+  void testExportFileRuleNoUacQid() throws Exception {
+    try (QueueSpy<EventDTO> outboundUacQueue =
+        pubsubHelper.pubsubProjectListen(OUTBOUND_UAC_SUBSCRIPTION, EventDTO.class)) {
+      // Given
+      Case caze = junkDataHelper.setupJunkCase();
+      ExportFileTemplate exportFileTemplate = setUpExportFileTemplateNoUac();
+
+      // When
+      setUpActionRule(
+          ActionRuleType.EXPORT_FILE,
+          caze.getCollectionExercise(),
+          exportFileTemplate,
+          null,
+          null,
+          null);
+      EventDTO rme = outboundUacQueue.getQueue().poll(20, TimeUnit.SECONDS);
+      List<ExportFileRow> exportFileRows = exportFileRowRepository.findAll();
+      ExportFileRow exportFileRow = exportFileRows.get(0);
+
+      // Then
+      assertThat(exportFileRow).isNotNull();
+      assertThat(exportFileRow.getBatchQuantity()).isEqualTo(1);
+      assertThat(exportFileRow.getPackCode()).isEqualTo(PACK_CODE);
+      assertThat(exportFileRow.getExportFileDestination()).isEqualTo(EXPORT_FILE_DESTINATION);
+      assertThat(exportFileRow.getRow())
+          .startsWith("\"" + caze.getCaseRef() + "\",\"" + caze.getAddressLine1() + "\"");
+    }
+  }
+
+  @Test
+  void testUacTemplateWithNoQidType(CapturedOutput output) throws Exception {
+    Case caze = junkDataHelper.setupJunkCase();
+    ExportFileTemplate exportFileTemplate = setUpExportFileTemplate(null);
+
+    // When
+    ActionRule actionRule =
+        setUpActionRule(
+            ActionRuleType.EXPORT_FILE,
+            caze.getCollectionExercise(),
+            exportFileTemplate,
+            null,
+            null,
+            "NoneExistantColumn = 'Throw A SQL Exception");
+
+    actionRulePoller.getTriggeredActionRule(actionRule.getId());
+
+    String expectedErrorMessage =
+        "ActionRule "
+            + actionRule.getId()
+            + " failed with an IllegalStateException,"
+            + " it has been marked Triggered to stop it running until it is fixed.";
+
+    assertThat(output).contains(expectedErrorMessage);
   }
 
   @Test
@@ -137,7 +193,7 @@ class ActionRuleIT {
   @Test
   void testBadSQLIsHandled(CapturedOutput output) throws Exception {
     Case caze = junkDataHelper.setupJunkCase();
-    ExportFileTemplate exportFileTemplate = setUpExportFileTemplate();
+    ExportFileTemplate exportFileTemplate = setUpExportFileTemplate(1);
 
     // When
     ActionRule actionRule =
@@ -160,13 +216,23 @@ class ActionRuleIT {
     assertThat(output).contains(expectedErrorMessage);
   }
 
-  private ExportFileTemplate setUpExportFileTemplate() {
+  private ExportFileTemplate setUpExportFileTemplate(Integer questionnaireType) {
     ExportFileTemplate exportFileTemplate = new ExportFileTemplate();
     exportFileTemplate.setTemplate(new String[] {"__caseref__", "ADDRESS_LINE1", "__uac__"});
     exportFileTemplate.setPackCode(PACK_CODE);
     exportFileTemplate.setExportFileDestination(EXPORT_FILE_DESTINATION);
     exportFileTemplate.setDescription("Test description");
-    exportFileTemplate.setQuestionnaireType(1);
+    exportFileTemplate.setQuestionnaireType(questionnaireType);
+    return exportFileTemplateRepository.saveAndFlush(exportFileTemplate);
+  }
+
+  private ExportFileTemplate setUpExportFileTemplateNoUac() {
+    ExportFileTemplate exportFileTemplate = new ExportFileTemplate();
+    exportFileTemplate.setTemplate(new String[] {"__caseref__", "ADDRESS_LINE1"});
+    exportFileTemplate.setPackCode(PACK_CODE);
+    exportFileTemplate.setExportFileDestination(EXPORT_FILE_DESTINATION);
+    exportFileTemplate.setDescription("Test description");
+    exportFileTemplate.setQuestionnaireType(null);
     return exportFileTemplateRepository.saveAndFlush(exportFileTemplate);
   }
 

--- a/src/test/java/uk/gov/ons/census/caseprocessor/schedule/ActionRuleIT.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/schedule/ActionRuleIT.java
@@ -160,7 +160,7 @@ class ActionRuleIT {
     String expectedErrorMessage =
         "ActionRule "
             + actionRule.getId()
-            + " failed with an IllegalStateException,"
+            + " failed with an IllegalArgumentException,"
             + " it has been marked Triggered to stop it running until it is fixed.";
 
     assertThat(output).contains(expectedErrorMessage);

--- a/src/test/java/uk/gov/ons/census/caseprocessor/schedule/ActionRuleTriggererTest.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/schedule/ActionRuleTriggererTest.java
@@ -16,6 +16,8 @@ import org.springframework.jdbc.BadSqlGrammarException;
 import uk.gov.ons.census.caseprocessor.model.repository.ActionRuleRepository;
 import uk.gov.ons.census.common.model.entity.ActionRule;
 import uk.gov.ons.census.common.model.entity.ActionRuleStatus;
+import uk.gov.ons.census.common.model.entity.ActionRuleType;
+import uk.gov.ons.census.common.model.entity.ExportFileTemplate;
 
 class ActionRuleTriggererTest {
   private final ActionRuleRepository actionRuleRepository = mock(ActionRuleRepository.class);
@@ -61,6 +63,36 @@ class ActionRuleTriggererTest {
     verify(actionRuleProcessor, times(50))
         .updateActionRuleStatus(any(ActionRule.class), eq(ActionRuleStatus.SELECTING_CASES));
     verify(actionRuleProcessor, times(50)).processTriggeredActionRule(any(ActionRule.class));
+  }
+
+  @Test
+  void testNullQuestionnaireTypeButUacTemplate() throws UnknownHostException {
+    // Given
+    ExportFileTemplate exportFileTemplate = new ExportFileTemplate();
+    exportFileTemplate.setTemplate(new String[] {"__caseref__", "ADDRESS_LINE1", "__uac__"});
+    exportFileTemplate.setPackCode("Packcode");
+    exportFileTemplate.setExportFileDestination("test-export-file-destination");
+    exportFileTemplate.setDescription("Test description");
+    exportFileTemplate.setQuestionnaireType(null);
+
+    ActionRule actionRule = new ActionRule();
+    actionRule.setHasTriggered(false);
+    actionRule.setType(ActionRuleType.EXPORT_FILE);
+    actionRule.setExportFileTemplate(exportFileTemplate);
+
+    when(actionRuleRepository.findByTriggerDateTimeBeforeAndHasTriggeredIsFalse(
+            any(OffsetDateTime.class)))
+        .thenReturn(Collections.singletonList(actionRule));
+
+    // When
+    ActionRuleTriggerer underTest =
+        new ActionRuleTriggerer(actionRuleRepository, actionRuleProcessor);
+    underTest.triggerAllActionRules();
+
+    // Then
+    assertThat(actionRule.isHasTriggered()).isTrue();
+    assertThat(actionRule.getActionRuleStatus()).isEqualTo(ActionRuleStatus.ERRORED);
+    verify(actionRuleRepository).save(actionRule); // Verify it was saved
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/caseprocessor/schedule/FulfilmentIT.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/schedule/FulfilmentIT.java
@@ -75,6 +75,7 @@ class FulfilmentIT {
       exportFileTemplate.setExportFileDestination(EXPORT_FILE_DESTINATION);
       exportFileTemplate.setTemplate(new String[] {"__caseref__", "ADDRESS_LINE1", "__uac__"});
       exportFileTemplate.setDescription("Test description");
+      exportFileTemplate.setQuestionnaireType(1);
       exportFileTemplateRepository.saveAndFlush(exportFileTemplate);
 
       Case caze = junkDataHelper.setupJunkCase();

--- a/src/test/java/uk/gov/ons/census/caseprocessor/service/CaseToProcessProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/service/CaseToProcessProcessorTest.java
@@ -33,6 +33,7 @@ class CaseToProcessProcessorTest {
     exportFileTemplate.setTemplate(new String[] {"__caseref__", "__uac__", "foo"});
     exportFileTemplate.setPackCode("test pack code");
     exportFileTemplate.setExportFileDestination("test export file destination");
+    exportFileTemplate.setQuestionnaireType(1);
 
     ActionRule actionRule = new ActionRule();
     actionRule.setId(UUID.randomUUID());
@@ -57,6 +58,7 @@ class CaseToProcessProcessorTest {
             exportFileTemplate.getExportFileDestination(),
             actionRule.getId(),
             null,
+            1,
             actionRule.getUacMetadata());
   }
 

--- a/src/test/java/uk/gov/ons/census/caseprocessor/service/ExportFileProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/service/ExportFileProcessorTest.java
@@ -80,6 +80,7 @@ class ExportFileProcessorTest {
         exportFileTemplate.getExportFileDestination(),
         actionRule.getId(),
         null,
+        1,
         actionRule.getUacMetadata());
 
     //    // Then
@@ -124,6 +125,7 @@ class ExportFileProcessorTest {
     exportFileTemplate.setPackCode(PACK_CODE);
     exportFileTemplate.setExportFileDestination(EXPORT_FILE_DESTINATION);
     exportFileTemplate.setTemplate(new String[] {"__caseref__", "__uac__", "UPRN"});
+    exportFileTemplate.setQuestionnaireType(1);
 
     Case caze = new Case();
     CaseFieldsHelper.setDummyCaseFields(caze);
@@ -189,6 +191,7 @@ class ExportFileProcessorTest {
     exportFileTemplate.setExportFileDestination(EXPORT_FILE_DESTINATION);
     exportFileTemplate.setTemplate(
         new String[] {"__caseref__", "__uac__", "__request__.foo", "__request__.spam"});
+    exportFileTemplate.setQuestionnaireType(1);
 
     Case caze = new Case();
     CaseFieldsHelper.setDummyCaseFields(caze);
@@ -253,6 +256,7 @@ class ExportFileProcessorTest {
     exportFileTemplate.setPackCode(PACK_CODE);
     exportFileTemplate.setExportFileDestination(EXPORT_FILE_DESTINATION);
     exportFileTemplate.setTemplate(new String[] {"__caseref__", "__uac__", "__request__.foo"});
+    exportFileTemplate.setQuestionnaireType(1);
 
     Case caze = new Case();
     CaseFieldsHelper.setDummyCaseFields(caze);

--- a/src/test/java/uk/gov/ons/census/caseprocessor/service/ExportFileProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/service/ExportFileProcessorTest.java
@@ -119,6 +119,66 @@ class ExportFileProcessorTest {
   }
 
   @Test
+  void testProcessExportFileRowNoUacQid() {
+    // Given
+    Case caze = new Case();
+
+    CaseFieldsHelper.setDummyCaseFields(caze);
+
+    ExportFileTemplate exportFileTemplate = new ExportFileTemplate();
+    exportFileTemplate.setTemplate(new String[] {"__caseref__", "UPRN"});
+    exportFileTemplate.setPackCode(PACK_CODE);
+    exportFileTemplate.setExportFileDestination(EXPORT_FILE_DESTINATION);
+
+    ActionRule actionRule = new ActionRule();
+    actionRule.setId(UUID.randomUUID());
+    actionRule.setType(ActionRuleType.EXPORT_FILE);
+    actionRule.setExportFileTemplate(exportFileTemplate);
+    actionRule.setUacMetadata(TEST_UAC_METADATA);
+
+    CaseToProcess caseToProcess = new CaseToProcess();
+    caseToProcess.setActionRule(actionRule);
+    caseToProcess.setCaze(caze);
+    caseToProcess.setBatchId(UUID.fromString("6a127d58-c1cb-489c-a3f5-72014a0c32d6"));
+
+    // When
+    underTest.processExportFileRow(
+        exportFileTemplate.getTemplate(),
+        caze,
+        caseToProcess.getBatchId(),
+        caseToProcess.getBatchQuantity(),
+        exportFileTemplate.getPackCode(),
+        exportFileTemplate.getExportFileDestination(),
+        actionRule.getId(),
+        null,
+        null,
+        actionRule.getUacMetadata());
+
+    //    // Then
+    ArgumentCaptor<ExportFileRow> exportFileRowArgumentCaptor =
+        ArgumentCaptor.forClass(ExportFileRow.class);
+    verify(exportFileRowRepository).save(exportFileRowArgumentCaptor.capture());
+    ExportFileRow actualExportFileRow = exportFileRowArgumentCaptor.getValue();
+    assertThat(actualExportFileRow.getPackCode()).isEqualTo(PACK_CODE);
+    assertThat(actualExportFileRow.getExportFileDestination()).isEqualTo(EXPORT_FILE_DESTINATION);
+    assertThat(actualExportFileRow.getRow()).isEqualTo("\"123\",\"" + caze.getUprn() + "\"");
+
+    ArgumentCaptor<EventDTO> eventCaptor = ArgumentCaptor.forClass(EventDTO.class);
+    verify(eventLogger)
+        .logCaseEvent(
+            eq(caze),
+            eq("Export file generated with pack code " + PACK_CODE),
+            eq(EventType.EXPORT_FILE),
+            eventCaptor.capture(),
+            any(OffsetDateTime.class));
+
+    EventDTO actualEvent = eventCaptor.getValue();
+    Assertions.assertThat(actualEvent.getHeader().getCorrelationId()).isEqualTo(actionRule.getId());
+    Assertions.assertThat(actualEvent.getPayload().getExportFile().getPackCode())
+        .isEqualTo(PACK_CODE);
+  }
+
+  @Test
   void testProcessFulfilment() {
     // Given
     ExportFileTemplate exportFileTemplate = new ExportFileTemplate();

--- a/src/test/java/uk/gov/ons/census/caseprocessor/testutils/JunkDataHelper.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/testutils/JunkDataHelper.java
@@ -91,6 +91,7 @@ public class JunkDataHelper {
     junkExportFileTemplate.setPackCode("JUNK");
     junkExportFileTemplate.setTemplate(template);
     junkExportFileTemplate.setDescription("junk");
+    junkExportFileTemplate.setQuestionnaireType(1);
     exportFileTemplateRepository.saveAndFlush(junkExportFileTemplate);
     return junkExportFileTemplate;
   }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We've added qid type to the templates that we're using. This allows means that any case attached to the template will use that qid type for an export file or sms. For case processor, we need to pass in the export file templates/sms templates qid type so it can call the uacqid service with the correct type so it receives the correct version.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Pass in qid types to uacqid calls from export file generation
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run `make build` and all tests should pass
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Jira](https://officefornationalstatistics.atlassian.net/browse/CN-42)
