### PR TITLE
CN-120 Adding messageType to event header

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseprocessor/model/dto/EventHeaderDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/model/dto/EventHeaderDTO.java
@@ -3,6 +3,7 @@ package uk.gov.ons.census.caseprocessor.model.dto;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import lombok.Data;
+import uk.gov.ons.census.common.model.entity.EventType;
 
 @Data
 public class EventHeaderDTO {
@@ -14,4 +15,5 @@ public class EventHeaderDTO {
   private UUID messageId;
   private UUID correlationId;
   private String originatingUser;
+  private EventType messageType;
 }

--- a/src/main/java/uk/gov/ons/census/caseprocessor/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/service/CaseService.java
@@ -16,6 +16,7 @@ import uk.gov.ons.census.caseprocessor.model.repository.CaseRepository;
 import uk.gov.ons.census.caseprocessor.utils.CaseFieldMapper;
 import uk.gov.ons.census.caseprocessor.utils.EventHelper;
 import uk.gov.ons.census.common.model.entity.Case;
+import uk.gov.ons.census.common.model.entity.EventType;
 
 @Service
 public class CaseService {
@@ -44,7 +45,8 @@ public class CaseService {
 
   public void emitCaseUpdate(Case caze, UUID correlationId, String originatingUser) {
     EventHeaderDTO eventHeader =
-        EventHelper.createEventDTO(caseUpdateTopic, correlationId, originatingUser);
+        EventHelper.createEventDTO(
+            caseUpdateTopic, correlationId, originatingUser, EventType.CASE_UPDATE);
 
     EventDTO event = prepareCaseEvent(caze, eventHeader);
 

--- a/src/main/java/uk/gov/ons/census/caseprocessor/service/DeactivateUacProcessor.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/service/DeactivateUacProcessor.java
@@ -13,6 +13,7 @@ import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
 import uk.gov.ons.census.caseprocessor.model.dto.EventHeaderDTO;
 import uk.gov.ons.census.caseprocessor.model.dto.PayloadDTO;
 import uk.gov.ons.census.common.model.entity.Case;
+import uk.gov.ons.census.common.model.entity.EventType;
 import uk.gov.ons.census.common.model.entity.UacQidLink;
 
 @Component
@@ -42,7 +43,8 @@ public class DeactivateUacProcessor {
   }
 
   private EventDTO prepareDeactivateUacEvent(UacQidLink uacQidLink, UUID correlationId) {
-    EventHeaderDTO eventHeader = createEventDTO(deactivateUacTopic, correlationId, null);
+    EventHeaderDTO eventHeader =
+        createEventDTO(deactivateUacTopic, correlationId, null, EventType.DEACTIVATE_UAC);
 
     EventDTO event = new EventDTO();
     event.setHeader(eventHeader);

--- a/src/main/java/uk/gov/ons/census/caseprocessor/service/UacService.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/service/UacService.java
@@ -15,6 +15,7 @@ import uk.gov.ons.census.caseprocessor.model.repository.UacQidLinkRepository;
 import uk.gov.ons.census.caseprocessor.utils.EventHelper;
 import uk.gov.ons.census.caseprocessor.utils.HashHelper;
 import uk.gov.ons.census.common.model.entity.Case;
+import uk.gov.ons.census.common.model.entity.EventType;
 import uk.gov.ons.census.common.model.entity.UacQidLink;
 
 @Service
@@ -38,7 +39,8 @@ public class UacService {
     UacQidLink savedUacQidLink = uacQidLinkRepository.save(uacQidLink);
 
     EventHeaderDTO eventHeader =
-        EventHelper.createEventDTO(uacUpdateTopic, correlationId, originatingUser);
+        EventHelper.createEventDTO(
+            uacUpdateTopic, correlationId, originatingUser, EventType.UAC_UPDATE);
 
     UacUpdateDTO uac = new UacUpdateDTO();
     uac.setQid(savedUacQidLink.getQid());

--- a/src/main/java/uk/gov/ons/census/caseprocessor/utils/EventHelper.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/utils/EventHelper.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
 import uk.gov.ons.census.caseprocessor.model.dto.EventHeaderDTO;
 import uk.gov.ons.census.caseprocessor.model.dto.PayloadDTO;
+import uk.gov.ons.census.common.model.entity.EventType;
 
 public class EventHelper {
 
@@ -18,7 +19,8 @@ public class EventHelper {
       String eventChannel,
       String eventSource,
       UUID correlationId,
-      String originatingUser) {
+      String originatingUser,
+      EventType eventType) {
     EventHeaderDTO eventHeader = new EventHeaderDTO();
 
     eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
@@ -29,13 +31,20 @@ public class EventHelper {
     eventHeader.setCorrelationId(correlationId);
     eventHeader.setOriginatingUser(originatingUser);
     eventHeader.setTopic(topic);
+    eventHeader.setMessageType(eventType);
 
     return eventHeader;
   }
 
   public static EventHeaderDTO createEventDTO(
       String topic, UUID correlationId, String originatingUser) {
-    return createEventDTO(topic, EVENT_CHANNEL, EVENT_SOURCE, correlationId, originatingUser);
+    return createEventDTO(topic, EVENT_CHANNEL, EVENT_SOURCE, correlationId, originatingUser, null);
+  }
+
+  public static EventHeaderDTO createEventDTO(
+      String topic, UUID correlationId, String originatingUser, EventType eventType) {
+    return createEventDTO(
+        topic, EVENT_CHANNEL, EVENT_SOURCE, correlationId, originatingUser, eventType);
   }
 
   public static EventDTO getDummyEvent(UUID correlationId, String originatingUser) {

--- a/src/test/java/uk/gov/ons/census/caseprocessor/messaging/DeactivateUacReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/messaging/DeactivateUacReceiverIT.java
@@ -64,6 +64,7 @@ public class DeactivateUacReceiverIT {
       EventHeaderDTO eventHeader = new EventHeaderDTO();
       eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
       eventHeader.setTopic(deactivateUacTopic);
+      eventHeader.setMessageType(EventType.DEACTIVATE_UAC);
       junkDataHelper.junkify(eventHeader);
       event.setHeader(eventHeader);
 

--- a/src/test/java/uk/gov/ons/census/caseprocessor/messaging/EmailFulfilmentReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/messaging/EmailFulfilmentReceiverIT.java
@@ -30,6 +30,7 @@ import uk.gov.ons.census.caseprocessor.testutils.PubsubHelper;
 import uk.gov.ons.census.caseprocessor.testutils.QueueSpy;
 import uk.gov.ons.census.caseprocessor.utils.HashHelper;
 import uk.gov.ons.census.common.model.entity.Case;
+import uk.gov.ons.census.common.model.entity.EventType;
 import uk.gov.ons.census.common.model.entity.UacQidLink;
 
 @ContextConfiguration
@@ -84,6 +85,7 @@ class EmailFulfilmentReceiverIT {
     EventHeaderDTO eventHeader = new EventHeaderDTO();
     eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     eventHeader.setTopic(EMAIL_CONFIRMATION_TOPIC);
+    eventHeader.setMessageType(EventType.EMAIL_FULFILMENT);
     junkDataHelper.junkify(eventHeader);
 
     EventDTO event = new EventDTO();

--- a/src/test/java/uk/gov/ons/census/caseprocessor/messaging/EqLaunchReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/messaging/EqLaunchReceiverIT.java
@@ -28,6 +28,7 @@ import uk.gov.ons.census.caseprocessor.testutils.PubsubHelper;
 import uk.gov.ons.census.caseprocessor.testutils.QueueSpy;
 import uk.gov.ons.census.common.model.entity.Case;
 import uk.gov.ons.census.common.model.entity.Event;
+import uk.gov.ons.census.common.model.entity.EventType;
 import uk.gov.ons.census.common.model.entity.UacQidLink;
 
 @ContextConfiguration
@@ -76,6 +77,7 @@ public class EqLaunchReceiverIT {
       EventHeaderDTO eventHeader = new EventHeaderDTO();
       eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
       eventHeader.setTopic(INBOUND_TOPIC);
+      eventHeader.setMessageType(EventType.EQ_LAUNCH);
       junkDataHelper.junkify(eventHeader);
       eqLaunchedEvent.setHeader(eventHeader);
 

--- a/src/test/java/uk/gov/ons/census/caseprocessor/messaging/InvalidCaseReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/messaging/InvalidCaseReceiverIT.java
@@ -69,6 +69,7 @@ public class InvalidCaseReceiverIT {
       EventHeaderDTO eventHeader = new EventHeaderDTO();
       eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
       eventHeader.setTopic(INBOUND_INVALID_CASE_TOPIC);
+      eventHeader.setMessageType(EventType.INVALID_CASE);
       junkDataHelper.junkify(eventHeader);
       event.setHeader(eventHeader);
 

--- a/src/test/java/uk/gov/ons/census/caseprocessor/messaging/NewCaseReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/messaging/NewCaseReceiverIT.java
@@ -63,6 +63,7 @@ public class NewCaseReceiverIT {
       EventHeaderDTO eventHeader = new EventHeaderDTO();
       eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
       eventHeader.setTopic(NEW_CASE_TOPIC);
+      eventHeader.setMessageType(EventType.NEW_CASE);
       junkDataHelper.junkify(eventHeader);
       event.setHeader(eventHeader);
 

--- a/src/test/java/uk/gov/ons/census/caseprocessor/messaging/PrintFulfilmentReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/messaging/PrintFulfilmentReceiverIT.java
@@ -29,6 +29,7 @@ import uk.gov.ons.census.caseprocessor.testutils.DeleteDataHelper;
 import uk.gov.ons.census.caseprocessor.testutils.JunkDataHelper;
 import uk.gov.ons.census.caseprocessor.testutils.PubsubHelper;
 import uk.gov.ons.census.common.model.entity.Case;
+import uk.gov.ons.census.common.model.entity.EventType;
 import uk.gov.ons.census.common.model.entity.ExportFileTemplate;
 import uk.gov.ons.census.common.model.entity.FulfilmentToProcess;
 
@@ -68,6 +69,7 @@ class PrintFulfilmentReceiverIT {
     junkDataHelper.junkify(printFulfilmentEvent.getHeader());
     printFulfilmentEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     printFulfilmentEvent.getHeader().setTopic(PRINT_FULFILMENT_TOPIC);
+    printFulfilmentEvent.getHeader().setMessageType(EventType.PRINT_FULFILMENT);
     printFulfilmentEvent.setPayload(new PayloadDTO());
     printFulfilmentEvent.getPayload().setPrintFulfilment(new PrintFulfilmentDTO());
     printFulfilmentEvent.getPayload().getPrintFulfilment().setCaseId(caze.getId());
@@ -118,6 +120,7 @@ class PrintFulfilmentReceiverIT {
     junkDataHelper.junkify(printFulfilmentEvent.getHeader());
     printFulfilmentEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     printFulfilmentEvent.getHeader().setTopic(PRINT_FULFILMENT_TOPIC);
+    printFulfilmentEvent.getHeader().setMessageType(EventType.PRINT_FULFILMENT);
     printFulfilmentEvent.setPayload(new PayloadDTO());
     printFulfilmentEvent.getPayload().setPrintFulfilment(new PrintFulfilmentDTO());
     printFulfilmentEvent.getPayload().getPrintFulfilment().setCaseId(caze.getId());

--- a/src/test/java/uk/gov/ons/census/caseprocessor/messaging/ReceiptReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/messaging/ReceiptReceiverIT.java
@@ -85,6 +85,7 @@ public class ReceiptReceiverIT {
       EventHeaderDTO eventHeader = new EventHeaderDTO();
       eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
       eventHeader.setTopic(INBOUND_RECEIPT_TOPIC);
+      eventHeader.setMessageType(EventType.RECEIPT);
       junkDataHelper.junkify(eventHeader);
       event.setHeader(eventHeader);
 

--- a/src/test/java/uk/gov/ons/census/caseprocessor/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/messaging/RefusalReceiverIT.java
@@ -69,6 +69,7 @@ class RefusalReceiverIT {
       EventHeaderDTO eventHeader = new EventHeaderDTO();
       eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
       eventHeader.setTopic(INBOUND_REFUSAL_TOPIC);
+      eventHeader.setMessageType(EventType.RECEIPT);
       junkDataHelper.junkify(eventHeader);
       event.setHeader(eventHeader);
 

--- a/src/test/java/uk/gov/ons/census/caseprocessor/messaging/SmsFulfilmentReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/messaging/SmsFulfilmentReceiverIT.java
@@ -30,6 +30,7 @@ import uk.gov.ons.census.caseprocessor.testutils.PubsubHelper;
 import uk.gov.ons.census.caseprocessor.testutils.QueueSpy;
 import uk.gov.ons.census.caseprocessor.utils.HashHelper;
 import uk.gov.ons.census.common.model.entity.Case;
+import uk.gov.ons.census.common.model.entity.EventType;
 import uk.gov.ons.census.common.model.entity.UacQidLink;
 
 @ContextConfiguration
@@ -84,6 +85,7 @@ class SmsFulfilmentReceiverIT {
     EventHeaderDTO eventHeader = new EventHeaderDTO();
     eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
     eventHeader.setTopic(SMS_CONFIRMATION_TOPIC);
+    eventHeader.setMessageType(EventType.SMS_FULFILMENT);
     junkDataHelper.junkify(eventHeader);
 
     EventDTO event = new EventDTO();

--- a/src/test/java/uk/gov/ons/census/caseprocessor/utils/EventHelperTest.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/utils/EventHelperTest.java
@@ -31,7 +31,7 @@ public class EventHelperTest {
   public void testCreateEventDTOWithEventTypeChannelAndSource() {
     EventHeaderDTO eventHeader =
         EventHelper.createEventDTO(
-            "TOPIC", "CHANNEL", "SOURCE", TEST_CORRELATION_ID, TEST_ORIGINATING_USER);
+            "TOPIC", "CHANNEL", "SOURCE", TEST_CORRELATION_ID, TEST_ORIGINATING_USER, null);
 
     assertThat(eventHeader.getVersion()).isEqualTo(OUTBOUND_EVENT_SCHEMA_VERSION);
     assertThat(eventHeader.getCorrelationId()).isEqualTo(TEST_CORRELATION_ID);


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To be able to use the event type to determine what to do in the EQlaunch receiver, we need to add the messageType to the event header to match the event dictionary . Since this field is available, I've update the case update and uac update emitters to have a type. 
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Updated eventheader to include messageType
- Update events to include it where it sends an event out of case processor
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Build and run with other branches
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Jira](https://officefornationalstatistics.atlassian.net/browse/CN-120)
# Screenshots (if appropriate):
