### PR TITLE
Cn 94 mark case as receipted when linked qid receipted and receipt qid linked

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseprocessor/messaging/ReceiptReceiver.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/messaging/ReceiptReceiver.java
@@ -1,56 +1,27 @@
 package uk.gov.ons.census.caseprocessor.messaging;
 
-import static uk.gov.ons.census.caseprocessor.utils.JsonHelper.convertJsonBytesToEvent;
-
 import static uk.gov.ons.census.caseprocessor.utils.MessageDateHelper.getMessageTimeStamp;
 
 import java.time.OffsetDateTime;
-
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
-import uk.gov.ons.census.caseprocessor.logging.EventLogger;
-import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
 import uk.gov.ons.census.caseprocessor.service.QidReceiptService;
-import uk.gov.ons.census.caseprocessor.service.UacService;
-import uk.gov.ons.census.common.model.entity.EventType;
-import uk.gov.ons.census.common.model.entity.UacQidLink;
-
-
 
 @MessageEndpoint
 public class ReceiptReceiver {
-    private final QidReceiptService qidReceiptService;
+  private final QidReceiptService qidReceiptService;
 
-    public ReceiptReceiver(QidReceiptService qidReceiptService) {
-        this.qidReceiptService = qidReceiptService;
-    }
+  public ReceiptReceiver(QidReceiptService qidReceiptService) {
+    this.qidReceiptService = qidReceiptService;
+  }
 
   @Transactional(isolation = Isolation.REPEATABLE_READ)
   @ServiceActivator(inputChannel = "receiptInputChannel", adviceChain = "retryAdvice")
   public void receiveMessage(Message<byte[]> message) {
-
-      OffsetDateTime messageTimestamp = getMessageTimeStamp(message);
-      EventDTO event = convertJsonBytesToEvent(message.getPayload());
-      qidReceiptService.processReceipt(event.getPayload(), messageTimestamp);
-
-//    EventDTO event = convertJsonBytesToEvent(message.getPayload());
-//
-//    UacQidLink uacQidLink = uacService.findByQid(event.getPayload().getReceipt().getQid());
-//
-//    if (!uacQidLink.isReceiptReceived()) {
-//      uacQidLink.setActive(false);
-//      uacQidLink.setReceiptReceived(true);
-//
-//      uacQidLink =
-//          uacService.saveAndEmitUacUpdateEvent(
-//              uacQidLink,
-//              event.getHeader().getCorrelationId(),
-//              event.getHeader().getOriginatingUser());
-    }
-
-    //eventLogger.logUacQidEvent(uacQidLink, "Receipt received", EventType.RECEIPT, event, message);
+    OffsetDateTime messageTimestamp = getMessageTimeStamp(message);
+    qidReceiptService.processReceipt(message, messageTimestamp);
   }
-
+}

--- a/src/main/java/uk/gov/ons/census/caseprocessor/messaging/ReceiptReceiver.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/messaging/ReceiptReceiver.java
@@ -36,7 +36,8 @@ public class ReceiptReceiver {
 
     UacQidLink uacQidLink = qidReceiptService.processReceiptEvent(receiptEvent);
 
-    eventLogger.logUacQidEvent(uacQidLink, "Receipt received", EventType.RECEIPT, receiptEvent, message);
+    eventLogger.logUacQidEvent(
+        uacQidLink, "Receipt received", EventType.RECEIPT, receiptEvent, message);
   }
 
   private boolean processEvent(EventDTO receiptEvent) {
@@ -50,7 +51,8 @@ public class ReceiptReceiver {
       default:
         // Should never get here
         throw new RuntimeException(
-            String.format("Event Type '%s' is invalid on this topic", eventHeader.getMessageType()));
+            String.format(
+                "Event Type '%s' is invalid on this topic", eventHeader.getMessageType()));
     }
   }
 }

--- a/src/main/java/uk/gov/ons/census/caseprocessor/messaging/ReceiptReceiver.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/messaging/ReceiptReceiver.java
@@ -2,6 +2,10 @@ package uk.gov.ons.census.caseprocessor.messaging;
 
 import static uk.gov.ons.census.caseprocessor.utils.JsonHelper.convertJsonBytesToEvent;
 
+import static uk.gov.ons.census.caseprocessor.utils.MessageDateHelper.getMessageTimeStamp;
+
+import java.time.OffsetDateTime;
+
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;
@@ -9,38 +13,44 @@ import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.census.caseprocessor.logging.EventLogger;
 import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
+import uk.gov.ons.census.caseprocessor.service.QidReceiptService;
 import uk.gov.ons.census.caseprocessor.service.UacService;
 import uk.gov.ons.census.common.model.entity.EventType;
 import uk.gov.ons.census.common.model.entity.UacQidLink;
 
+
+
 @MessageEndpoint
 public class ReceiptReceiver {
-  private final UacService uacService;
-  private final EventLogger eventLogger;
+    private final QidReceiptService qidReceiptService;
 
-  public ReceiptReceiver(UacService uacService, EventLogger eventLogger) {
-    this.uacService = uacService;
-    this.eventLogger = eventLogger;
-  }
+    public ReceiptReceiver(QidReceiptService qidReceiptService) {
+        this.qidReceiptService = qidReceiptService;
+    }
 
   @Transactional(isolation = Isolation.REPEATABLE_READ)
   @ServiceActivator(inputChannel = "receiptInputChannel", adviceChain = "retryAdvice")
   public void receiveMessage(Message<byte[]> message) {
-    EventDTO event = convertJsonBytesToEvent(message.getPayload());
 
-    UacQidLink uacQidLink = uacService.findByQid(event.getPayload().getReceipt().getQid());
+      OffsetDateTime messageTimestamp = getMessageTimeStamp(message);
+      EventDTO event = convertJsonBytesToEvent(message.getPayload());
+      qidReceiptService.processReceipt(event.getPayload(), messageTimestamp);
 
-    if (!uacQidLink.isReceiptReceived()) {
-      uacQidLink.setActive(false);
-      uacQidLink.setReceiptReceived(true);
-
-      uacQidLink =
-          uacService.saveAndEmitUacUpdateEvent(
-              uacQidLink,
-              event.getHeader().getCorrelationId(),
-              event.getHeader().getOriginatingUser());
+//    EventDTO event = convertJsonBytesToEvent(message.getPayload());
+//
+//    UacQidLink uacQidLink = uacService.findByQid(event.getPayload().getReceipt().getQid());
+//
+//    if (!uacQidLink.isReceiptReceived()) {
+//      uacQidLink.setActive(false);
+//      uacQidLink.setReceiptReceived(true);
+//
+//      uacQidLink =
+//          uacService.saveAndEmitUacUpdateEvent(
+//              uacQidLink,
+//              event.getHeader().getCorrelationId(),
+//              event.getHeader().getOriginatingUser());
     }
 
-    eventLogger.logUacQidEvent(uacQidLink, "Receipt received", EventType.RECEIPT, event, message);
+    //eventLogger.logUacQidEvent(uacQidLink, "Receipt received", EventType.RECEIPT, event, message);
   }
-}
+

--- a/src/main/java/uk/gov/ons/census/caseprocessor/messaging/ReceiptReceiver.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/messaging/ReceiptReceiver.java
@@ -1,27 +1,56 @@
 package uk.gov.ons.census.caseprocessor.messaging;
 
-import static uk.gov.ons.census.caseprocessor.utils.MessageDateHelper.getMessageTimeStamp;
+import static uk.gov.ons.census.caseprocessor.utils.JsonHelper.convertJsonBytesToEvent;
 
-import java.time.OffsetDateTime;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.ons.census.caseprocessor.logging.EventLogger;
+import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
+import uk.gov.ons.census.caseprocessor.model.dto.EventHeaderDTO;
 import uk.gov.ons.census.caseprocessor.service.QidReceiptService;
+import uk.gov.ons.census.common.model.entity.EventType;
+import uk.gov.ons.census.common.model.entity.UacQidLink;
 
 @MessageEndpoint
 public class ReceiptReceiver {
+  private final EventLogger eventLogger;
   private final QidReceiptService qidReceiptService;
 
-  public ReceiptReceiver(QidReceiptService qidReceiptService) {
+  public ReceiptReceiver(EventLogger eventLogger, QidReceiptService qidReceiptService) {
+    this.eventLogger = eventLogger;
     this.qidReceiptService = qidReceiptService;
   }
 
   @Transactional(isolation = Isolation.REPEATABLE_READ)
   @ServiceActivator(inputChannel = "receiptInputChannel", adviceChain = "retryAdvice")
   public void receiveMessage(Message<byte[]> message) {
-    OffsetDateTime messageTimestamp = getMessageTimeStamp(message);
-    qidReceiptService.processReceipt(message, messageTimestamp);
+
+    EventDTO receiptEvent = convertJsonBytesToEvent(message.getPayload());
+
+    if (!processEvent(receiptEvent)) {
+      return;
+    }
+
+    UacQidLink uacQidLink = qidReceiptService.processReceiptEvent(receiptEvent);
+
+    eventLogger.logUacQidEvent(uacQidLink, "Receipt received", EventType.RECEIPT, receiptEvent, message);
+  }
+
+  private boolean processEvent(EventDTO receiptEvent) {
+
+    EventHeaderDTO eventHeader = receiptEvent.getHeader();
+
+    switch (eventHeader.getMessageType()) {
+      case RECEIPT:
+        return true;
+
+      default:
+        // Should never get here
+        throw new RuntimeException(
+            String.format("Event Type '%s' is invalid on this topic", eventHeader.getMessageType()));
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/census/caseprocessor/service/CaseReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/service/CaseReceiptService.java
@@ -8,6 +8,8 @@ import java.util.function.BiFunction;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
 import uk.gov.ons.census.common.model.entity.Case;
@@ -16,11 +18,11 @@ import uk.gov.ons.census.common.model.entity.UacQidLink;
 @Component
 public class CaseReceiptService {
 
+  private static final Logger log = LoggerFactory.getLogger(CaseReceiptService.class);
+
   private CaseService caseService;
   private static final String HH = "H";
   private static final String IND = "I";
-  private static final String CE1 = "C";
-  private static final String CONT = "Cont";
 
   private Map<Key, BiFunction<Case, EventDTO, Case>> rules = new HashMap<>();
 
@@ -30,15 +32,13 @@ public class CaseReceiptService {
   }
 
   private void setUpRules() {
-    // This table is not accessible to me. Replace with the correct URL if needed.
     /*
-     This table is based on: https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=SDC&title=Receipting
+     This table is based on: https://officefornationalstatistics.atlassian.net/wiki/x/igE4Ew
     */
-
     rules.put(new Key("HH", "U", HH), receiptAndCancel);
-    rules.put(new Key("HH", "U", CE1), noActionRequired);
-    rules.put(new Key("HH", "U", CONT), noActionRequired);
     rules.put(new Key("HI", "U", HH), receiptCase);
+    rules.put(new Key("HI", "U", IND), receiptCase);
+    rules.put(new Key("HH", "U", IND), noActionRequired);
   }
 
   public UacQidLink receiptCase(UacQidLink uacQidLink, EventDTO causeEvent) {
@@ -77,19 +77,6 @@ public class CaseReceiptService {
         return caze;
       };
 
-  BiFunction<Case, EventDTO, Case> receiptAndUpdate =
-      (caze, event) -> {
-        if (caze.isReceiptReceived()) {
-          return caze;
-        }
-        Case updatedCase = receiptCase(caze);
-        caseService.saveCaseAndEmitCaseUpdate(
-            updatedCase,
-            event.getHeader().getCorrelationId(),
-            event.getHeader().getOriginatingUser());
-        return caze;
-      };
-
   BiFunction<Case, EventDTO, Case> receiptCase =
       (caze, event) -> {
         if (caze.isReceiptReceived()) {
@@ -103,13 +90,22 @@ public class CaseReceiptService {
         return caze;
       };
 
-  BiFunction<Case, EventDTO, Case> noActionRequired = (caze, event) -> caze;
+  BiFunction<Case, EventDTO, Case> noActionRequired =
+      (caze, event) -> {
+        if (log.isWarnEnabled()) {
+          log.warn(
+              "Receipt received with questionnaire type and form type mismatch. No action rule applied. QID: {}, Correlation ID: {}, Channel: {}",
+              event.getPayload().getReceipt().getQid(),
+              event.getHeader().getCorrelationId(),
+              event.getHeader().getChannel());
+        }
+        return caze;
+      };
 
   @AllArgsConstructor
   @EqualsAndHashCode
   @ToString
   private class Key {
-
     private String caseType;
     private String addressLevel;
     private String formType;

--- a/src/main/java/uk/gov/ons/census/caseprocessor/service/CaseReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/service/CaseReceiptService.java
@@ -8,8 +8,6 @@ import java.util.function.BiFunction;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
 import uk.gov.ons.census.common.model.entity.Case;
@@ -17,8 +15,6 @@ import uk.gov.ons.census.common.model.entity.UacQidLink;
 
 @Component
 public class CaseReceiptService {
-
-  private static final Logger log = LoggerFactory.getLogger(CaseReceiptService.class);
 
   private CaseService caseService;
   private static final String HH = "H";

--- a/src/main/java/uk/gov/ons/census/caseprocessor/service/CaseReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/service/CaseReceiptService.java
@@ -10,7 +10,6 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
-import uk.gov.ons.census.caseprocessor.model.repository.CaseRepository;
 import uk.gov.ons.census.common.model.entity.Case;
 import uk.gov.ons.census.common.model.entity.UacQidLink;
 
@@ -18,7 +17,6 @@ import uk.gov.ons.census.common.model.entity.UacQidLink;
 public class CaseReceiptService {
 
   private CaseService caseService;
-  private final CaseRepository caseRepository;
   private static final String HH = "H";
   private static final String IND = "I";
   private static final String CE1 = "C";
@@ -26,9 +24,8 @@ public class CaseReceiptService {
 
   private Map<Key, BiFunction<Case, EventDTO, Case>> rules = new HashMap<>();
 
-  public CaseReceiptService(CaseService caseService, CaseRepository caseRepository) {
+  public CaseReceiptService(CaseService caseService) {
     this.caseService = caseService;
-    this.caseRepository = caseRepository;
     setUpRules();
   }
 
@@ -44,7 +41,7 @@ public class CaseReceiptService {
     rules.put(new Key("HI", "U", HH), receiptCase);
   }
 
-  public void receiptCase(UacQidLink uacQidLink, EventDTO causeEvent) {
+  public UacQidLink receiptCase(UacQidLink uacQidLink, EventDTO causeEvent) {
     Case caze = uacQidLink.getCaze();
 
     Key ruleKey = makeRulesKey(caze, uacQidLink);
@@ -54,6 +51,7 @@ public class CaseReceiptService {
     }
 
     var unused = rules.get(ruleKey).apply(caze, causeEvent);
+    return uacQidLink;
   }
 
   private Key makeRulesKey(Case caze, UacQidLink uacQidLink) {

--- a/src/main/java/uk/gov/ons/census/caseprocessor/service/CaseReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/service/CaseReceiptService.java
@@ -1,42 +1,18 @@
 package uk.gov.ons.census.caseprocessor.service;
 
-import static uk.gov.ons.census.casesvc.utility.FormTypeHelper.mapQuestionnaireTypeToFormType;
-import static uk.gov.ons.census.casesvc.utility.MetadataHelper.buildMetadata;
+import static uk.gov.ons.census.caseprocessor.utils.FormTypeHelper.mapQuestionnaireTypeToFormType;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 import java.util.function.BiFunction;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.springframework.stereotype.Component;
-import uk.gov.ons.census.casesvc.model.dto.ActionInstructionType;
 import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
-import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
-import uk.gov.ons.census.casesvc.model.dto.Metadata;
+import uk.gov.ons.census.caseprocessor.model.repository.CaseRepository;
 import uk.gov.ons.census.common.model.entity.Case;
 import uk.gov.ons.census.common.model.entity.UacQidLink;
-import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
-import uk.gov.ons.census.casesvc.utility.FieldworkHelper;
-
-
-import java.util.Optional;
-import java.util.UUID;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-import uk.gov.ons.census.caseprocessor.messaging.MessageSender;
-import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
-import uk.gov.ons.census.caseprocessor.model.dto.EventHeaderDTO;
-import uk.gov.ons.census.caseprocessor.model.dto.PayloadDTO;
-import uk.gov.ons.census.caseprocessor.model.dto.UacUpdateDTO;
-import uk.gov.ons.census.caseprocessor.model.repository.UacQidLinkRepository;
-import uk.gov.ons.census.caseprocessor.utils.EventHelper;
-import uk.gov.ons.census.caseprocessor.utils.HashHelper;
-import uk.gov.ons.census.common.model.entity.Case;
-import uk.gov.ons.census.common.model.entity.EventType;
-import uk.gov.ons.census.common.model.entity.UacQidLink;
-
 
 @Component
 public class CaseReceiptService {
@@ -47,9 +23,8 @@ public class CaseReceiptService {
   private static final String IND = "I";
   private static final String CE1 = "C";
   private static final String CONT = "Cont";
-  private static final String EQ_EVENT_CHANNEL = "EQ";
 
-  private Map<Key, BiFunction<Case, EventTypeDTO, Case>> rules = new HashMap<>();
+  private Map<Key, BiFunction<Case, EventDTO, Case>> rules = new HashMap<>();
 
   public CaseReceiptService(CaseService caseService, CaseRepository caseRepository) {
     this.caseService = caseService;
@@ -58,6 +33,7 @@ public class CaseReceiptService {
   }
 
   private void setUpRules() {
+    // This table is not accessible to me. Replace with the correct URL if needed.
     /*
      This table is based on: https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=SDC&title=Receipting
     */
@@ -66,33 +42,10 @@ public class CaseReceiptService {
     rules.put(new Key("HH", "U", CE1), noActionRequired);
     rules.put(new Key("HH", "U", CONT), noActionRequired);
     rules.put(new Key("HI", "U", HH), receiptCase);
-    rules.put(new Key("HI", "U", IND), receiptCase);
-    rules.put(new Key("HI", "U", CE1), noActionRequired);
-    rules.put(new Key("HI", "U", CONT), noActionRequired);
-    rules.put(new Key("CE", "E", HH), incrementAndUpdate);
-    rules.put(new Key("CE", "E", IND), incrementAndUpdate);
-    rules.put(new Key("CE", "E", CE1), receiptAndUpdate);
-    rules.put(new Key("CE", "E", CONT), noActionRequired);
-    rules.put(new Key("CE", "U", HH), ceUnitRule);
-    rules.put(new Key("CE", "U", IND), ceUnitRule);
-    rules.put(new Key("CE", "U", CE1), noActionRequired);
-    rules.put(new Key("CE", "U", CONT), noActionRequired);
-    rules.put(new Key("SPG", "E", HH), noActionRequired);
-    rules.put(new Key("SPG", "E", IND), noActionRequired);
-    rules.put(new Key("SPG", "E", CE1), noActionRequired);
-    rules.put(new Key("SPG", "E", CONT), noActionRequired);
-    rules.put(new Key("SPG", "U", HH), receiptAndCancel);
-    rules.put(new Key("SPG", "U", IND), noActionRequired);
-    rules.put(new Key("SPG", "U", CE1), noActionRequired);
-    rules.put(new Key("SPG", "U", CONT), noActionRequired);
   }
 
   public void receiptCase(UacQidLink uacQidLink, EventDTO causeEvent) {
     Case caze = uacQidLink.getCaze();
-
-    if (uacQidLink.isBlankQuestionnaire() && !causeEvent.getChannel().equals(EQ_EVENT_CHANNEL)) {
-      return;
-    }
 
     Key ruleKey = makeRulesKey(caze, uacQidLink);
 
@@ -100,7 +53,7 @@ public class CaseReceiptService {
       throw new RuntimeException(ruleKey.toString() + " does not map to any known processing rule");
     }
 
-    rules.get(ruleKey).apply(caze, causeEvent.getType());
+    var unused = rules.get(ruleKey).apply(caze, causeEvent);
   }
 
   private Key makeRulesKey(Case caze, UacQidLink uacQidLink) {
@@ -108,81 +61,51 @@ public class CaseReceiptService {
     return new Key(caze.getCaseType(), caze.getAddressLevel(), formType);
   }
 
-  private Case getCaseAndLockIt(UUID caseId) {
-    return caseService.getCaseAndLockIt(caseId);
-  }
-
-  private Case incrementNoReceipt(Case caze) {
-    Case lockedCase = getCaseAndLockIt(caze.getCaseId());
-    lockedCase.setCeActualResponses(lockedCase.getCeActualResponses() + 1);
-
-    return lockedCase;
-  }
-
   private Case receiptCase(Case caze) {
     caze.setReceiptReceived(true);
     return caze;
   }
 
-  BiFunction<Case, EventTypeDTO, Case> receiptAndCancel =
-      (caze, causeEventType) -> {
+  BiFunction<Case, EventDTO, Case> receiptAndCancel =
+      (caze, event) -> {
         if (caze.isReceiptReceived()) {
           return caze;
         }
         Case updatedCase = receiptCase(caze);
-        caseService.saveCaseAndEmitCaseUpdatedEvent(
-            updatedCase, buildMetadata(causeEventType, ActionInstructionType.CANCEL));
+        caseService.saveCaseAndEmitCaseUpdate(
+            updatedCase,
+            event.getHeader().getCorrelationId(),
+            event.getHeader().getOriginatingUser());
         return caze;
       };
 
-  BiFunction<Case, EventTypeDTO, Case> receiptAndUpdate =
-      (caze, causeEventType) -> {
+  BiFunction<Case, EventDTO, Case> receiptAndUpdate =
+      (caze, event) -> {
         if (caze.isReceiptReceived()) {
           return caze;
         }
         Case updatedCase = receiptCase(caze);
-        caseService.saveCaseAndEmitCaseUpdatedEvent(
-            updatedCase, buildMetadata(causeEventType, ActionInstructionType.UPDATE));
+        caseService.saveCaseAndEmitCaseUpdate(
+            updatedCase,
+            event.getHeader().getCorrelationId(),
+            event.getHeader().getOriginatingUser());
         return caze;
       };
 
-  BiFunction<Case, EventTypeDTO, Case> receiptCase =
-      (caze, causeEventType) -> {
+  BiFunction<Case, EventDTO, Case> receiptCase =
+      (caze, event) -> {
         if (caze.isReceiptReceived()) {
           return caze;
         }
         Case updatedCase = receiptCase(caze);
-        caseService.saveCaseAndEmitCaseUpdatedEvent(
-            updatedCase, buildMetadata(causeEventType, null));
+        caseService.saveCaseAndEmitCaseUpdate(
+            updatedCase,
+            event.getHeader().getCorrelationId(),
+            event.getHeader().getOriginatingUser());
         return caze;
       };
 
-  BiFunction<Case, EventTypeDTO, Case> incrementAndUpdate =
-      (caze, causeEventType) -> {
-        Case updatedCase = incrementNoReceipt(caze);
-
-        Metadata metadata = null;
-        if (FieldworkHelper.shouldSendCaseToField(caze)) {
-          metadata = buildMetadata(causeEventType, ActionInstructionType.UPDATE);
-        }
-
-        caseService.saveCaseAndEmitCaseUpdatedEvent(updatedCase, metadata);
-        return caze;
-      };
-
-  BiFunction<Case, EventTypeDTO, Case> ceUnitRule =
-      (caze, causeEventType) -> {
-        Case lockedCase = incrementNoReceipt(caze);
-
-        ActionInstructionType fieldInstruction =
-            decideWhatToSendToFieldAndWhetherToReceiptCase(lockedCase);
-
-        caseService.saveCaseAndEmitCaseUpdatedEvent(
-            lockedCase, buildMetadata(causeEventType, fieldInstruction));
-        return caze;
-      };
-
-  BiFunction<Case, EventTypeDTO, Case> noActionRequired = (caze, causeEventType) -> caze;
+  BiFunction<Case, EventDTO, Case> noActionRequired = (caze, event) -> caze;
 
   @AllArgsConstructor
   @EqualsAndHashCode
@@ -192,29 +115,5 @@ public class CaseReceiptService {
     private String caseType;
     private String addressLevel;
     private String formType;
-  }
-
-  private ActionInstructionType decideWhatToSendToFieldAndWhetherToReceiptCase(Case caze) {
-
-    ActionInstructionType fieldInstruction = null;
-
-    // If case is already receipted we dont need to tell Field about any more responses
-    if (!caze.isReceiptReceived()) {
-
-      // If we are still expecting some responses or we dont know how many responses we are due to
-      // receive, UPDATE field
-      if (caze.getCeExpectedCapacity() == null
-          || caze.getCeActualResponses() < caze.getCeExpectedCapacity()) {
-        fieldInstruction = ActionInstructionType.UPDATE;
-      } else {
-
-        // We now have all responses expected so tell Field to CANCEL the case and mark case as
-        // receipted
-        caze.setReceiptReceived(true);
-        fieldInstruction = ActionInstructionType.CANCEL;
-      }
-    }
-
-    return fieldInstruction;
   }
 }

--- a/src/main/java/uk/gov/ons/census/caseprocessor/service/CaseReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/service/CaseReceiptService.java
@@ -1,0 +1,220 @@
+package uk.gov.ons.census.caseprocessor.service;
+
+import static uk.gov.ons.census.casesvc.utility.FormTypeHelper.mapQuestionnaireTypeToFormType;
+import static uk.gov.ons.census.casesvc.utility.MetadataHelper.buildMetadata;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.springframework.stereotype.Component;
+import uk.gov.ons.census.casesvc.model.dto.ActionInstructionType;
+import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
+import uk.gov.ons.census.casesvc.model.dto.EventTypeDTO;
+import uk.gov.ons.census.casesvc.model.dto.Metadata;
+import uk.gov.ons.census.common.model.entity.Case;
+import uk.gov.ons.census.common.model.entity.UacQidLink;
+import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
+import uk.gov.ons.census.casesvc.utility.FieldworkHelper;
+
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.ons.census.caseprocessor.messaging.MessageSender;
+import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
+import uk.gov.ons.census.caseprocessor.model.dto.EventHeaderDTO;
+import uk.gov.ons.census.caseprocessor.model.dto.PayloadDTO;
+import uk.gov.ons.census.caseprocessor.model.dto.UacUpdateDTO;
+import uk.gov.ons.census.caseprocessor.model.repository.UacQidLinkRepository;
+import uk.gov.ons.census.caseprocessor.utils.EventHelper;
+import uk.gov.ons.census.caseprocessor.utils.HashHelper;
+import uk.gov.ons.census.common.model.entity.Case;
+import uk.gov.ons.census.common.model.entity.EventType;
+import uk.gov.ons.census.common.model.entity.UacQidLink;
+
+
+@Component
+public class CaseReceiptService {
+
+  private CaseService caseService;
+  private final CaseRepository caseRepository;
+  private static final String HH = "H";
+  private static final String IND = "I";
+  private static final String CE1 = "C";
+  private static final String CONT = "Cont";
+  private static final String EQ_EVENT_CHANNEL = "EQ";
+
+  private Map<Key, BiFunction<Case, EventTypeDTO, Case>> rules = new HashMap<>();
+
+  public CaseReceiptService(CaseService caseService, CaseRepository caseRepository) {
+    this.caseService = caseService;
+    this.caseRepository = caseRepository;
+    setUpRules();
+  }
+
+  private void setUpRules() {
+    /*
+     This table is based on: https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=SDC&title=Receipting
+    */
+
+    rules.put(new Key("HH", "U", HH), receiptAndCancel);
+    rules.put(new Key("HH", "U", CE1), noActionRequired);
+    rules.put(new Key("HH", "U", CONT), noActionRequired);
+    rules.put(new Key("HI", "U", HH), receiptCase);
+    rules.put(new Key("HI", "U", IND), receiptCase);
+    rules.put(new Key("HI", "U", CE1), noActionRequired);
+    rules.put(new Key("HI", "U", CONT), noActionRequired);
+    rules.put(new Key("CE", "E", HH), incrementAndUpdate);
+    rules.put(new Key("CE", "E", IND), incrementAndUpdate);
+    rules.put(new Key("CE", "E", CE1), receiptAndUpdate);
+    rules.put(new Key("CE", "E", CONT), noActionRequired);
+    rules.put(new Key("CE", "U", HH), ceUnitRule);
+    rules.put(new Key("CE", "U", IND), ceUnitRule);
+    rules.put(new Key("CE", "U", CE1), noActionRequired);
+    rules.put(new Key("CE", "U", CONT), noActionRequired);
+    rules.put(new Key("SPG", "E", HH), noActionRequired);
+    rules.put(new Key("SPG", "E", IND), noActionRequired);
+    rules.put(new Key("SPG", "E", CE1), noActionRequired);
+    rules.put(new Key("SPG", "E", CONT), noActionRequired);
+    rules.put(new Key("SPG", "U", HH), receiptAndCancel);
+    rules.put(new Key("SPG", "U", IND), noActionRequired);
+    rules.put(new Key("SPG", "U", CE1), noActionRequired);
+    rules.put(new Key("SPG", "U", CONT), noActionRequired);
+  }
+
+  public void receiptCase(UacQidLink uacQidLink, EventDTO causeEvent) {
+    Case caze = uacQidLink.getCaze();
+
+    if (uacQidLink.isBlankQuestionnaire() && !causeEvent.getChannel().equals(EQ_EVENT_CHANNEL)) {
+      return;
+    }
+
+    Key ruleKey = makeRulesKey(caze, uacQidLink);
+
+    if (!rules.containsKey(ruleKey)) {
+      throw new RuntimeException(ruleKey.toString() + " does not map to any known processing rule");
+    }
+
+    rules.get(ruleKey).apply(caze, causeEvent.getType());
+  }
+
+  private Key makeRulesKey(Case caze, UacQidLink uacQidLink) {
+    String formType = mapQuestionnaireTypeToFormType(uacQidLink.getQid());
+    return new Key(caze.getCaseType(), caze.getAddressLevel(), formType);
+  }
+
+  private Case getCaseAndLockIt(UUID caseId) {
+    return caseService.getCaseAndLockIt(caseId);
+  }
+
+  private Case incrementNoReceipt(Case caze) {
+    Case lockedCase = getCaseAndLockIt(caze.getCaseId());
+    lockedCase.setCeActualResponses(lockedCase.getCeActualResponses() + 1);
+
+    return lockedCase;
+  }
+
+  private Case receiptCase(Case caze) {
+    caze.setReceiptReceived(true);
+    return caze;
+  }
+
+  BiFunction<Case, EventTypeDTO, Case> receiptAndCancel =
+      (caze, causeEventType) -> {
+        if (caze.isReceiptReceived()) {
+          return caze;
+        }
+        Case updatedCase = receiptCase(caze);
+        caseService.saveCaseAndEmitCaseUpdatedEvent(
+            updatedCase, buildMetadata(causeEventType, ActionInstructionType.CANCEL));
+        return caze;
+      };
+
+  BiFunction<Case, EventTypeDTO, Case> receiptAndUpdate =
+      (caze, causeEventType) -> {
+        if (caze.isReceiptReceived()) {
+          return caze;
+        }
+        Case updatedCase = receiptCase(caze);
+        caseService.saveCaseAndEmitCaseUpdatedEvent(
+            updatedCase, buildMetadata(causeEventType, ActionInstructionType.UPDATE));
+        return caze;
+      };
+
+  BiFunction<Case, EventTypeDTO, Case> receiptCase =
+      (caze, causeEventType) -> {
+        if (caze.isReceiptReceived()) {
+          return caze;
+        }
+        Case updatedCase = receiptCase(caze);
+        caseService.saveCaseAndEmitCaseUpdatedEvent(
+            updatedCase, buildMetadata(causeEventType, null));
+        return caze;
+      };
+
+  BiFunction<Case, EventTypeDTO, Case> incrementAndUpdate =
+      (caze, causeEventType) -> {
+        Case updatedCase = incrementNoReceipt(caze);
+
+        Metadata metadata = null;
+        if (FieldworkHelper.shouldSendCaseToField(caze)) {
+          metadata = buildMetadata(causeEventType, ActionInstructionType.UPDATE);
+        }
+
+        caseService.saveCaseAndEmitCaseUpdatedEvent(updatedCase, metadata);
+        return caze;
+      };
+
+  BiFunction<Case, EventTypeDTO, Case> ceUnitRule =
+      (caze, causeEventType) -> {
+        Case lockedCase = incrementNoReceipt(caze);
+
+        ActionInstructionType fieldInstruction =
+            decideWhatToSendToFieldAndWhetherToReceiptCase(lockedCase);
+
+        caseService.saveCaseAndEmitCaseUpdatedEvent(
+            lockedCase, buildMetadata(causeEventType, fieldInstruction));
+        return caze;
+      };
+
+  BiFunction<Case, EventTypeDTO, Case> noActionRequired = (caze, causeEventType) -> caze;
+
+  @AllArgsConstructor
+  @EqualsAndHashCode
+  @ToString
+  private class Key {
+
+    private String caseType;
+    private String addressLevel;
+    private String formType;
+  }
+
+  private ActionInstructionType decideWhatToSendToFieldAndWhetherToReceiptCase(Case caze) {
+
+    ActionInstructionType fieldInstruction = null;
+
+    // If case is already receipted we dont need to tell Field about any more responses
+    if (!caze.isReceiptReceived()) {
+
+      // If we are still expecting some responses or we dont know how many responses we are due to
+      // receive, UPDATE field
+      if (caze.getCeExpectedCapacity() == null
+          || caze.getCeActualResponses() < caze.getCeExpectedCapacity()) {
+        fieldInstruction = ActionInstructionType.UPDATE;
+      } else {
+
+        // We now have all responses expected so tell Field to CANCEL the case and mark case as
+        // receipted
+        caze.setReceiptReceived(true);
+        fieldInstruction = ActionInstructionType.CANCEL;
+      }
+    }
+
+    return fieldInstruction;
+  }
+}

--- a/src/main/java/uk/gov/ons/census/caseprocessor/service/CaseReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/service/CaseReceiptService.java
@@ -64,6 +64,8 @@ public class CaseReceiptService {
     return caze;
   }
 
+  /*TODO: This function will send a field cancel message in the future.
+  For now, it is identical to receiptCase, but this will change after field integration is implemented.*/
   BiFunction<Case, EventDTO, Case> receiptAndCancel =
       (caze, event) -> {
         if (caze.isReceiptReceived()) {
@@ -90,17 +92,7 @@ public class CaseReceiptService {
         return caze;
       };
 
-  BiFunction<Case, EventDTO, Case> noActionRequired =
-      (caze, event) -> {
-        if (log.isWarnEnabled()) {
-          log.warn(
-              "Receipt received with questionnaire type and form type mismatch. No action rule applied. QID: {}, Correlation ID: {}, Channel: {}",
-              event.getPayload().getReceipt().getQid(),
-              event.getHeader().getCorrelationId(),
-              event.getHeader().getChannel());
-        }
-        return caze;
-      };
+  BiFunction<Case, EventDTO, Case> noActionRequired = (caze, event) -> caze;
 
   @AllArgsConstructor
   @EqualsAndHashCode

--- a/src/main/java/uk/gov/ons/census/caseprocessor/service/QidReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/service/QidReceiptService.java
@@ -1,0 +1,146 @@
+package uk.gov.ons.census.caseprocessor.service;
+
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import java.time.OffsetDateTime;
+import org.springframework.stereotype.Service;
+import uk.gov.ons.census.caseprocessor.logging.EventLogger;
+//import uk.gov.ons.census.caseprocessor.model.dto.ResponseDTO;
+//import uk.gov.ons.census.caseprocessor.model.dto.ResponseManagementEvent;
+import uk.gov.ons.census.common.model.entity.Case;
+import uk.gov.ons.census.common.model.entity.Event;
+import uk.gov.ons.census.common.model.entity.EventType;
+import uk.gov.ons.census.common.model.entity.UacQidLink;
+
+import uk.gov.ons.census.caseprocessor.logging.EventLogger;
+import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
+import uk.gov.ons.census.caseprocessor.model.dto.EventHeaderDTO;
+import uk.gov.ons.census.common.model.entity.EventType;
+import uk.gov.ons.census.common.model.entity.UacQidLink;
+
+
+
+@Service
+public class QidReceiptService {
+
+  private static final Logger log = LoggerFactory.getLogger(QidReceiptService.class);
+  public static final String QID_RECEIPTED = "QID Receipted";
+  public static final String BLANK_QUESTIONNAIRE_RECEIVED = "Blank questionnaire received";
+  private final UacService uacService;
+  private final EventLogger eventLogger;
+  private final CaseReceiptService caseReceiptService;
+  private final BlankQuestionnaireService blankQuestionnaireService;
+
+  public QidReceiptService(
+      UacService uacService,
+      EventLogger eventLogger,
+      CaseReceiptService caseReceiptService,
+      BlankQuestionnaireService blankQuestionnaireService) {
+    this.uacService = uacService;
+    this.eventLogger = eventLogger;
+    this.caseReceiptService = caseReceiptService;
+    this.blankQuestionnaireService = blankQuestionnaireService;
+  }
+
+  public void processReceipt(
+      ResponseManagementEvent receiptEvent, OffsetDateTime messageTimestamp) {
+    ResponseDTO receiptPayload = receiptEvent.getPayload().getResponse();
+    UacQidLink uacQidLink = uacService.findByQid(receiptPayload.getQuestionnaireId());
+    if (receiptPayload.getUnreceipt()) {
+      processUnreceipt(receiptEvent, messageTimestamp, uacQidLink);
+      return;
+    }
+
+    // Deactivating a UAC which is already deactivated is madness, but the blank questionnaire
+    // scenarios are horrendously over-complicated, including the impossible scenario where
+    // a respondent attempts to use their UAC via EQ after THEY ALREADY SENT IT BACK TO US BLANK
+    if (uacQidLink.isActive() || uacQidLink.isBlankQuestionnaire()) {
+      uacQidLink.setActive(false);
+      uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
+
+      Case caze = uacQidLink.getCaze();
+
+      if (caze != null) {
+        caseReceiptService.receiptCase(uacQidLink, receiptEvent.getEvent());
+      } else {
+        log.with("qid", receiptPayload.getQuestionnaireId())
+            .with("tx_id", receiptEvent.getEvent().getTransactionId())
+            .with("channel", receiptEvent.getEvent().getChannel())
+            .warn("Receipt received for unaddressed UAC/QID pair not yet linked to a case");
+      }
+    }
+
+    eventLogger.logUacQidEvent(
+        uacQidLink,
+        receiptEvent.getEvent().getDateTime(),
+        QID_RECEIPTED,
+        EventType.RESPONSE_RECEIVED,
+        receiptEvent.getEvent(),
+        receiptPayload,
+        messageTimestamp);
+  }
+
+  public void processUnreceipt(
+      ResponseManagementEvent unreceiptEvent,
+      OffsetDateTime messageTimestamp,
+      UacQidLink uacQidLink) {
+
+    ResponseDTO receiptPayload = unreceiptEvent.getPayload().getResponse();
+
+    if (!uacQidLink.isActive() && hasEqReceipt(uacQidLink)) {
+      // If we have an EQ receipt for this QID then we must have a response for the case so we do
+      // not want to action the unreceipt, we just log it
+
+      log.with("qid", uacQidLink.getQid())
+          .with("tx_id", unreceiptEvent.getEvent().getTransactionId())
+          .with("channel", unreceiptEvent.getEvent().getChannel())
+          .warn("Unreceipt received for QID which was already receipted via EQ");
+    } else {
+      handleBlankQuestionnaire(unreceiptEvent, uacQidLink, receiptPayload);
+    }
+
+    eventLogger.logUacQidEvent(
+        uacQidLink,
+        unreceiptEvent.getEvent().getDateTime(),
+        BLANK_QUESTIONNAIRE_RECEIVED,
+        EventType.RESPONSE_RECEIVED,
+        unreceiptEvent.getEvent(),
+        receiptPayload,
+        messageTimestamp);
+  }
+
+  private void handleBlankQuestionnaire(
+      ResponseManagementEvent unreceiptEvent, UacQidLink uacQidLink, ResponseDTO receiptPayload) {
+    uacQidLink.setActive(false);
+    uacQidLink.setBlankQuestionnaire(true);
+
+    uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
+
+    Case caze = uacQidLink.getCaze();
+
+    if (caze != null) {
+      blankQuestionnaireService.handleBlankQuestionnaire(
+          caze, uacQidLink, unreceiptEvent.getEvent().getType());
+    } else {
+      log.with("qid", receiptPayload.getQuestionnaireId())
+          .with("tx_id", unreceiptEvent.getEvent().getTransactionId())
+          .with("channel", unreceiptEvent.getEvent().getChannel())
+          .warn("Unreceipt received for unaddressed UAC/QID pair not yet linked to a case");
+    }
+  }
+
+  private boolean hasEqReceipt(UacQidLink uacQidLink) {
+    if (uacQidLink.getEvents() == null) {
+      return false;
+    }
+
+    for (Event event : uacQidLink.getEvents()) {
+      if (event.getEventType() == EventType.RESPONSE_RECEIVED
+          && event.getEventChannel().equalsIgnoreCase("EQ")) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/src/main/java/uk/gov/ons/census/caseprocessor/service/QidReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/service/QidReceiptService.java
@@ -1,146 +1,63 @@
 package uk.gov.ons.census.caseprocessor.service;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
+import static uk.gov.ons.census.caseprocessor.utils.JsonHelper.convertJsonBytesToEvent;
+
 import java.time.OffsetDateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.messaging.Message;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.census.caseprocessor.logging.EventLogger;
-//import uk.gov.ons.census.caseprocessor.model.dto.ResponseDTO;
-//import uk.gov.ons.census.caseprocessor.model.dto.ResponseManagementEvent;
-import uk.gov.ons.census.common.model.entity.Case;
-import uk.gov.ons.census.common.model.entity.Event;
-import uk.gov.ons.census.common.model.entity.EventType;
-import uk.gov.ons.census.common.model.entity.UacQidLink;
-
-import uk.gov.ons.census.caseprocessor.logging.EventLogger;
 import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
-import uk.gov.ons.census.caseprocessor.model.dto.EventHeaderDTO;
+import uk.gov.ons.census.common.model.entity.Case;
 import uk.gov.ons.census.common.model.entity.EventType;
 import uk.gov.ons.census.common.model.entity.UacQidLink;
-
-
 
 @Service
 public class QidReceiptService {
 
   private static final Logger log = LoggerFactory.getLogger(QidReceiptService.class);
-  public static final String QID_RECEIPTED = "QID Receipted";
-  public static final String BLANK_QUESTIONNAIRE_RECEIVED = "Blank questionnaire received";
   private final UacService uacService;
   private final EventLogger eventLogger;
   private final CaseReceiptService caseReceiptService;
-  private final BlankQuestionnaireService blankQuestionnaireService;
 
   public QidReceiptService(
-      UacService uacService,
-      EventLogger eventLogger,
-      CaseReceiptService caseReceiptService,
-      BlankQuestionnaireService blankQuestionnaireService) {
+      UacService uacService, EventLogger eventLogger, CaseReceiptService caseReceiptService) {
     this.uacService = uacService;
     this.eventLogger = eventLogger;
     this.caseReceiptService = caseReceiptService;
-    this.blankQuestionnaireService = blankQuestionnaireService;
   }
 
-  public void processReceipt(
-      ResponseManagementEvent receiptEvent, OffsetDateTime messageTimestamp) {
-    ResponseDTO receiptPayload = receiptEvent.getPayload().getResponse();
-    UacQidLink uacQidLink = uacService.findByQid(receiptPayload.getQuestionnaireId());
-    if (receiptPayload.getUnreceipt()) {
-      processUnreceipt(receiptEvent, messageTimestamp, uacQidLink);
-      return;
-    }
+  public void processReceipt(Message<byte[]> message, OffsetDateTime messageTimestamp) {
 
-    // Deactivating a UAC which is already deactivated is madness, but the blank questionnaire
-    // scenarios are horrendously over-complicated, including the impossible scenario where
-    // a respondent attempts to use their UAC via EQ after THEY ALREADY SENT IT BACK TO US BLANK
-    if (uacQidLink.isActive() || uacQidLink.isBlankQuestionnaire()) {
+    EventDTO event = convertJsonBytesToEvent(message.getPayload());
+    UacQidLink uacQidLink = uacService.findByQid(event.getPayload().getReceipt().getQid());
+
+    if (!uacQidLink.isReceiptReceived()) {
       uacQidLink.setActive(false);
-      uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
+      uacQidLink.setReceiptReceived(true);
+
+      uacQidLink =
+          uacService.saveAndEmitUacUpdateEvent(
+              uacQidLink,
+              event.getHeader().getCorrelationId(),
+              event.getHeader().getOriginatingUser());
 
       Case caze = uacQidLink.getCaze();
 
       if (caze != null) {
-        caseReceiptService.receiptCase(uacQidLink, receiptEvent.getEvent());
+        caseReceiptService.receiptCase(uacQidLink, event);
       } else {
-        log.with("qid", receiptPayload.getQuestionnaireId())
-            .with("tx_id", receiptEvent.getEvent().getTransactionId())
-            .with("channel", receiptEvent.getEvent().getChannel())
-            .warn("Receipt received for unaddressed UAC/QID pair not yet linked to a case");
+        if (log.isWarnEnabled()) {
+          log.warn(
+              "Receipt received for unaddressed UAC/QID pair not yet linked to a case. QID: {}, Correlation ID: {}, Channel: {}",
+              event.getPayload().getReceipt().getQid(),
+              // event.getHeader().getTransactionId(),
+              event.getHeader().getCorrelationId(),
+              event.getHeader().getChannel());
+        }
       }
     }
-
-    eventLogger.logUacQidEvent(
-        uacQidLink,
-        receiptEvent.getEvent().getDateTime(),
-        QID_RECEIPTED,
-        EventType.RESPONSE_RECEIVED,
-        receiptEvent.getEvent(),
-        receiptPayload,
-        messageTimestamp);
-  }
-
-  public void processUnreceipt(
-      ResponseManagementEvent unreceiptEvent,
-      OffsetDateTime messageTimestamp,
-      UacQidLink uacQidLink) {
-
-    ResponseDTO receiptPayload = unreceiptEvent.getPayload().getResponse();
-
-    if (!uacQidLink.isActive() && hasEqReceipt(uacQidLink)) {
-      // If we have an EQ receipt for this QID then we must have a response for the case so we do
-      // not want to action the unreceipt, we just log it
-
-      log.with("qid", uacQidLink.getQid())
-          .with("tx_id", unreceiptEvent.getEvent().getTransactionId())
-          .with("channel", unreceiptEvent.getEvent().getChannel())
-          .warn("Unreceipt received for QID which was already receipted via EQ");
-    } else {
-      handleBlankQuestionnaire(unreceiptEvent, uacQidLink, receiptPayload);
-    }
-
-    eventLogger.logUacQidEvent(
-        uacQidLink,
-        unreceiptEvent.getEvent().getDateTime(),
-        BLANK_QUESTIONNAIRE_RECEIVED,
-        EventType.RESPONSE_RECEIVED,
-        unreceiptEvent.getEvent(),
-        receiptPayload,
-        messageTimestamp);
-  }
-
-  private void handleBlankQuestionnaire(
-      ResponseManagementEvent unreceiptEvent, UacQidLink uacQidLink, ResponseDTO receiptPayload) {
-    uacQidLink.setActive(false);
-    uacQidLink.setBlankQuestionnaire(true);
-
-    uacService.saveAndEmitUacUpdatedEvent(uacQidLink);
-
-    Case caze = uacQidLink.getCaze();
-
-    if (caze != null) {
-      blankQuestionnaireService.handleBlankQuestionnaire(
-          caze, uacQidLink, unreceiptEvent.getEvent().getType());
-    } else {
-      log.with("qid", receiptPayload.getQuestionnaireId())
-          .with("tx_id", unreceiptEvent.getEvent().getTransactionId())
-          .with("channel", unreceiptEvent.getEvent().getChannel())
-          .warn("Unreceipt received for unaddressed UAC/QID pair not yet linked to a case");
-    }
-  }
-
-  private boolean hasEqReceipt(UacQidLink uacQidLink) {
-    if (uacQidLink.getEvents() == null) {
-      return false;
-    }
-
-    for (Event event : uacQidLink.getEvents()) {
-      if (event.getEventType() == EventType.RESPONSE_RECEIVED
-          && event.getEventChannel().equalsIgnoreCase("EQ")) {
-        return true;
-      }
-    }
-
-    return false;
+    eventLogger.logUacQidEvent(uacQidLink, "Receipt received", EventType.RECEIPT, event, message);
   }
 }

--- a/src/main/java/uk/gov/ons/census/caseprocessor/service/QidReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/service/QidReceiptService.java
@@ -1,7 +1,5 @@
 package uk.gov.ons.census.caseprocessor.service;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
 import uk.gov.ons.census.common.model.entity.Case;
@@ -10,7 +8,6 @@ import uk.gov.ons.census.common.model.entity.UacQidLink;
 @Service
 public class QidReceiptService {
 
-  private static final Logger log = LoggerFactory.getLogger(QidReceiptService.class);
   private final UacService uacService;
   private final CaseReceiptService caseReceiptService;
 
@@ -37,14 +34,6 @@ public class QidReceiptService {
 
       if (caze != null && "RH".equals(eventDTO.getHeader().getChannel())) {
         uacQidLink = caseReceiptService.receiptCase(uacQidLink, eventDTO);
-      } else {
-        if (log.isWarnEnabled()) {
-          log.warn(
-              "Receipt received for unaddressed UAC/QID pair not yet linked to a case. QID: {}, Correlation ID: {}, Channel: {}",
-              eventDTO.getPayload().getReceipt().getQid(),
-              eventDTO.getHeader().getCorrelationId(),
-              eventDTO.getHeader().getChannel());
-        }
       }
     }
     return uacQidLink;

--- a/src/main/java/uk/gov/ons/census/caseprocessor/service/QidReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/service/QidReceiptService.java
@@ -52,7 +52,6 @@ public class QidReceiptService {
           log.warn(
               "Receipt received for unaddressed UAC/QID pair not yet linked to a case. QID: {}, Correlation ID: {}, Channel: {}",
               event.getPayload().getReceipt().getQid(),
-              // event.getHeader().getTransactionId(),
               event.getHeader().getCorrelationId(),
               event.getHeader().getChannel());
         }

--- a/src/main/java/uk/gov/ons/census/caseprocessor/service/QidReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/service/QidReceiptService.java
@@ -1,16 +1,10 @@
 package uk.gov.ons.census.caseprocessor.service;
 
-import static uk.gov.ons.census.caseprocessor.utils.JsonHelper.convertJsonBytesToEvent;
-
-import java.time.OffsetDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.messaging.Message;
 import org.springframework.stereotype.Service;
-import uk.gov.ons.census.caseprocessor.logging.EventLogger;
 import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
 import uk.gov.ons.census.common.model.entity.Case;
-import uk.gov.ons.census.common.model.entity.EventType;
 import uk.gov.ons.census.common.model.entity.UacQidLink;
 
 @Service
@@ -18,20 +12,16 @@ public class QidReceiptService {
 
   private static final Logger log = LoggerFactory.getLogger(QidReceiptService.class);
   private final UacService uacService;
-  private final EventLogger eventLogger;
   private final CaseReceiptService caseReceiptService;
 
-  public QidReceiptService(
-      UacService uacService, EventLogger eventLogger, CaseReceiptService caseReceiptService) {
+  public QidReceiptService(UacService uacService, CaseReceiptService caseReceiptService) {
     this.uacService = uacService;
-    this.eventLogger = eventLogger;
     this.caseReceiptService = caseReceiptService;
   }
 
-  public void processReceipt(Message<byte[]> message, OffsetDateTime messageTimestamp) {
+  public UacQidLink processReceiptEvent(EventDTO eventDTO) {
 
-    EventDTO event = convertJsonBytesToEvent(message.getPayload());
-    UacQidLink uacQidLink = uacService.findByQid(event.getPayload().getReceipt().getQid());
+    UacQidLink uacQidLink = uacService.findByQid(eventDTO.getPayload().getReceipt().getQid());
 
     if (!uacQidLink.isReceiptReceived()) {
       uacQidLink.setActive(false);
@@ -40,23 +30,23 @@ public class QidReceiptService {
       uacQidLink =
           uacService.saveAndEmitUacUpdateEvent(
               uacQidLink,
-              event.getHeader().getCorrelationId(),
-              event.getHeader().getOriginatingUser());
+              eventDTO.getHeader().getCorrelationId(),
+              eventDTO.getHeader().getOriginatingUser());
 
       Case caze = uacQidLink.getCaze();
 
-      if (caze != null) {
-        caseReceiptService.receiptCase(uacQidLink, event);
+      if (caze != null && "RH".equals(eventDTO.getHeader().getChannel())) {
+        uacQidLink = caseReceiptService.receiptCase(uacQidLink, eventDTO);
       } else {
         if (log.isWarnEnabled()) {
           log.warn(
               "Receipt received for unaddressed UAC/QID pair not yet linked to a case. QID: {}, Correlation ID: {}, Channel: {}",
-              event.getPayload().getReceipt().getQid(),
-              event.getHeader().getCorrelationId(),
-              event.getHeader().getChannel());
+              eventDTO.getPayload().getReceipt().getQid(),
+              eventDTO.getHeader().getCorrelationId(),
+              eventDTO.getHeader().getChannel());
         }
       }
     }
-    eventLogger.logUacQidEvent(uacQidLink, "Receipt received", EventType.RECEIPT, event, message);
+    return uacQidLink;
   }
 }

--- a/src/main/java/uk/gov/ons/census/caseprocessor/utils/FormTypeHelper.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/utils/FormTypeHelper.java
@@ -3,8 +3,6 @@ package uk.gov.ons.census.caseprocessor.utils;
 public class FormTypeHelper {
   public static final String HH_FORM_TYPE = "H";
   public static final String IND_FORM_TYPE = "I";
-  public static final String CE1_FORM_TYPE = "C";
-  public static final String CONT_FORM_TYPE = "Cont";
 
   public static String mapQuestionnaireTypeToFormType(String qid) {
     int questionnaireType = Integer.parseInt(qid.substring(0, 2));
@@ -15,43 +13,19 @@ public class FormTypeHelper {
       case 2:
       case 3:
       case 4:
-        // CCS Postback
-      case 51:
-      case 52:
-      case 53:
-      case 54:
-        // CCS Household
-      case 71:
-      case 72:
-      case 73:
-      case 74:
+      case 5:
+      case 6:
+      case 7:
         return HH_FORM_TYPE;
         // Individual
       case 21:
       case 22:
       case 23:
       case 24:
+      case 25:
+      case 26:
+      case 27:
         return IND_FORM_TYPE;
-        // CE1
-      case 31:
-      case 32:
-      case 33:
-      case 34:
-        // CCS CE Manager
-      case 81:
-      case 82:
-      case 83:
-      case 84:
-        return CE1_FORM_TYPE;
-        // Continuation forms
-      case 11:
-      case 12:
-      case 13:
-      case 14:
-        // CCS Continuation
-      case 61:
-      case 63:
-        return CONT_FORM_TYPE;
       default:
         return null;
     }

--- a/src/main/java/uk/gov/ons/census/caseprocessor/utils/FormTypeHelper.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/utils/FormTypeHelper.java
@@ -1,0 +1,59 @@
+package uk.gov.ons.census.caseprocessor.utils;
+
+public class FormTypeHelper {
+  public static final String HH_FORM_TYPE = "H";
+  public static final String IND_FORM_TYPE = "I";
+  public static final String CE1_FORM_TYPE = "C";
+  public static final String CONT_FORM_TYPE = "Cont";
+
+  public static String mapQuestionnaireTypeToFormType(String qid) {
+    int questionnaireType = Integer.parseInt(qid.substring(0, 2));
+
+    switch (questionnaireType) {
+        // Household
+      case 1:
+      case 2:
+      case 3:
+      case 4:
+        // CCS Postback
+      case 51:
+      case 52:
+      case 53:
+      case 54:
+        // CCS Household
+      case 71:
+      case 72:
+      case 73:
+      case 74:
+        return HH_FORM_TYPE;
+        // Individual
+      case 21:
+      case 22:
+      case 23:
+      case 24:
+        return IND_FORM_TYPE;
+        // CE1
+      case 31:
+      case 32:
+      case 33:
+      case 34:
+        // CCS CE Manager
+      case 81:
+      case 82:
+      case 83:
+      case 84:
+        return CE1_FORM_TYPE;
+        // Continuation forms
+      case 11:
+      case 12:
+      case 13:
+      case 14:
+        // CCS Continuation
+      case 61:
+      case 63:
+        return CONT_FORM_TYPE;
+      default:
+        return null;
+    }
+  }
+}

--- a/src/test/java/uk/gov/ons/census/caseprocessor/messaging/ReceiptReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/messaging/ReceiptReceiverIT.java
@@ -72,7 +72,7 @@ public class ReceiptReceiverIT {
       uacQidLink.setCaze(caze);
       uacQidLink.setActive(true);
       uacQidLink.setReceiptReceived(false);
-      uacQidLink.setSurveyLaunched(false);
+      uacQidLink.setSurveyLaunched(true);
       uacQidLinkRepository.saveAndFlush(uacQidLink);
 
       ReceiptDTO receiptDTO = new ReceiptDTO();

--- a/src/test/java/uk/gov/ons/census/caseprocessor/messaging/ReceiptReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/messaging/ReceiptReceiverTest.java
@@ -1,7 +1,8 @@
 package uk.gov.ons.census.caseprocessor.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static uk.gov.ons.census.caseprocessor.testutils.MessageConstructor.constructMessage;
 import static uk.gov.ons.census.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
@@ -10,7 +11,7 @@ import static uk.gov.ons.census.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCH
 
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
-import java.util.UUID;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -19,144 +20,95 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.Message;
 import uk.gov.ons.census.caseprocessor.logging.EventLogger;
-import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
-import uk.gov.ons.census.caseprocessor.model.dto.EventHeaderDTO;
-import uk.gov.ons.census.caseprocessor.model.dto.PayloadDTO;
-import uk.gov.ons.census.caseprocessor.model.dto.ReceiptDTO;
-import uk.gov.ons.census.caseprocessor.service.UacService;
+import uk.gov.ons.census.caseprocessor.model.dto.*;
+import uk.gov.ons.census.caseprocessor.service.QidReceiptService;
 import uk.gov.ons.census.common.model.entity.EventType;
 import uk.gov.ons.census.common.model.entity.UacQidLink;
 
 @ExtendWith(MockitoExtension.class)
 public class ReceiptReceiverTest {
-  private static final String QID = "12345";
+  private final String QID = "1234567890123456";
 
-  @Mock private UacService uacService;
   @Mock private EventLogger eventLogger;
+  @Mock private QidReceiptService qidReceiptService;
 
   @InjectMocks ReceiptReceiver underTest;
 
   @Test
-  public void testUnlinkedUacQidReceiptWhereActive() {
+  public void testReceiptReceivedEventFromRH() {
+    EventDTO receiptEvent = new EventDTO();
+    receiptEvent.setHeader(new EventHeaderDTO());
+    receiptEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
+    receiptEvent.getHeader().setCorrelationId(TEST_CORRELATION_ID);
+    receiptEvent.getHeader().setOriginatingUser(TEST_ORIGINATING_USER);
+    receiptEvent.getHeader().setDateTime(OffsetDateTime.now(ZoneId.of("UTC")));
+    receiptEvent.getHeader().setTopic("Test topic");
+    receiptEvent.getHeader().setChannel("RH");
+    receiptEvent.getHeader().setMessageType(EventType.RECEIPT);
+    receiptEvent.setPayload(new PayloadDTO());
+
     ReceiptDTO receiptDTO = new ReceiptDTO();
     receiptDTO.setQid(QID);
+    receiptEvent.getPayload().setReceipt(receiptDTO);
 
-    PayloadDTO payloadDTO = new PayloadDTO();
-    payloadDTO.setReceipt(receiptDTO);
-    EventDTO event = new EventDTO();
-    event.setPayload(payloadDTO);
+    UacQidLink expectedUacQidLink = new UacQidLink();
+    expectedUacQidLink.setQid(QID);
+    expectedUacQidLink.setReceiptReceived(true);
+    expectedUacQidLink.setActive(false);
 
-    EventHeaderDTO eventHeader = new EventHeaderDTO();
-    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
-    eventHeader.setCorrelationId(TEST_CORRELATION_ID);
-    eventHeader.setOriginatingUser(TEST_ORIGINATING_USER);
-    eventHeader.setTopic("Test topic");
-    eventHeader.setDateTime(OffsetDateTime.now(ZoneId.of("UTC")));
-    event.setHeader(eventHeader);
-    Message<byte[]> message = constructMessage(event);
+    Message<byte[]> message = constructMessage(receiptEvent);
 
-    UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setActive(true);
+    // Given
+    when(qidReceiptService.processReceiptEvent(receiptEvent)).thenReturn(expectedUacQidLink);
 
-    when(uacService.findByQid(any())).thenReturn(uacQidLink);
-    when(uacService.saveAndEmitUacUpdateEvent(any(UacQidLink.class), any(UUID.class), anyString()))
-        .thenReturn(uacQidLink);
-
+    // when
     underTest.receiveMessage(message);
 
+    // then
+    verify(qidReceiptService).processReceiptEvent(receiptEvent);
+
     ArgumentCaptor<UacQidLink> uacQidLinkCaptor = ArgumentCaptor.forClass(UacQidLink.class);
-    verify(uacService)
-        .saveAndEmitUacUpdateEvent(
-            uacQidLinkCaptor.capture(), eq(TEST_CORRELATION_ID), eq(TEST_ORIGINATING_USER));
-    UacQidLink actualUacQidLink = uacQidLinkCaptor.getValue();
-    assertThat(actualUacQidLink.isActive()).isFalse();
 
     verify(eventLogger)
         .logUacQidEvent(
-            eq(actualUacQidLink),
+            uacQidLinkCaptor.capture(),
             eq("Receipt received"),
             eq(EventType.RECEIPT),
-            eq(event),
+            eq(receiptEvent),
             eq(message));
-  }
 
-  @Test
-  public void testUnlinkedUacQidReceiptWherePreviouslyReceipted() {
-    ReceiptDTO receiptDTO = new ReceiptDTO();
-    receiptDTO.setQid(QID);
-
-    PayloadDTO payloadDTO = new PayloadDTO();
-    payloadDTO.setReceipt(receiptDTO);
-    EventDTO event = new EventDTO();
-    event.setPayload(payloadDTO);
-
-    EventHeaderDTO eventHeader = new EventHeaderDTO();
-    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
-    eventHeader.setTopic("Test topic");
-    eventHeader.setDateTime(OffsetDateTime.now(ZoneId.of("UTC")));
-    event.setHeader(eventHeader);
-    Message<byte[]> message = constructMessage(event);
-
-    UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setActive(true);
-    uacQidLink.setReceiptReceived(true);
-
-    when(uacService.findByQid(any())).thenReturn(uacQidLink);
-
-    underTest.receiveMessage(message);
-
-    ArgumentCaptor<String> uacQidLinkCaptor = ArgumentCaptor.forClass(String.class);
-    verify(uacService).findByQid(uacQidLinkCaptor.capture());
-
-    verify(eventLogger)
-        .logUacQidEvent(
-            eq(uacQidLink), eq("Receipt received"), eq(EventType.RECEIPT), eq(event), eq(message));
-
-    verifyNoMoreInteractions(uacService);
-  }
-
-  @Test
-  public void testUnlinkedUacQidReceiptsUacQid() {
-    ReceiptDTO receiptDTO = new ReceiptDTO();
-    receiptDTO.setQid(QID);
-
-    PayloadDTO payloadDTO = new PayloadDTO();
-    payloadDTO.setReceipt(receiptDTO);
-    EventDTO event = new EventDTO();
-    event.setPayload(payloadDTO);
-
-    EventHeaderDTO eventHeader = new EventHeaderDTO();
-    eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
-    eventHeader.setCorrelationId(TEST_CORRELATION_ID);
-    eventHeader.setOriginatingUser(TEST_ORIGINATING_USER);
-    eventHeader.setTopic("Test topic");
-    eventHeader.setDateTime(OffsetDateTime.now(ZoneId.of("UTC")));
-    event.setHeader(eventHeader);
-    Message<byte[]> message = constructMessage(event);
-
-    UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setActive(true);
-
-    when(uacService.findByQid(any())).thenReturn(uacQidLink);
-    when(uacService.saveAndEmitUacUpdateEvent(any(UacQidLink.class), any(UUID.class), anyString()))
-        .thenReturn(uacQidLink);
-
-    underTest.receiveMessage(message);
-
-    ArgumentCaptor<UacQidLink> uacQidLinkCaptor = ArgumentCaptor.forClass(UacQidLink.class);
-    verify(uacService)
-        .saveAndEmitUacUpdateEvent(
-            uacQidLinkCaptor.capture(), eq(TEST_CORRELATION_ID), eq(TEST_ORIGINATING_USER));
     UacQidLink actualUacQidLink = uacQidLinkCaptor.getValue();
-    assertThat(actualUacQidLink.isActive()).isFalse();
+    assertThat(actualUacQidLink.getQid()).isEqualTo(QID);
     assertThat(actualUacQidLink.isReceiptReceived()).isTrue();
+    assertThat(actualUacQidLink.isActive()).isFalse();
 
-    verify(eventLogger)
-        .logUacQidEvent(
-            eq(actualUacQidLink),
-            eq("Receipt received"),
-            eq(EventType.RECEIPT),
-            eq(event),
-            eq(message));
+    verifyNoMoreInteractions(eventLogger);
+    verifyNoMoreInteractions(qidReceiptService);
+  }
+
+  @Test
+  void testReceiptEventFromRHWrongEventType() {
+    EventDTO receiptEvent = new EventDTO();
+    receiptEvent.setHeader(new EventHeaderDTO());
+    receiptEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
+    receiptEvent.getHeader().setCorrelationId(TEST_CORRELATION_ID);
+    receiptEvent.getHeader().setOriginatingUser(TEST_ORIGINATING_USER);
+    receiptEvent.getHeader().setDateTime(OffsetDateTime.now(ZoneId.of("UTC")));
+    receiptEvent.getHeader().setTopic("Test topic");
+    receiptEvent.getHeader().setChannel("RH");
+    receiptEvent.getHeader().setMessageType(EventType.CASE_UPDATE);
+    receiptEvent.setPayload(new PayloadDTO());
+
+    ReceiptDTO receiptDTO = new ReceiptDTO();
+    receiptDTO.setQid(QID);
+    receiptEvent.getPayload().setReceipt(receiptDTO);
+
+    Message<byte[]> message = constructMessage(receiptEvent);
+
+    RuntimeException thrown =
+        assertThrows(RuntimeException.class, () -> underTest.receiveMessage(message));
+
+    Assertions.assertThat(thrown.getMessage())
+        .isEqualTo("Event Type 'CASE_UPDATE' is invalid on this topic");
   }
 }

--- a/src/test/java/uk/gov/ons/census/caseprocessor/service/CaseReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/service/CaseReceiptServiceTest.java
@@ -66,9 +66,9 @@ class CaseReceiptServiceTest {
 
   @Test
   void receiptCaseDoesNothingForNoActionRule() {
-    UacQidLink uacQidLink = buildLink("3112345678901234", "HH");
+    UacQidLink uacQidLink = buildLink("2112345678901234", "HH");
 
-    UacQidLink result = underTest.receiptCase(uacQidLink, buildReceiptEvent("3112345678901234"));
+    UacQidLink result = underTest.receiptCase(uacQidLink, buildReceiptEvent("2112345678901234"));
 
     assertThat(result).isSameAs(uacQidLink);
     assertThat(uacQidLink.getCaze().isReceiptReceived()).isFalse();

--- a/src/test/java/uk/gov/ons/census/caseprocessor/service/CaseReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/service/CaseReceiptServiceTest.java
@@ -1,0 +1,123 @@
+package uk.gov.ons.census.caseprocessor.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static uk.gov.ons.census.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
+import static uk.gov.ons.census.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
+import static uk.gov.ons.census.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
+import uk.gov.ons.census.caseprocessor.model.dto.EventHeaderDTO;
+import uk.gov.ons.census.caseprocessor.model.dto.PayloadDTO;
+import uk.gov.ons.census.caseprocessor.model.dto.ReceiptDTO;
+import uk.gov.ons.census.common.model.entity.Case;
+import uk.gov.ons.census.common.model.entity.EventType;
+import uk.gov.ons.census.common.model.entity.UacQidLink;
+
+@ExtendWith(MockitoExtension.class)
+class CaseReceiptServiceTest {
+
+  @Mock private CaseService caseService;
+
+  @InjectMocks private CaseReceiptService underTest;
+
+  @Test
+  void receiptCaseUpdatesHouseholdCaseAndEmitsUpdate() {
+    UacQidLink uacQidLink = buildLink("0112345678901234", "HH");
+
+    UacQidLink result = underTest.receiptCase(uacQidLink, buildReceiptEvent("0112345678901234"));
+
+    assertThat(result).isSameAs(uacQidLink);
+
+    ArgumentCaptor<Case> caseCaptor = ArgumentCaptor.forClass(Case.class);
+    verify(caseService)
+        .saveCaseAndEmitCaseUpdate(
+            caseCaptor.capture(), eq(TEST_CORRELATION_ID), eq(TEST_ORIGINATING_USER));
+
+    assertThat(caseCaptor.getValue().isReceiptReceived()).isTrue();
+  }
+
+  @Test
+  void receiptCaseUpdatesHICaseAndEmitsUpdate() {
+    UacQidLink uacQidLink = buildLink("0112345678901234", "HI");
+
+    UacQidLink result = underTest.receiptCase(uacQidLink, buildReceiptEvent("0112345678901234"));
+
+    assertThat(result).isSameAs(uacQidLink);
+
+    ArgumentCaptor<Case> caseCaptor = ArgumentCaptor.forClass(Case.class);
+    verify(caseService)
+        .saveCaseAndEmitCaseUpdate(
+            caseCaptor.capture(), eq(TEST_CORRELATION_ID), eq(TEST_ORIGINATING_USER));
+
+    assertThat(caseCaptor.getValue().isReceiptReceived()).isTrue();
+  }
+
+  @Test
+  void receiptCaseDoesNothingForNoActionRule() {
+    UacQidLink uacQidLink = buildLink("3112345678901234", "HH");
+
+    UacQidLink result = underTest.receiptCase(uacQidLink, buildReceiptEvent("3112345678901234"));
+
+    assertThat(result).isSameAs(uacQidLink);
+    assertThat(uacQidLink.getCaze().isReceiptReceived()).isFalse();
+
+    verifyNoInteractions(caseService);
+  }
+
+  @Test
+  void receiptCaseThrowsWhenNoRuleMatches() {
+    UacQidLink uacQidLink = buildLink("9912345678901234", "HH");
+
+    RuntimeException thrown =
+        assertThrows(
+            RuntimeException.class,
+            () -> underTest.receiptCase(uacQidLink, buildReceiptEvent("9912345678901234")));
+
+    assertThat(thrown.getMessage()).contains("does not map to any known processing rule");
+    verifyNoInteractions(caseService);
+  }
+
+  private UacQidLink buildLink(String qid, String caseType) {
+    Case caze = new Case();
+    caze.setCaseType(caseType);
+    caze.setAddressLevel("U");
+    caze.setReceiptReceived(false);
+
+    UacQidLink uacQidLink = new UacQidLink();
+    uacQidLink.setQid(qid);
+    uacQidLink.setCaze(caze);
+    uacQidLink.setReceiptReceived(false);
+    return uacQidLink;
+  }
+
+  private EventDTO buildReceiptEvent(String qid) {
+    EventDTO receiptEvent = new EventDTO();
+    receiptEvent.setHeader(new EventHeaderDTO());
+    receiptEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
+    receiptEvent.getHeader().setCorrelationId(TEST_CORRELATION_ID);
+    receiptEvent.getHeader().setOriginatingUser(TEST_ORIGINATING_USER);
+    receiptEvent.getHeader().setDateTime(OffsetDateTime.now(ZoneId.of("UTC")));
+    receiptEvent.getHeader().setTopic("Test topic");
+    receiptEvent.getHeader().setChannel("RH");
+    receiptEvent.getHeader().setMessageType(EventType.RECEIPT);
+
+    ReceiptDTO receiptDTO = new ReceiptDTO();
+    receiptDTO.setQid(qid);
+    PayloadDTO payloadDTO = new PayloadDTO();
+    payloadDTO.setReceipt(receiptDTO);
+    receiptEvent.setPayload(payloadDTO);
+    return receiptEvent;
+  }
+}

--- a/src/test/java/uk/gov/ons/census/caseprocessor/service/QidReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/service/QidReceiptServiceTest.java
@@ -1,0 +1,127 @@
+package uk.gov.ons.census.caseprocessor.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static uk.gov.ons.census.caseprocessor.testutils.TestConstants.TEST_CORRELATION_ID;
+import static uk.gov.ons.census.caseprocessor.testutils.TestConstants.TEST_ORIGINATING_USER;
+import static uk.gov.ons.census.caseprocessor.utils.Constants.OUTBOUND_EVENT_SCHEMA_VERSION;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.ons.census.caseprocessor.model.dto.*;
+import uk.gov.ons.census.common.model.entity.Case;
+import uk.gov.ons.census.common.model.entity.EventType;
+import uk.gov.ons.census.common.model.entity.UacQidLink;
+
+@ExtendWith(MockitoExtension.class)
+public class QidReceiptServiceTest {
+  private final String TEST_QID_ID = "1234567890123456";
+
+  @Mock private UacService uacService;
+  @Mock private CaseReceiptService caseReceiptService;
+
+  @InjectMocks QidReceiptService underTest;
+
+  @Test
+  public void testHandleReceiptEvent() {
+    // Given
+    EventDTO receiptEvent = new EventDTO();
+    receiptEvent.setHeader(new EventHeaderDTO());
+    receiptEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
+    receiptEvent.getHeader().setCorrelationId(TEST_CORRELATION_ID);
+    receiptEvent.getHeader().setOriginatingUser(TEST_ORIGINATING_USER);
+    receiptEvent.getHeader().setDateTime(OffsetDateTime.now(ZoneId.of("UTC")));
+    receiptEvent.getHeader().setTopic("Test topic");
+    receiptEvent.getHeader().setChannel("RH");
+    receiptEvent.getHeader().setMessageType(EventType.RECEIPT);
+    ReceiptDTO receiptDTO = new ReceiptDTO();
+    receiptDTO.setQid(TEST_QID_ID);
+    PayloadDTO payloadDTO = new PayloadDTO();
+    payloadDTO.setReceipt(receiptDTO);
+    receiptEvent.setPayload(payloadDTO);
+
+    Case caze = new Case();
+    caze.setReceiptReceived(false);
+
+    UacQidLink expectedUacQidLink = new UacQidLink();
+    expectedUacQidLink.setQid(TEST_QID_ID);
+    expectedUacQidLink.setReceiptReceived(false);
+    expectedUacQidLink.setActive(true);
+    expectedUacQidLink.setCaze(caze);
+
+    when(uacService.findByQid(TEST_QID_ID)).thenReturn(expectedUacQidLink);
+
+    when(uacService.saveAndEmitUacUpdateEvent(
+            expectedUacQidLink,
+            receiptEvent.getHeader().getCorrelationId(),
+            receiptEvent.getHeader().getOriginatingUser()))
+        .thenReturn(expectedUacQidLink);
+
+    when(caseReceiptService.receiptCase(expectedUacQidLink, receiptEvent))
+        .thenReturn(expectedUacQidLink);
+
+    // When
+    underTest.processReceiptEvent(receiptEvent);
+
+    // Then
+    ArgumentCaptor<UacQidLink> uacQidLinkArgumentCaptor = ArgumentCaptor.forClass(UacQidLink.class);
+    verify(uacService)
+        .saveAndEmitUacUpdateEvent(
+            uacQidLinkArgumentCaptor.capture(), eq(TEST_CORRELATION_ID), eq(TEST_ORIGINATING_USER));
+    UacQidLink capturedUacQidLink = uacQidLinkArgumentCaptor.getValue();
+    assertThat(capturedUacQidLink.isActive()).isFalse();
+    assertThat(capturedUacQidLink.isReceiptReceived()).isTrue();
+    // assertThat(capturedUacQidLink.getCaze().isReceiptReceived()).isTrue();
+  }
+
+  @Test
+  public void testHandleReceiptEventNoCase() {
+    // Given
+    EventDTO receiptEvent = new EventDTO();
+    receiptEvent.setHeader(new EventHeaderDTO());
+    receiptEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
+    receiptEvent.getHeader().setCorrelationId(TEST_CORRELATION_ID);
+    receiptEvent.getHeader().setOriginatingUser(TEST_ORIGINATING_USER);
+    receiptEvent.getHeader().setDateTime(OffsetDateTime.now(ZoneId.of("UTC")));
+    receiptEvent.getHeader().setTopic("Test topic");
+    receiptEvent.getHeader().setChannel("RH");
+    receiptEvent.getHeader().setMessageType(EventType.RECEIPT);
+    ReceiptDTO receiptDTO = new ReceiptDTO();
+    receiptDTO.setQid(TEST_QID_ID);
+    PayloadDTO payloadDTO = new PayloadDTO();
+    payloadDTO.setReceipt(receiptDTO);
+    receiptEvent.setPayload(payloadDTO);
+
+    UacQidLink expectedUacQidLink = new UacQidLink();
+    expectedUacQidLink.setQid(TEST_QID_ID);
+    expectedUacQidLink.setActive(true);
+    expectedUacQidLink.setReceiptReceived(false);
+
+    when(uacService.findByQid(TEST_QID_ID)).thenReturn(expectedUacQidLink);
+    when(uacService.saveAndEmitUacUpdateEvent(
+            expectedUacQidLink,
+            receiptEvent.getHeader().getCorrelationId(),
+            receiptEvent.getHeader().getOriginatingUser()))
+        .thenReturn(expectedUacQidLink);
+
+    // When
+    underTest.processReceiptEvent(receiptEvent);
+
+    // Then
+    ArgumentCaptor<UacQidLink> uacQidLinkArgumentCaptor = ArgumentCaptor.forClass(UacQidLink.class);
+    verify(uacService)
+        .saveAndEmitUacUpdateEvent(
+            uacQidLinkArgumentCaptor.capture(), eq(TEST_CORRELATION_ID), eq(TEST_ORIGINATING_USER));
+    UacQidLink capturedUacQidLink = uacQidLinkArgumentCaptor.getValue();
+    assertThat(capturedUacQidLink.isReceiptReceived()).isTrue();
+    assertThat(capturedUacQidLink.isActive()).isFalse();
+
+    verifyNoInteractions(caseReceiptService);
+  }
+}

--- a/src/test/java/uk/gov/ons/census/caseprocessor/service/QidReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/service/QidReceiptServiceTest.java
@@ -77,7 +77,6 @@ public class QidReceiptServiceTest {
     UacQidLink capturedUacQidLink = uacQidLinkArgumentCaptor.getValue();
     assertThat(capturedUacQidLink.isActive()).isFalse();
     assertThat(capturedUacQidLink.isReceiptReceived()).isTrue();
-    // assertThat(capturedUacQidLink.getCaze().isReceiptReceived()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
SRM removed the concept of an explicit receipt marker on the case object, the receipted status of a case was implicit in the QIDs it was linked to. For Census31, we need that explicit field on the case back. 

# What has changed
<!--- What code changes has been made -->
Marked the case as receipted when RECEIPT event is received from RH (when a linked QID is receipted (and a receipt QID is linked))

<!--- Has there been any refactoring -->
1. Moved the receipting logic from the receiptReceiver to new two services called CaseReceiptService and QidReceiptService. This is so the receipt logic can be reused as part of the future qid linking journey
2. Copied the CaseReceiptService key/rule logic from the census2021
3. Added in the HH rules for a first iteration from the census2021 CaseReceiptService. Sending field instructions are ignored for now.
4. On receipted, updated the receiptReceived flag within the uac-qid-link (already existing logic, just moved it to the new QidReceiptService and called it) and called the case receipt service. 
5. Emited a caseUpdated event on receipted from the receipt actions which updated the case.
6. Retained/Reserve all the current logic for updating and emitting events for the QID - but moved to QID receipt service. 

<!--- What tests have been written -->
Unit tests, integration tests and acceptance tests have been written.

# How to test?
<!--- Describe in detail how you tested your changes. -->
1. Run "make build" for unit and integration tests 
2. Run "make test" for acceptance tests in census31-rm-acceptance-tests  
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run "make test" for acceptance tests in census31-rm-acceptance-tests with this branch/pr 

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
https://officefornationalstatistics.atlassian.net/browse/CN-94
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
<img width="1468" height="343" alt="image" src="https://github.com/user-attachments/assets/bf146249-8527-4c89-8975-acedaadecee9" />

