### PR TITLE
CN-121 Update Dockerhub image we use to use the GCR Miror instead

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: docker://onsdigital/github-pr-label-checker:v1.6.13
+      - uses: docker://mirror.gcr.io/onsdigital/github-pr-label-checker:v1.6.13
         with:
           one_of: breaking change,feature,patch
           none_of: do not merge,work in progress

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre-alpine
+FROM mirror.gcr.io/library/eclipse-temurin:21-jre-alpine
 
 ARG JAR_FILE=census-rm-caseprocessor*.jar
 CMD ["/opt/java/openjdk/bin/java", "-jar", "/opt/census-rm-caseprocessor.jar"]


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
switch all of our images currently sourced from Dockerhub to explicitly pull from the GCR mirror using the image URI prefix mirror.gcr.io
# What has changed
<!--- What code changes has been made -->
change in dockerfile and github action script
<!--- Has there been any refactoring -->
No refactoring
<!--- What tests have been written -->
Existing test used to validate the change

# How to test?
<!--- Describe in detail how you tested your changes. -->
make build - should run successfully
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
No automated test in scope

# Links
<!--- Add any links to issues (trello, github issues) -->
https://officefornationalstatistics.atlassian.net/browse/CN-121
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
