### PR TITLE
Cn 104 ingest respondent authenticate event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ target/*
 megalinter-reports/
 # Podman secrets
 podman-build-secret*
+*.ipr
+*.iws

--- a/src/main/java/uk/gov/ons/census/caseprocessor/messaging/SurveyLaunchedReceiver.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/messaging/SurveyLaunchedReceiver.java
@@ -10,47 +10,69 @@ import uk.gov.ons.census.caseprocessor.logging.EventLogger;
 import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
 import uk.gov.ons.census.caseprocessor.model.dto.EventHeaderDTO;
 import uk.gov.ons.census.caseprocessor.service.SurveyLaunchedService;
+import uk.gov.ons.census.caseprocessor.service.UacService;
 import uk.gov.ons.census.common.model.entity.EventType;
 import uk.gov.ons.census.common.model.entity.UacQidLink;
 
 @MessageEndpoint
 public class SurveyLaunchedReceiver {
-  private final EventLogger eventLogger;
-  private final SurveyLaunchedService surveyLaunchedService;
 
-  public SurveyLaunchedReceiver(
-      EventLogger eventLogger, SurveyLaunchedService surveyLaunchedService) {
-    this.eventLogger = eventLogger;
-    this.surveyLaunchedService = surveyLaunchedService;
-  }
+    private final EventLogger eventLogger;
+    private final SurveyLaunchedService surveyLaunchedService;
+    private final UacService uacService;
 
-  @Transactional
-  @ServiceActivator(inputChannel = "surveyLaunchedInputChannel", adviceChain = "retryAdvice")
-  public void receiveMessage(Message<byte[]> message) {
-    EventDTO event = convertJsonBytesToEvent(message.getPayload());
-
-    if (!processEvent(event)) {
-      return;
+    public SurveyLaunchedReceiver(
+            EventLogger eventLogger, SurveyLaunchedService surveyLaunchedService, UacService uacService) {
+        this.eventLogger = eventLogger;
+        this.surveyLaunchedService = surveyLaunchedService;
+        this.uacService = uacService;
     }
 
-    UacQidLink uacQidLink = surveyLaunchedService.handleSurveyLaunchedEvent(event);
+    @Transactional
+    @ServiceActivator(inputChannel = "surveyLaunchedInputChannel", adviceChain = "retryAdvice")
+    public void receiveMessage(Message<byte[]> message) {
+        EventDTO event = convertJsonBytesToEvent(message.getPayload());
 
-    eventLogger.logUacQidEvent(
-        uacQidLink, "Survey launched", EventType.SURVEY_LAUNCHED, event, message);
-  }
+        if (!isSurveyLaunchedEvent(event)) {
+            logRespondentAuthenticatedEvent(event, message);
+            return;
+        }
 
-  private boolean processEvent(EventDTO surveyEvent) {
+        UacQidLink uacQidLink = surveyLaunchedService.handleSurveyLaunchedEvent(event);
 
-    EventHeaderDTO event = surveyEvent.getHeader();
-
-    switch (event.getMessageType()) {
-      case SURVEY_LAUNCHED:
-        return true;
-
-      default:
-        // Should never get here
-        throw new RuntimeException(
-            String.format("Event Type '%s' is invalid on this topic", event.getMessageType()));
+        eventLogger.logUacQidEvent(
+                uacQidLink, "Survey launched", EventType.SURVEY_LAUNCHED, event, message);
     }
-  }
+
+    /**
+     * Returns {@code true} if the event is a genuine SURVEY_LAUNCHED event, {@code false} if it's a
+     * RESPONDENT_AUTHENTICATED event that should be discarded (after logging — see {@link
+     * #logRespondentAuthenticatedEvent}).
+     *
+     * @throws IllegalStateException if the event is neither of the expected message types.
+     */
+    private boolean isSurveyLaunchedEvent(EventDTO surveyEvent) {
+        EventHeaderDTO header = surveyEvent.getHeader();
+
+        return switch (header.getMessageType()) {
+            case SURVEY_LAUNCHED -> true;
+            case RESPONDENT_AUTHENTICATED -> false;
+            default ->
+                    throw new IllegalStateException(
+                            "Event Type '%s' is invalid on this topic".formatted(header.getMessageType()));
+        };
+    }
+
+    private void logRespondentAuthenticatedEvent(EventDTO surveyEvent, Message<byte[]> message) {
+        UacQidLink uacQidLink =
+                uacService.findByQid(
+                        surveyEvent.getPayload().getRespondentAuthenticated().getQuestionnaireId());
+
+        eventLogger.logUacQidEvent(
+                uacQidLink,
+                "Respondent authenticated",
+                EventType.RESPONDENT_AUTHENTICATED,
+                surveyEvent,
+                message);
+    }
 }

--- a/src/main/java/uk/gov/ons/census/caseprocessor/model/dto/PayloadDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/model/dto/PayloadDTO.java
@@ -23,4 +23,5 @@ public class PayloadDTO {
   private SmsRequest smsRequest;
   private EmailRequest emailRequest;
   private ExportFileDTO exportFile;
+  private RespondentAuthenticatedDTO respondentAuthenticated;
 }

--- a/src/main/java/uk/gov/ons/census/caseprocessor/model/dto/RespondentAuthenticatedDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseprocessor/model/dto/RespondentAuthenticatedDTO.java
@@ -1,0 +1,12 @@
+package uk.gov.ons.census.caseprocessor.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RespondentAuthenticatedDTO {
+  private String questionnaireId;
+}

--- a/src/test/java/uk/gov/ons/census/caseprocessor/messaging/SurveyLaunchedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/messaging/SurveyLaunchedReceiverIT.java
@@ -16,7 +16,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.ons.census.caseprocessor.model.dto.*;
+import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
+import uk.gov.ons.census.caseprocessor.model.dto.EventHeaderDTO;
+import uk.gov.ons.census.caseprocessor.model.dto.PayloadDTO;
+import uk.gov.ons.census.caseprocessor.model.dto.CaseUpdateDTO;
+import uk.gov.ons.census.caseprocessor.model.dto.RespondentAuthenticatedDTO;
+import uk.gov.ons.census.caseprocessor.model.dto.SurveyLaunchedDTO;
+import uk.gov.ons.census.caseprocessor.model.dto.UacUpdateDTO;
 import uk.gov.ons.census.caseprocessor.model.repository.EventRepository;
 import uk.gov.ons.census.caseprocessor.model.repository.UacQidLinkRepository;
 import uk.gov.ons.census.caseprocessor.testutils.DeleteDataHelper;
@@ -103,6 +109,57 @@ public class SurveyLaunchedReceiverIT {
       assertThat(events.size()).isEqualTo(1);
       Event event = events.get(0);
       assertThat(event.getDescription()).isEqualTo("Survey launched");
+      UacQidLink actualUacQidLink = event.getUacQidLink();
+      assertThat(actualUacQidLink.getQid()).isEqualTo(TEST_QID);
+      assertThat(actualUacQidLink.getCaze().getId()).isEqualTo(caze.getId());
+    }
+  }
+
+  @Test
+  public void testRespondentAuthenticatedLogsEventButDoesNotEmitMessages() throws Exception {
+    // GIVEN
+    try (QueueSpy<EventDTO> outboundUacQueueSpy =
+            pubsubHelper.pubsubProjectListen(OUTBOUND_UAC_SUBSCRIPTION, EventDTO.class);
+        QueueSpy<EventDTO> outboundCaseQueueSpy =
+            pubsubHelper.pubsubProjectListen(OUTBOUND_CASE_SUBSCRIPTION, EventDTO.class)) {
+      Case caze = junkDataHelper.setupJunkCase();
+
+      UacQidLink uacQidLink = new UacQidLink();
+      uacQidLink.setId(UUID.randomUUID());
+      uacQidLink.setCaze(caze);
+      uacQidLink.setUac("Junk");
+      uacQidLink.setUacHash("junkHash");
+      uacQidLink.setQid(TEST_QID);
+      uacQidLink.setSurveyLaunched(false);
+      uacQidLinkRepository.saveAndFlush(uacQidLink);
+
+      EventDTO respondentAuthenticatedEvent = new EventDTO();
+      EventHeaderDTO eventHeader = new EventHeaderDTO();
+      eventHeader.setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
+      eventHeader.setTopic(INBOUND_TOPIC);
+      eventHeader.setChannel("RH");
+      eventHeader.setMessageType(EventType.RESPONDENT_AUTHENTICATED);
+      junkDataHelper.junkify(eventHeader);
+      respondentAuthenticatedEvent.setHeader(eventHeader);
+
+      RespondentAuthenticatedDTO respondentAuthenticated = new RespondentAuthenticatedDTO();
+      respondentAuthenticated.setQuestionnaireId(uacQidLink.getQid());
+      PayloadDTO payloadDTO = new PayloadDTO();
+      payloadDTO.setRespondentAuthenticated(respondentAuthenticated);
+      respondentAuthenticatedEvent.setPayload(payloadDTO);
+
+      // WHEN
+      pubsubHelper.sendMessageToPubsubProject(INBOUND_TOPIC, respondentAuthenticatedEvent);
+
+      // THEN
+      outboundUacQueueSpy.checkMessageIsNotReceived(5);
+      outboundCaseQueueSpy.checkMessageIsNotReceived(1);
+
+      List<Event> events = eventRepository.findAll();
+      assertThat(events.size()).isEqualTo(1);
+      Event event = events.get(0);
+      assertThat(event.getDescription()).isEqualTo("Respondent authenticated");
+      assertThat(event.getType()).isEqualTo(EventType.RESPONDENT_AUTHENTICATED);
       UacQidLink actualUacQidLink = event.getUacQidLink();
       assertThat(actualUacQidLink.getQid()).isEqualTo(TEST_QID);
       assertThat(actualUacQidLink.getCaze().getId()).isEqualTo(caze.getId());

--- a/src/test/java/uk/gov/ons/census/caseprocessor/messaging/SurveyLaunchedReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/caseprocessor/messaging/SurveyLaunchedReceiverTest.java
@@ -23,8 +23,10 @@ import uk.gov.ons.census.caseprocessor.logging.EventLogger;
 import uk.gov.ons.census.caseprocessor.model.dto.EventDTO;
 import uk.gov.ons.census.caseprocessor.model.dto.EventHeaderDTO;
 import uk.gov.ons.census.caseprocessor.model.dto.PayloadDTO;
+import uk.gov.ons.census.caseprocessor.model.dto.RespondentAuthenticatedDTO;
 import uk.gov.ons.census.caseprocessor.model.dto.SurveyLaunchedDTO;
 import uk.gov.ons.census.caseprocessor.service.SurveyLaunchedService;
+import uk.gov.ons.census.caseprocessor.service.UacService;
 import uk.gov.ons.census.common.model.entity.EventType;
 import uk.gov.ons.census.common.model.entity.UacQidLink;
 
@@ -34,6 +36,7 @@ public class SurveyLaunchedReceiverTest {
 
   @Mock private EventLogger eventLogger;
   @Mock private SurveyLaunchedService surveyLaunchedService;
+  @Mock private UacService uacService;
 
   @InjectMocks SurveyLaunchedReceiver underTest;
 
@@ -114,5 +117,49 @@ public class SurveyLaunchedReceiverTest {
 
     Assertions.assertThat(thrown.getMessage())
         .isEqualTo("Event Type 'RECEIPT' is invalid on this topic");
+  }
+
+  @Test
+  void testRespondentAuthenticatedEventFromRH() {
+    EventDTO managementEvent = new EventDTO();
+    managementEvent.setHeader(new EventHeaderDTO());
+    managementEvent.getHeader().setVersion(OUTBOUND_EVENT_SCHEMA_VERSION);
+    managementEvent.getHeader().setCorrelationId(TEST_CORRELATION_ID);
+    managementEvent.getHeader().setOriginatingUser(TEST_ORIGINATING_USER);
+    managementEvent.getHeader().setDateTime(OffsetDateTime.now(ZoneId.of("UTC")));
+    managementEvent.getHeader().setTopic("Test topic");
+    managementEvent.getHeader().setChannel("RH");
+    managementEvent.getHeader().setMessageType(EventType.RESPONDENT_AUTHENTICATED);
+    managementEvent.setPayload(new PayloadDTO());
+
+    RespondentAuthenticatedDTO respondentAuthenticated = new RespondentAuthenticatedDTO();
+    respondentAuthenticated.setQuestionnaireId(TEST_QID_ID);
+    managementEvent.getPayload().setRespondentAuthenticated(respondentAuthenticated);
+
+    UacQidLink expectedUacQidLink = new UacQidLink();
+    expectedUacQidLink.setQid(TEST_QID_ID);
+    Message<byte[]> message = constructMessage(managementEvent);
+
+    // Given
+    when(uacService.findByQid(TEST_QID_ID)).thenReturn(expectedUacQidLink);
+
+    // when
+    underTest.receiveMessage(message);
+
+    // then
+    verify(uacService).findByQid(TEST_QID_ID);
+    verify(surveyLaunchedService, never()).handleSurveyLaunchedEvent(any());
+
+    verify(eventLogger)
+        .logUacQidEvent(
+            eq(expectedUacQidLink),
+            eq("Respondent authenticated"),
+            eq(EventType.RESPONDENT_AUTHENTICATED),
+            eq(managementEvent),
+            eq(message));
+
+    verifyNoMoreInteractions(eventLogger);
+    verifyNoMoreInteractions(surveyLaunchedService);
+    verifyNoMoreInteractions(uacService);
   }
 }


### PR DESCRIPTION
# Motivation and Context

The case processor has been updated to handle `RESPONDENT_AUTHENTICATED` events on the survey-launched topic. These events are logged against the UAC without updating the `surveyLaunched` flag on the case or UAC. This MR adds acceptance test coverage for that new behaviour.

* [ ] [Context Index](github.com/ONSdigital/census-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed

- Added a new scenario in `survey_launched.feature` that verifies a `RESPONDENT_AUTHENTICATED` event is logged without updating case/UAC flags
- Added a new step definition `a RESPONDENT_AUTHENTICATED event is received` in `steps/survey_launched.py`
- Added helper function `_send_respondent_authenticated_msg()` that publishes a message with `messageType: RESPONDENT_AUTHENTICATED` and payload `respondentAuthenticated: {questionnaireId}` to the survey-launched topic

No refactoring was required.

# How to test?

Run the acceptance tests targeting the survey launched feature:

```bash
behave acceptance_tests/features/survey_launched.feature

The new scenario requires the case processor with the  RESPONDENT_AUTHENTICATED  switch case deployed. It will:

1. Load a sample and create an export file action rule
2. Wait for the initial  UAC_UPDATE 
3. Send a  RESPONDENT_AUTHENTICATED  event to the survey-launched topic
4. Assert the event is logged as  RESPONDENT_AUTHENTICATED  in the database (no  CASE_UPDATE  or additional  UAC_UPDATE  emitted)
